### PR TITLE
TF Provider Template API's

### DIFF
--- a/apps/core/lib/core/schema/provider_scaffold.ex
+++ b/apps/core/lib/core/schema/provider_scaffold.ex
@@ -1,0 +1,18 @@
+defmodule Core.Schema.ProviderScaffold do
+  defstruct [:name, :content]
+  @providers ~w(aws gcp azure equinix)a
+
+  def available(), do: @providers
+
+  def new(name) when name in @providers do
+    %__MODULE__{
+      name: name,
+      content: provider_file(name)
+    }
+  end
+
+  defp provider_file(name) do
+    Path.join([:code.priv_dir(:core), "scaffolds/terraform/providers", "#{name}.eex"])
+    |> File.read!
+  end
+end

--- a/apps/core/lib/core/services/scaffolds.ex
+++ b/apps/core/lib/core/services/scaffolds.ex
@@ -43,6 +43,10 @@ defmodule Core.Services.Scaffolds do
     end)
   end
 
+  def available_providers(), do: Core.Schema.ProviderScaffold.available()
+
+  def provider(name), do: Core.Schema.ProviderScaffold.new(name)
+
   defp eval(file, application, provider, ctx) do
     scaffold_file(file)
     |> eval_file(

--- a/apps/core/priv/scaffolds/terraform/providers/aws.eex
+++ b/apps/core/priv/scaffolds/terraform/providers/aws.eex
@@ -1,0 +1,36 @@
+terraform {
+  backend "s3" {
+    bucket = {{ .Values.Bucket | quote }}
+    key = "{{ .Values.__CLUSTER__ }}/{{ .Values.Prefix }}/terraform.tfstate"
+    region = {{ .Values.Region | quote }}
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.63.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = {{ .Values.Region | quote }}
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = {{ .Values.Cluster }}
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = {{ .Values.Cluster }}
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}

--- a/apps/core/priv/scaffolds/terraform/providers/azure.eex
+++ b/apps/core/priv/scaffolds/terraform/providers/azure.eex
@@ -1,0 +1,87 @@
+terraform {
+  backend "azurerm" {
+    storage_account_name = {{ .Values.Context.StorageAccount | quote }}
+    resource_group_name = {{ .Values.ResourceGroup | quote }}
+    container_name = {{ .Values.Bucket | quote }}
+    key = "{{ .Values.__CLUSTER__ }}/{{ .Values.Prefix }}/terraform.tfstate"
+  }
+
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "2.57.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.5.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+{{ if .Values.ClusterCreated }}
+provider "kubernetes" {
+  host                   = {{ .Values.Cluster }}.host
+  client_certificate     = base64decode({{ .Values.Cluster }}.client_certificate)
+  client_key             = base64decode({{ .Values.Cluster }}.client_key)
+  cluster_ca_certificate = base64decode({{ .Values.Cluster }}.cluster_ca_certificate)
+}
+{{ else }}
+data "azurerm_kubernetes_cluster" "cluster" {
+  name = {{ .Values.Cluster }}
+  resource_group_name = {{ .Values.ResourceGroup | quote }}
+}
+
+provider "kubernetes" {
+  host                   = data.azurerm_kubernetes_cluster.cluster.kube_config[0].host
+  client_certificate     = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config[0].client_certificate)
+  client_key             = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config[0].client_key)
+  cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config[0].cluster_ca_certificate)
+}
+{{ end }}terraform {
+  backend "azurerm" {
+    storage_account_name = {{ .Values.Context.StorageAccount | quote }}
+    resource_group_name = {{ .Values.ResourceGroup | quote }}
+    container_name = {{ .Values.Bucket | quote }}
+    key = "{{ .Values.__CLUSTER__ }}/{{ .Values.Prefix }}/terraform.tfstate"
+  }
+
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "2.57.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.5.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+{{ if .Values.ClusterCreated }}
+provider "kubernetes" {
+  host                   = {{ .Values.Cluster }}.host
+  client_certificate     = base64decode({{ .Values.Cluster }}.client_certificate)
+  client_key             = base64decode({{ .Values.Cluster }}.client_key)
+  cluster_ca_certificate = base64decode({{ .Values.Cluster }}.cluster_ca_certificate)
+}
+{{ else }}
+data "azurerm_kubernetes_cluster" "cluster" {
+  name = {{ .Values.Cluster }}
+  resource_group_name = {{ .Values.ResourceGroup | quote }}
+}
+
+provider "kubernetes" {
+  host                   = data.azurerm_kubernetes_cluster.cluster.kube_config[0].host
+  client_certificate     = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config[0].client_certificate)
+  client_key             = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config[0].client_key)
+  cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config[0].cluster_ca_certificate)
+}
+{{ end }}

