### PR TITLE
Add autolinting for vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@ erl_crash.dump
 
 /secrets/
 
-/.vscode
+/.vscode/**/*
+!/.vscode/settings.json
 
 /cmd/build
 /cmd/forge

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "eslint.validate": ["javascript"]
+}


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
This PR adds the autolinting feature to VSCode.
Basically forces lint on cmd+s

I feel it belongs out of the .gitignore because it enforces the code style. This PR is a suggestion, not a feature. 🤟 