### PR TITLE
Breaking Change Infrastructure

### DIFF
--- a/apps/core/lib/core/pubsub/events.ex
+++ b/apps/core/lib/core/pubsub/events.ex
@@ -65,3 +65,5 @@ defmodule Core.PubSub.OIDCProviderCreated, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.DockerRepositoryUpdated, do: use Piazza.PubSub.Event
 
 defmodule Core.PubSub.LicensePing, do: use Piazza.PubSub.Event
+
+defmodule Core.PubSub.InstallationLocked, do: use Piazza.PubSub.Event

--- a/apps/core/lib/core/schema/chart_installation.ex
+++ b/apps/core/lib/core/schema/chart_installation.ex
@@ -3,6 +3,8 @@ defmodule Core.Schema.ChartInstallation do
   alias Core.Schema.{Chart, Installation, Version}
 
   schema "chart_installations" do
+    field :locked, :boolean, default: false
+
     belongs_to :installation, Installation
     belongs_to :chart,        Chart
     belongs_to :version,      Version

--- a/apps/core/lib/core/schema/dependencies.ex
+++ b/apps/core/lib/core/schema/dependencies.ex
@@ -44,23 +44,42 @@ defmodule Core.Schema.Dependencies do
     end
   end
 
+  defmodule ChangeInstructions do
+    use Piazza.Ecto.Schema
+
+    embedded_schema do
+      field :script,       :string
+      field :instructions, :string
+    end
+
+    @valid ~w(script instructions)a
+
+    def changeset(model, attrs \\ %{}) do
+      model
+      |> cast(attrs, @valid)
+    end
+  end
+
   embedded_schema do
     field :providers,        {:array, Provider}
     field :provider_wirings, :map
     field :outputs,          :map
     field :secrets,          {:array, :string}
     field :application,      :boolean, default: false
+    field :breaking,         :boolean, default: false
 
     embeds_many :dependencies, Dependency, on_replace: :delete
-    embeds_one  :wirings, Wirings, on_replace: :update
+    embeds_one  :instructions, ChangeInstructions
+    embeds_one  :wirings,      Wirings, on_replace: :update
   end
 
-  @valid ~w(providers provider_wirings application outputs secrets)a
+  @valid ~w(providers provider_wirings application outputs secrets breaking)a
 
   def changeset(model, attrs \\ %{}) do
     model
     |> cast(attrs, @valid)
     |> cast_embed(:dependencies)
     |> cast_embed(:wirings)
+    |> cast_embed(:instructions)
   end
 end

--- a/apps/core/lib/core/schema/terraform_installation.ex
+++ b/apps/core/lib/core/schema/terraform_installation.ex
@@ -3,6 +3,8 @@ defmodule Core.Schema.TerraformInstallation do
   alias Core.Schema.{Terraform, Installation, Version}
 
   schema "terraform_installations" do
+    field :locked, :boolean, default: false
+
     belongs_to :installation, Installation
     belongs_to :terraform, Terraform
     belongs_to :version, Version

--- a/apps/core/lib/core/services/dependencies.ex
+++ b/apps/core/lib/core/services/dependencies.ex
@@ -89,6 +89,7 @@ defmodule Core.Services.Dependencies do
   def closure(nil), do: []
   def closure(deps) when is_list(deps), do: closure(deps, MapSet.new(), [])
 
+  defp valid_version?([%{locked: true} | _], _), do: false # don't deliver updates when an installation is locked
   defp valid_version?([_ | _], %{version: nil}), do: true
   defp valid_version?(versions, %{any_of: [_ | _] = deps}) do
     by_name = Enum.into(deps, %{}, & {&1.name, &1})

--- a/apps/core/priv/repo/migrations/20220215231021_add_breaking_changes.exs
+++ b/apps/core/priv/repo/migrations/20220215231021_add_breaking_changes.exs
@@ -1,0 +1,13 @@
+defmodule Core.Repo.Migrations.AddBreakingChanges do
+  use Ecto.Migration
+
+  def change do
+    alter table(:chart_installations) do
+      add :locked, :boolean, default: false
+    end
+
+    alter table(:terraform_installations) do
+      add :locked, :boolean, default: false
+    end
+  end
+end

