### PR TITLE
GCP CLI use Region so it is consistent with other providers

### DIFF
--- a/apps/core/priv/scaffolds/terraform/providers/gcp.eex
+++ b/apps/core/priv/scaffolds/terraform/providers/gcp.eex
@@ -16,15 +16,9 @@ terraform {
   }
 }
 
-locals {
-  gcp_location  = {{ .Values.Location | quote }}
-  gcp_location_parts = split("-", local.gcp_location)
-  gcp_region         = "${local.gcp_location_parts[0]}-${local.gcp_location_parts[1]}"
-}
-
 provider "google" {
   project = {{ .Values.Project | quote }}
-  region  = local.gcp_region
+  region  = {{ .Values.Region | quote }}
 }
 
 data "google_client_config" "current" {}
@@ -38,7 +32,7 @@ provider "kubernetes" {
 {{ else }}
 data "google_container_cluster" "cluster" {
   name = {{ .Values.Cluster }}
-  location = local.gcp_region
+  location = {{ .Values.Region | quote }}
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
## Summary
Accompanying change for https://github.com/pluralsh/plural-cli/pull/30. The template has been updated to reflect the CLI change where the GCP Region is used rather than the Zone.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.