--- a/apps/core/priv/scaffolds/terraform/providers/equinix.eex
+++ b/apps/core/priv/scaffolds/terraform/providers/equinix.eex
@@ -1,0 +1,65 @@
+terraform {
+  backend "local" {
+    path = "../../{{ .Values.Bucket }}/{{ .Values.__CLUSTER__ }}/{{ .Values.Prefix }}/terraform.tfstate"
+  }
+{{- if .Values.ClusterCreated }}
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.7.1"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.13.1"
+    }
+    helm = {
+      source = "hashicorp/helm"
+      version = ">= 2.4, <3"
+    }
+  }
+}
+{{- else }}
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.7.1"
+    }
+  }
+}
+{{- end }}
+
+{{- if .Values.ClusterCreated }}
+provider "helm" {
+  kubernetes {
+    host = {{ .Values.Cluster }}.api_server_url
+    cluster_ca_certificate = {{ .Values.Cluster }}.ca_crt
+    client_certificate = {{ .Values.Cluster }}.client_cert
+    client_key = {{ .Values.Cluster }}.client_key
+  }
+}
+
+provider "kubectl" {
+  host = {{ .Values.Cluster }}.api_server_url
+  cluster_ca_certificate = {{ .Values.Cluster }}.ca_crt
+  client_certificate = {{ .Values.Cluster }}.client_cert
+  client_key = {{ .Values.Cluster }}.client_key
+  load_config_file = false
+}
+
+provider "kubernetes" {
+  host = {{ .Values.Cluster }}.api_server_url
+  cluster_ca_certificate = {{ .Values.Cluster }}.ca_crt
+  client_certificate = {{ .Values.Cluster }}.client_cert
+  client_key = {{ .Values.Cluster }}.client_key
+}
+{{- else }}
+provider "helm" {
+  kubernetes {
+    config_path    = "../../bootstrap/terraform/kube_config_cluster.yaml"
+  }
+}
+
+provider "kubernetes" {
+  config_path    = "../../bootstrap/terraform/kube_config_cluster.yaml"
+}
+{{- end }}

--- a/apps/core/priv/scaffolds/terraform/providers/gcp.eex
+++ b/apps/core/priv/scaffolds/terraform/providers/gcp.eex
@@ -1,0 +1,49 @@
+terraform {
+  backend "gcs" {
+    bucket = {{ .Values.Bucket | quote }}
+    prefix = "{{ .Values.__CLUSTER__ }}/{{ .Values.Prefix }}"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.65.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.5.0"
+    }
+  }
+}
+
+locals {
+  gcp_location  = {{ .Values.Location | quote }}
+  gcp_location_parts = split("-", local.gcp_location)
+  gcp_region         = "${local.gcp_location_parts[0]}-${local.gcp_location_parts[1]}"
+}
+
+provider "google" {
+  project = {{ .Values.Project | quote }}
+  region  = local.gcp_region
+}
+
+data "google_client_config" "current" {}
+
+{{ if .Values.ClusterCreated }}
+provider "kubernetes" {
+  host = {{ .Values.Cluster }}.endpoint
+  cluster_ca_certificate = base64decode({{ .Values.Cluster }}.ca_certificate)
+  token = data.google_client_config.current.access_token
+}
+{{ else }}
+data "google_container_cluster" "cluster" {
+  name = {{ .Values.Cluster }}
+  location = local.gcp_region
+}
+
+provider "kubernetes" {
+  host = data.google_container_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.google_container_cluster.cluster.master_auth.0.cluster_ca_certificate)
+  token = data.google_client_config.current.access_token
+}
+{{ end }}