--- a/apps/core/test/services/dependencies_test.exs
+++ b/apps/core/test/services/dependencies_test.exs
@@ -24,6 +24,28 @@ defmodule Core.Services.DependenciesTest do
       assert Dependencies.valid?(terraform.dependencies, user)
     end
 
+    test "If a dependency is locked, it will return false" do
+      chart     = insert(:chart)
+      terraform = insert(:terraform)
+      user      = insert(:user)
+      insert(:chart_installation,
+        chart: chart,
+        locked: true,
+        installation: insert(:installation, user: user, repository: chart.repository)
+      )
+      insert(:terraform_installation,
+        terraform: terraform,
+        installation: insert(:installation, user: user, repository: terraform.repository)
+      )
+
+      terraform = insert(:terraform, dependencies: %{dependencies: [
+        %{type: :helm, repo: chart.repository.name, name: chart.name, providers: [:gcp]},
+        %{type: :terraform, repo: terraform.repository.name, name: terraform.name}
+      ]})
+
+      refute Dependencies.valid?(terraform.dependencies, user)
+    end
+
     test "If a dependency is missing it returns false" do
       chart     = insert(:chart)
       terraform = insert(:terraform)

--- a/apps/core/test/services/rollable/versions_test.exs
+++ b/apps/core/test/services/rollable/versions_test.exs
@@ -41,6 +41,48 @@ defmodule Core.Rollable.VersionsTest do
       end
     end
 
+    test "it will lock an installation if the version is breaking" do
+      %{chart: chart} = chart_version = insert(:version, version: "0.1.0")
+      auto_upgraded = for _ <- 1..3 do
+        insert(:chart_installation,
+          installation: insert(:installation, auto_upgrade: true),
+          chart: chart,
+          version: chart_version
+        )
+      end
+
+      queues = for %{installation: %{user: user}} <- auto_upgraded do
+        insert(:upgrade_queue, user: user)
+      end
+
+      ignored = insert_list(2, :chart_installation, chart: chart, version: chart_version)
+      version = insert(:version, version: "0.1.1", chart: chart, dependencies: %{breaking: true})
+      insert(:version_tag, version: version, chart: chart, tag: "latest")
+
+      event = %PubSub.VersionCreated{item: version}
+      {:ok, rollout} = Rollouts.create_rollout(chart.repository_id, event)
+
+      {:ok, rolled} = Rollouts.execute(rollout)
+
+      assert rolled.status == :finished
+      assert rolled.count == 3
+
+
+      for %{id: id} = bumped <- auto_upgraded do
+        inst = refetch(bumped)
+        assert_receive {:event, %PubSub.InstallationLocked{item: %{id: ^id}}}
+        assert inst.version_id == version.id
+        assert inst.locked
+      end
+
+      for ignore <- ignored,
+        do: assert refetch(ignore).version_id == chart_version.id
+
+      for queue <- queues do
+        refute Core.Schema.Upgrade.for_queue(queue.id) |> Core.Repo.exists?()
+      end
+    end
+
     test "it will defer updates if a version's dependencies aren't satisfied" do
       dep_chart = insert(:chart)
       %{chart: chart} = chart_version = insert(:version, version: "0.1.0")

--- a/apps/core/test/services/rollouts_test.exs
+++ b/apps/core/test/services/rollouts_test.exs
@@ -3,6 +3,25 @@ defmodule Core.Services.RolloutsTest do
   alias Core.Services.Rollouts
   alias Core.PubSub
 
+  describe "#unlock/1" do
+    test "it will unlock locked module installations" do
+      user = insert(:user)
+      repo = insert(:repository)
+      inst = insert(:installation, repository: repo, user: user)
+      cl = insert(:chart_installation, installation: inst, locked: true, chart: insert(:chart, repository: repo))
+      tl = insert(:terraform_installation, installation: inst, locked: true, terraform: insert(:terraform, repository: repo))
+
+      ignore = insert(:chart_installation, locked: true, chart: cl.chart)
+
+      {:ok, 2} = Rollouts.unlock(repo.name, user)
+
+      refute refetch(cl).locked
+      refute refetch(tl).locked
+
+      assert refetch(ignore).locked
+    end
+  end
+
   describe "#create_rollout/2" do
     test "it can create a rollout for a repository and event" do
       repo = insert(:repository)

--- a/apps/email/lib/email/builder/locked_installation.ex
+++ b/apps/email/lib/email/builder/locked_installation.ex
@@ -1,0 +1,20 @@
+defmodule Email.Builder.LockedInstallation do
+  use Email.Builder.Base
+
+  def email(inst) do
+    %{installation: %{user: user}} = inst = Core.Repo.preload(inst, [:version, installation: [:user, :repository]])
+    repo = inst.installation.repository
+    base_email()
+    |> to(user)
+    |> subject("Breaking Changes Need to be applied for #{repo.name}")
+    |> assign(:type, inst_type(inst))
+    |> assign(:user, user)
+    |> assign(:installation, inst)
+    |> assign(:deps, inst.version.dependencies)
+    |> assign(:repo, repo)
+    |> render(:locked_installation)
+  end
+
+  defp inst_type(%{chart: _}), do: :chart
+  defp inst_type(%{terraform: _}), do: :terraform
+end

--- a/apps/email/lib/email/deliverable/versions.ex
+++ b/apps/email/lib/email/deliverable/versions.ex
@@ -1,0 +1,3 @@
+defimpl Email.Deliverable, for: Core.PubSub.InstallationLocked do
+  def email(%{item: inst}), do: Email.Builder.LockedInstallation.email(inst)
+end

--- a/apps/email/lib/email_web/templates/email/locked_installation.html.eex
+++ b/apps/email/lib/email_web/templates/email/locked_installation.html.eex
@@ -1,0 +1,23 @@
+<p>
+  Repository <b><%= @repo.name %></b> has unapplied breaking changes, to apply them,
+  check out your repo locally and run the folling commands:
+</p>
+
+<code>
+<%= if @deps.instructions.script do %>
+<%= @deps.instructions.script %>
+<% end %>
+plural build --only <%= @repo.name %>
+plural deploy --commit "applying breaking changes to <%= @repo.name %>"
+plural repos unlock <%= @repo.name %>
+</code>
+
+<%= if @deps.instructions.instructions do %>
+<p>
+The maintainers also have provided these instructions:
+
+<pre>
+<%= @deps.instructions.instructions %>
+</pre>
+</p>
+<% end %>

--- a/apps/email/lib/email_web/templates/email/locked_installation.text.eex
+++ b/apps/email/lib/email_web/templates/email/locked_installation.text.eex
@@ -1,0 +1,17 @@
+Repository <%= @repo.name %> has unapplied breaking changes, to apply them,
+check out your repo locally and run the folling commands:
+
+```
+<%= if @deps.instructions.script do %>
+<%= @deps.instructions.script %>
+<% end %>
+plural build --only <%= @repo.name %>
+plural deploy --commit "applying breaking changes to <%= @repo.name %>"
+plural repos unlock <%= @repo.name %>
+```
+
+<%= if @deps.instructions.instructions do %>
+The maintainers also have provided these instructions:
+
+<%= @deps.instructions.instructions %>
+<% end %>

--- a/apps/email/test/email/deliverable/versions_test.exs
+++ b/apps/email/test/email/deliverable/versions_test.exs
@@ -1,0 +1,22 @@
+defmodule Email.Deliverable.VersionsTest do
+  use Core.SchemaCase, async: true
+  use Bamboo.Test
+
+  alias Core.PubSub
+  alias Email.PubSub.Consumer
+
+  describe "InstallationLocked" do
+    test "it can send reset emails" do
+      ci = insert(:chart_installation,
+        version: build(:version,
+          dependencies: %{instructions: %{script: "blach", instructions: nil}},
+        )
+      )
+
+      event = %PubSub.InstallationLocked{item: ci}
+      Consumer.handle_event(event)
+
+      assert_delivered_email Email.Builder.LockedInstallation.email(ci)
+    end
+  end
+end