--- a/apps/core/test/services/scaffolds_test.exs
+++ b/apps/core/test/services/scaffolds_test.exs
@@ -1,0 +1,21 @@
+defmodule Core.Services.ScaffoldsTest do
+  use Core.SchemaCase, async: true
+  alias Core.Services.Scaffolds
+
+  describe "#tf providers" do
+    test "it retrieves all available tf providers" do
+      assert :aws in Scaffolds.available_providers()
+    end
+
+    test "it retrieves definition for a given provider" do
+      %{:name => name, :content => content} = Scaffolds.provider(:aws)
+      assert name == :aws
+      assert String.length(content) > 10
+    end
+
+    test "all available providers have definitions" do
+      Scaffolds.available_providers()
+      |> Enum.map(&Scaffolds.provider/1)
+    end
+  end
+end

--- a/apps/graphql/lib/graphql.ex
+++ b/apps/graphql/lib/graphql.ex
@@ -22,6 +22,7 @@ defmodule GraphQl do
   import_types GraphQl.Schema.OAuth
   import_types GraphQl.Schema.Dns
   import_types GraphQl.Schema.Shell
+  import_types GraphQl.Schema.Scaffold
 
   alias GraphQl.Resolvers.{
     User,
@@ -36,7 +37,8 @@ defmodule GraphQl do
     Account,
     Incidents,
     Rollout,
-    Dns
+    Dns,
+    Scaffolds
   }
 
   @sources [
@@ -106,6 +108,7 @@ defmodule GraphQl do
     import_fields :dns_queries
     import_fields :shell_queries
     import_fields :metric_queries
+    import_fields :provider_queries
   end
 
   mutation do

--- a/apps/graphql/lib/graphql/resolvers/scaffolds.ex
+++ b/apps/graphql/lib/graphql/resolvers/scaffolds.ex
@@ -1,0 +1,11 @@
+defmodule GraphQl.Resolvers.Scaffolds do
+  alias Core.Services.Scaffolds
+
+  def list_providers(_, _) do
+    {:ok, Scaffolds.available_providers()}
+  end
+
+  def provider(%{name: name}, _) do
+    {:ok, Scaffolds.provider(name)}
+  end
+end

--- a/apps/graphql/lib/graphql/schema/scaffold.ex
+++ b/apps/graphql/lib/graphql/schema/scaffold.ex
@@ -1,0 +1,22 @@
+defmodule GraphQl.Schema.Scaffold do
+  use GraphQl.Schema.Base
+
+  alias GraphQl.Resolvers.Scaffolds
+
+  object :terraform_provider do
+    field :name,         :provider
+    field :content,      :string
+  end
+
+  object :provider_queries do
+    field :terraform_providers, list_of(:provider) do
+      resolve &Scaffolds.list_providers/2
+    end
+
+    field :terraform_provider, :terraform_provider do
+      arg :name,   non_null(:provider)
+
+      resolve &Scaffolds.provider/2
+    end
+  end
+end

--- a/apps/graphql/test/queries/scaffolds_queries_test.exs
+++ b/apps/graphql/test/queries/scaffolds_queries_test.exs
@@ -1,0 +1,29 @@
+defmodule GraphQl.ScaffoldsQueriesTest do
+  use Core.SchemaCase, async: true
+  import GraphQl.TestHelpers
+
+  describe "tf providers" do
+    test "it can list all available tf providers" do
+      {:ok, %{data: %{"terraformProviders" => found}}} = run_query("""
+        query {
+          terraformProviders
+        }
+      """, %{})
+      assert "AWS" in found
+    end
+
+    test "it can retrieve provider definition" do
+      aws = "AWS"
+      {:ok, %{data: %{"terraformProvider" => %{"content" => content, "name" => name}}}} = run_query("""
+        query Provider($name: Provider!) {
+          terraformProvider(name: $name) {
+              name
+              content
+            }
+        }
+      """, %{"name" => aws})
+      assert String.length(content) > 10
+      assert name == aws
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adds API's that return terraform scaffolds of our supported providers. This is so that the CLI is not hard coded with those scaffolding, to allow us to more seamlessly update those terraform definitions as needed.


## Test Plan
Added unit tests that cover the 2 new gqp api's as well as tests covering the underlying logic

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.