--- a/apps/graphql/lib/graphql.ex
+++ b/apps/graphql/lib/graphql.ex
@@ -123,6 +123,7 @@ defmodule GraphQl do
     import_fields :docker_mutations
     import_fields :dns_mutations
     import_fields :shell_mutations
+    import_fields :rollout_mutations
   end
 
   subscription do

--- a/apps/graphql/lib/graphql/resolvers/rollout.ex
+++ b/apps/graphql/lib/graphql/resolvers/rollout.ex
@@ -1,7 +1,11 @@
 defmodule GraphQl.Resolvers.Rollout do
   use GraphQl.Resolvers.Base, model: Core.Schema.Rollout
+  alias Core.Services.Rollouts
 
   def query(_, _), do: Rollout
+
+  def unlock(%{name: name}, %{context: %{current_user: user}}),
+    do: Rollouts.unlock(name, user)
 
   def list_rollouts(%{repository_id: id} = args, _) do
     Rollout.for_repository(id)

--- a/apps/graphql/lib/graphql/schema/rollout.ex
+++ b/apps/graphql/lib/graphql/schema/rollout.ex
@@ -27,6 +27,15 @@ defmodule GraphQl.Schema.Rollout do
     end
   end
 
+  object :rollout_mutations do
+    field :unlock_repository, :integer do
+      middleware Authenticated
+      arg :name, non_null(:string)
+
+      resolve &Rollout.unlock/2
+    end
+  end
+
   object :rollout_subscriptions do
     field :rollout_delta, :rollout_delta do
       arg :repository_id, non_null(:id)

--- a/apps/graphql/lib/graphql/schema/version.ex
+++ b/apps/graphql/lib/graphql/schema/version.ex
@@ -89,6 +89,13 @@ defmodule GraphQl.Schema.Version do
     field :provider_wirings, :map
     field :outputs,          :map
     field :wirings,          :wirings
+    field :breaking,         :boolean
+    field :instructions,     :change_instructions
+  end
+
+  object :change_instructions do
+    field :script,       :string
+    field :instructions, :string
   end
 
   ecto_enum :dependency_type, Core.Schema.Dependencies.Dependency.Type

--- a/apps/graphql/test/mutations/rollouts_test.exs
+++ b/apps/graphql/test/mutations/rollouts_test.exs
@@ -1,0 +1,29 @@
+defmodule GraphQl.RolloutMutationsTest do
+  use Core.SchemaCase, async: true
+  import GraphQl.TestHelpers
+
+  describe "unlockRepository" do
+    test "it will unlock the module installations for a repository" do
+      user = insert(:user)
+      repo = insert(:repository)
+      inst = insert(:installation, repository: repo, user: user)
+      cl = insert(:chart_installation, installation: inst, locked: true, chart: insert(:chart, repository: repo))
+      tl = insert(:terraform_installation, installation: inst, locked: true, terraform: insert(:terraform, repository: repo))
+
+      ignore = insert(:chart_installation, locked: true, chart: cl.chart)
+
+      {:ok, %{data: %{"unlockRepository" => unlock}}} = run_query("""
+        mutation Unlock($name: String!) {
+          unlockRepository(name: $name)
+        }
+      """, %{"name" => repo.name}, %{current_user: user})
+
+      assert unlock == 2
+
+      refute refetch(cl).locked
+      refute refetch(tl).locked
+
+      assert refetch(ignore).locked
+    end
+  end
+end


### PR DESCRIPTION
## Summary
The implementation relies on a boolean `breaking` field on the dependencies struct and locked fields
on chart and terraform installation schemas.  When a version is pushed marked breaking, the version is installed but
not passed to its upgrade queue, and marked locked.  Any downstream dependencies of that version are blocked from
being installed, and thus will be sent to a deferred queue.

We'll simultaneously deliver a user to affected users giving them instructions on how to apply the change, ultimately
resolvign to a cli command which will unlock the installations and restart upgrade queues.  We also add templatable sections
to allow maintainers to give additional useful instructions for upgrades (maybe kubectl commands and so forth).

## Test Plan
tons of unit tests, once deployed, will confirm with a temporary breaking change on a hardly used application

## Checklist
- [  ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ x ] I have added tests to cover my changes.

Close #161 