### PR TITLE
Begin Implementing Test APIs

### DIFF
--- a/apps/core/lib/core/policies/test.ex
+++ b/apps/core/lib/core/policies/test.ex
@@ -1,0 +1,17 @@
+defmodule Core.Policies.Test do
+  use Piazza.Policy
+  alias Core.Schema.{User, Test}
+  alias Core.Policies.Repository
+
+  def can?(%User{} = user, %Test{} = test, :create) do
+    %{repository: repo} = Core.Repo.preload(test, [repository: [publisher: :account]])
+    Repository.can?(user, repo, :edit)
+  end
+
+  def can?(%User{id: user_id}, %Test{creator_id: user_id}, :edit), do: :pass
+
+  def can?(user, %Ecto.Changeset{} = cs, action),
+    do: can?(user, apply_changes(cs), action)
+
+  def can?(_, _, _), do: {:error, :forbidden}
+end

--- a/apps/core/lib/core/pubsub/events.ex
+++ b/apps/core/lib/core/pubsub/events.ex
@@ -67,3 +67,6 @@ defmodule Core.PubSub.DockerRepositoryUpdated, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.LicensePing, do: use Piazza.PubSub.Event
 
 defmodule Core.PubSub.InstallationLocked, do: use Piazza.PubSub.Event
+
+defmodule Core.PubSub.TestCreated, do: use Piazza.PubSub.Event
+defmodule Core.PubSub.TestUpdated, do: use Piazza.PubSub.Event

--- a/apps/core/lib/core/pubsub/protocols/realtime.ex
+++ b/apps/core/lib/core/pubsub/protocols/realtime.ex
@@ -19,7 +19,9 @@ defimpl Core.PubSub.Realtime, for: [
   Core.PubSub.UpgradeQueueUpdated,
   Core.PubSub.UpgradeQueueCreated,
   Core.PubSub.RolloutCreated,
-  Core.PubSub.RolloutUpdated
+  Core.PubSub.RolloutUpdated,
+  Core.PubSub.TestCreated,
+  Core.PubSub.TestUpdated
 ] do
   def publish?(_), do: true
 end

--- a/apps/core/lib/core/schema/test.ex
+++ b/apps/core/lib/core/schema/test.ex
@@ -1,0 +1,47 @@
+defmodule Core.Schema.Test do
+  use Piazza.Ecto.Schema
+  alias Core.Schema.{Repository, User, TestBinding, TestStep}
+
+  defenum Status, queued: 0, running: 1, succeeded: 2, failed: 3
+
+  schema "tests" do
+    field :source_tag,  :string
+    field :promote_tag, :string
+    field :status,      Status
+
+    belongs_to :repository, Repository
+    belongs_to :creator,    User
+
+    has_many :bindings, TestBinding
+    has_many :steps,    TestStep
+
+    timestamps()
+  end
+
+  def for_repository(query \\ __MODULE__, repo_id) do
+    from(t in query, where: t.repository_id == ^repo_id)
+  end
+
+  def for_version(query \\ __MODULE__, vsn_id) do
+    from(t in query,
+      join: b in assoc(t, :bindings),
+      where: b.version_id == ^vsn_id
+    )
+  end
+
+  def ordered(query \\ __MODULE__, order \\ [desc: :inserted_at]) do
+    from(t in query, order_by: ^order)
+  end
+
+  @valid ~w(source_tag promote_tag status repository_id creator_id)a
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, @valid)
+    |> cast_assoc(:bindings)
+    |> cast_assoc(:steps)
+    |> foreign_key_constraint(:repository_id)
+    |> foreign_key_constraint(:creator_id)
+    |> validate_required([:status, :repository_id, :creator_id, :promote_tag])
+  end
+end

--- a/apps/core/lib/core/schema/test_bindings.ex
+++ b/apps/core/lib/core/schema/test_bindings.ex
@@ -1,0 +1,21 @@
+defmodule Core.Schema.TestBinding do
+  use Piazza.Ecto.Schema
+  alias Core.Schema.{Version, Test}
+
+  schema "test_bindings" do
+    belongs_to :test, Test
+    belongs_to :version, Version
+
+    timestamps()
+  end
+
+  @valid ~w(test_id version_id)a
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, @valid)
+    |> validate_required([:version_id])
+    |> foreign_key_constraint(:test_id)
+    |> foreign_key_constraint(:version_id)
+  end
+end

--- a/apps/core/lib/core/schema/test_step.ex
+++ b/apps/core/lib/core/schema/test_step.ex
@@ -1,0 +1,24 @@
+defmodule Core.Schema.TestStep do
+  use Piazza.Ecto.Schema
+  alias Core.Schema.Test
+
+  schema "test_steps" do
+    field :name,        :string
+    field :description, :string
+    field :status,      Test.Status
+    field :logs,        :string
+
+    belongs_to :test, Test
+
+    timestamps()
+  end
+
+  @valid ~w(name logs status description)a
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, @valid)
+    |> validate_required([:name, :status, :description])
+    |> foreign_key_constraint(:test_id)
+  end
+end

--- a/apps/core/lib/core/services/rbac.ex
+++ b/apps/core/lib/core/services/rbac.ex
@@ -24,8 +24,7 @@ defmodule Core.Services.Rbac do
   def validate(user, action, opts \\ [])
   def validate(user, action, opts) when is_list(opts),
     do: validate(user, action, Map.new(opts))
-  def validate(%User{id: id, account: %{id: aid, root_user_id: id}}, _, %{account: %{id: aid}}),
-    do: true
+  def validate(%User{id: id, account_id: aid}, _, %{account: %{id: aid, root_user_id: id}}), do: true
   def validate(%User{account_id: id, roles: %{admin: true}}, _, %{account: %{id: id}}),
     do: true
   def validate(%User{id: id, account: %{root_user_id: id}}, _, %{account: %{}}), do: false

--- a/apps/core/lib/core/services/tests.ex
+++ b/apps/core/lib/core/services/tests.ex
@@ -1,0 +1,55 @@
+defmodule Core.Services.Tests do
+  use Core.Services.Base
+  import Core.Policies.Test
+  alias Core.PubSub
+  alias Core.Schema.{
+    User,
+    Test,
+  }
+  alias Core.Services.{Versions, Repositories}
+
+  @type error :: {:error, term}
+  @type test_resp :: {:ok, Test.t} | error
+
+  def get_test!(id), do: Core.Repo.get!(Test, id)
+
+  @doc """
+  Will create a new test object for the given repo, with bindings
+  for all the user's current installations
+  """
+  @spec create_test(map, binary, User.t) :: test_resp
+  def create_test(attrs, repository_id, %User{id: user_id} = user) do
+    inst     = Repositories.get_installation(user_id, repository_id)
+    versions = Versions.installed_versions(repository_id, user)
+    attrs    = Map.merge(attrs, %{
+      bindings: Enum.map(versions, & %{version_id: &1.id}),
+      source_tag: inst.track_tag,
+    })
+
+    %Test{creator_id: user_id, repository_id: repository_id}
+    |> Test.changeset(attrs)
+    |> allow(user, :create)
+    |> when_ok(:insert)
+    |> notify(:create)
+  end
+
+  @doc """
+  Will update a test for given attrs
+  """
+  @spec update_test(map, binary, User.t) :: test_resp
+  def update_test(attrs, test_id, %User{} = user) do
+    get_test!(test_id)
+    |> Core.Repo.preload([:bindings, :steps])
+    |> Test.changeset(attrs)
+    |> allow(user, :edit)
+    |> when_ok(:update)
+    |> notify(:update)
+  end
+
+  defp notify({:ok, %Test{} = test}, :create),
+    do: handle_notify(PubSub.TestCreated, test)
+  defp notify({:ok, %Test{} = test}, :update),
+    do: handle_notify(PubSub.TestUpdated, test)
+
+  defp notify(pass, _), do: pass
+end

--- a/apps/core/priv/repo/migrations/20220402030328_add_test_resources.exs
+++ b/apps/core/priv/repo/migrations/20220402030328_add_test_resources.exs
@@ -1,0 +1,45 @@
+defmodule Core.Repo.Migrations.AddTestResources do
+  use Ecto.Migration
+
+  def change do
+    create table(:tests, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :repository_id, references(:repositories, type: :uuid, on_delete: :delete_all)
+      add :creator_id,    references(:users, type: :uuid, on_delete: :delete_all)
+      add :source_tag,    :string
+      add :promote_tag,   :string
+      add :status,        :integer
+
+      timestamps()
+    end
+
+    create index(:tests, [:repository_id])
+    create index(:tests, [:creator_id])
+
+    create table(:test_bindings, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :test_id, references(:tests, type: :uuid, on_delete: :delete_all)
+      add :version_id, references(:versions, type: :uuid, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create index(:test_bindings, [:test_id])
+    create index(:test_bindings, [:version_id])
+    create unique_index(:test_bindings, [:test_id, :version_id])
+
+    create table(:test_steps, primary_key: false) do
+      add :id,          :uuid, primary_key: true
+      add :name,        :string
+      add :description, :string
+      add :status,      :integer
+      add :logs,        :string
+      add :test_id,     references(:tests, type: :uuid, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create index(:test_steps, [:test_id])
+    create unique_index(:test_steps, [:test_id, :name])
+  end
+end

--- a/apps/core/test/services/tests_test.exs
+++ b/apps/core/test/services/tests_test.exs
@@ -1,0 +1,71 @@
+defmodule Core.Services.TestsTest do
+  use Core.SchemaCase, async: true
+  alias Core.Services.Tests
+  alias Core.PubSub
+
+  describe "#create_test/3" do
+    setup [:setup_root_user]
+
+    test "users that can edit a repository can create tests", %{user: user, account: account} do
+      repo = insert(:repository, publisher: build(:publisher, account: account))
+      inst = insert(:installation, user: user, repository: repo)
+      chart = insert(:chart, repository: repo)
+      tf = insert(:terraform, repository: repo)
+      ci = insert(:chart_installation, chart: chart, installation: inst, version: build(:version, chart: chart))
+      ti = insert(:terraform_installation, terraform: tf, installation: inst, version: build(:version, terraform: tf, chart_id: nil, chart: nil))
+
+      {:ok, test} = Tests.create_test(%{
+        steps: [%{name: "validate", description: "ensures the package is valid", status: :queued}],
+        status: :queued,
+        promote_tag: "warm",
+      }, repo.id, user)
+
+      assert test.status == :queued
+      assert test.creator_id == user.id
+      assert test.repository_id == repo.id
+
+      %{bindings: bindings, steps: [step]} = test
+      assert Enum.map(bindings, & &1.version_id) |>
+             ids_equal(Enum.map([ti, ci], & &1.version_id))
+
+      assert step.name == "validate"
+      assert step.description == "ensures the package is valid"
+      assert step.status == :queued
+
+      assert_receive {:event, %PubSub.TestCreated{item: ^test}}
+    end
+
+    test "random users cannot create tests" do
+      user = insert(:user)
+      repo = insert(:repository)
+      inst = insert(:installation, user: user, repository: repo)
+      chart = insert(:chart, repository: repo)
+      tf = insert(:terraform, repository: repo)
+      insert(:chart_installation, chart: chart, installation: inst, version: build(:version, chart: chart))
+      insert(:terraform_installation, terraform: tf, installation: inst, version: build(:version, terraform: tf, chart_id: nil, chart: nil))
+
+      {:error, _} = Tests.create_test(%{
+        steps: [%{name: "validate", description: "ensures the package is valid", status: :queued}],
+        status: :queued,
+        promote_tag: "warm",
+      }, repo.id, user)
+    end
+  end
+
+  describe "#update_test/3" do
+    test "a test creator can update tests" do
+      test = insert(:test)
+
+      {:ok, updated} = Tests.update_test(%{status: :succeeded}, test.id, test.creator)
+
+      assert updated.status == :succeeded
+
+      assert_receive {:event, %PubSub.TestUpdated{item: ^updated}}
+    end
+
+    test "random users cannot update tests" do
+      test = insert(:test)
+      {:error, _} = Tests.update_test(%{status: :succeeded}, test.id, insert(:user))
+    end
+  end
+end

--- a/apps/core/test/support/factory.ex
+++ b/apps/core/test/support/factory.ex
@@ -497,4 +497,28 @@ defmodule Core.Factory do
       pod_name: sequence(:pod_name, & "plrl-shell-#{&1}")
     }
   end
+
+  def test_factory do
+    %Schema.Test{
+      creator: build(:user),
+      repository: build(:repository),
+      status: :queued,
+      promote_tag: "warm",
+      source_tag: "latest",
+    }
+  end
+
+  def test_step_factory do
+    %Schema.TestStep{
+      name: sequence(:test_step, & "step-#{&1}"),
+      test: build(:test),
+    }
+  end
+
+  def test_binding_factory do
+    %Schema.TestBinding{
+      test: build(:test),
+      version: build(:version)
+    }
+  end
 end

--- a/apps/email/test/email/deliverable/versions_test.exs
+++ b/apps/email/test/email/deliverable/versions_test.exs
@@ -9,7 +9,7 @@ defmodule Email.Deliverable.VersionsTest do
     test "it can send reset emails" do
       ci = insert(:chart_installation,
         version: build(:version,
-          dependencies: %{instructions: %{script: "blach", instructions: nil}},
+          dependencies: %{instructions: %{script: "blach", instructions: nil}}
         )
       )
 

--- a/apps/graphql/lib/graphql.ex
+++ b/apps/graphql/lib/graphql.ex
@@ -23,6 +23,7 @@ defmodule GraphQl do
   import_types GraphQl.Schema.Dns
   import_types GraphQl.Schema.Shell
   import_types GraphQl.Schema.Scaffold
+  import_types GraphQl.Schema.Test
 
   alias GraphQl.Resolvers.{
     User,
@@ -38,6 +39,7 @@ defmodule GraphQl do
     Incidents,
     Rollout,
     Dns,
+    Test
   }
 
   @sources [
@@ -53,7 +55,8 @@ defmodule GraphQl do
     Account,
     Incidents,
     Rollout,
-    Dns
+    Dns,
+    Test
   ]
 
   def context(ctx) do
@@ -108,6 +111,7 @@ defmodule GraphQl do
     import_fields :shell_queries
     import_fields :metric_queries
     import_fields :provider_queries
+    import_fields :test_queries
   end
 
   mutation do
@@ -126,11 +130,13 @@ defmodule GraphQl do
     import_fields :dns_mutations
     import_fields :shell_mutations
     import_fields :rollout_mutations
+    import_fields :test_mutations
   end
 
   subscription do
     import_fields :incident_subscriptions
     import_fields :upgrade_subscriptions
     import_fields :rollout_subscriptions
+    import_fields :test_subscriptions
   end
 end

--- a/apps/graphql/lib/graphql/resolvers/base.ex
+++ b/apps/graphql/lib/graphql/resolvers/base.ex
@@ -38,4 +38,10 @@ defmodule GraphQl.Resolvers.Base do
 
   @compile {:inline, ok: 1}
   def ok(result), do: {:ok, result}
+
+  def get_repo_id(%{name: name}) do
+    Core.Services.Repositories.get_repository_by_name!(name)
+    |> Map.get(:id)
+  end
+  def get_repo_id(%{repository_id: id}), do: id
 end

--- a/apps/graphql/lib/graphql/resolvers/test.ex
+++ b/apps/graphql/lib/graphql/resolvers/test.ex
@@ -1,0 +1,30 @@
+defmodule GraphQl.Resolvers.Test do
+  use GraphQl.Resolvers.Base, model: Core.Schema.Test
+  alias Core.Schema.TestStep
+  alias Core.Services.{Tests}
+
+  def query(TestStep, _), do: TestStep
+  def query(_, _), do: Test
+
+  def list_tests(%{version_id: vsn_id} = args, _) do
+    Test.for_version(vsn_id)
+    |> Test.ordered()
+    |> paginate(args)
+  end
+
+  def list_tests(%{repository_id: repo_id} = args, _) do
+    Test.for_repository(repo_id)
+    |> Test.ordered()
+    |> paginate(args)
+  end
+
+  def resolve_test(%{id: id}, _), do: {:ok, Tests.get_test!(id)}
+
+  def create_test(%{attributes: attrs} = args, %{context: %{current_user: user}}) do
+    repo_id = get_repo_id(args)
+    Tests.create_test(attrs, repo_id, user)
+  end
+
+  def update_test(%{attributes: attrs, id: id}, %{context: %{current_user: user}}),
+    do: Tests.update_test(attrs, id, user)
+end

--- a/apps/graphql/lib/graphql/schema/test.ex
+++ b/apps/graphql/lib/graphql/schema/test.ex
@@ -1,0 +1,90 @@
+defmodule GraphQl.Schema.Test do
+  use GraphQl.Schema.Base
+  alias GraphQl.Resolvers.{
+    Test,
+    Repository,
+    User
+  }
+
+  ecto_enum :test_status, Core.Schema.Test.Status
+
+  input_object :test_attributes do
+    field :status,      :test_status
+    field :promote_tag, :string
+    field :steps,       list_of(:test_step_attributes)
+  end
+
+  input_object :test_step_attributes do
+    field :id,          :id
+    field :name,        non_null(:string)
+    field :description, non_null(:string)
+    field :status,      non_null(:test_status)
+    field :logs,        :string
+  end
+
+  object :test do
+    field :id,          non_null(:id)
+    field :status,      non_null(:test_status)
+    field :source_tag,  non_null(:string)
+    field :promote_tag, non_null(:string)
+    field :steps,       list_of(:test_step), resolve: dataloader(Test)
+    field :creator,     :user, resolve: dataloader(User)
+    field :repository,  :repository, resolve: dataloader(Repository)
+
+    timestamps()
+  end
+
+  object :test_step do
+    field :id,          non_null(:id)
+    field :status,      non_null(:test_status)
+    field :name,        non_null(:string)
+    field :description, non_null(:string)
+    field :logs,        :string
+
+    timestamps()
+  end
+
+  connection node_type: :test
+  delta :test
+
+  object :test_queries do
+    connection field :tests, node_type: :test do
+      arg :version_id,    :id
+      arg :repository_id, :id
+
+      resolve &Test.list_tests/2
+    end
+
+    field :test, :test do
+      arg :id, non_null(:id)
+
+      safe_resolve &Test.resolve_test/2
+    end
+  end
+
+  object :test_mutations do
+    field :create_test, :test do
+      middleware Authenticated
+      arg :repository_id, :id
+      arg :name,          :string
+      arg :attributes,    non_null(:test_attributes)
+
+      safe_resolve &Test.create_test/2
+    end
+
+    field :update_test, :test do
+      middleware Authenticated
+      arg :id,         non_null(:id)
+      arg :attributes, non_null(:test_attributes)
+
+      safe_resolve &Test.update_test/2
+    end
+  end
+
+  object :test_subscriptions do
+    field :test_delta, :test_delta do
+      arg :repository_id, non_null(:id)
+      config fn %{repository_id: id}, _ -> {:ok, topic: "tests:#{id}"} end
+    end
+  end
+end

--- a/apps/graphql/test/mutations/test_mutations_test.exs
+++ b/apps/graphql/test/mutations/test_mutations_test.exs
@@ -1,0 +1,55 @@
+defmodule GraphQl.TestMutationsTest do
+  use Core.SchemaCase, async: true
+  import GraphQl.TestHelpers
+
+  describe "createTest" do
+    test "owners can craete tests" do
+      %{owner: owner} = pub = insert(:publisher)
+      repo = insert(:repository, publisher: pub)
+      insert(:installation, user: owner, repository: repo)
+
+      {:ok, %{data: %{"createTest" => test}}} = run_query("""
+        mutation Create($id: ID!, $attrs: TestAttributes!) {
+          createTest(repositoryId: $id, attributes: $attrs) {
+            id
+            status
+            promoteTag
+            steps { id name description status }
+          }
+        }
+      """, %{"id" => repo.id, "attrs" => %{
+        "promoteTag" => "warm",
+        "status" => "QUEUED",
+        "steps" => [%{"name" => "name", "description" => "description", "status" => "QUEUED"}]
+      }}, %{current_user: owner})
+
+      assert test["id"]
+      assert test["promoteTag"] == "warm"
+      assert test["status"] == "QUEUED"
+
+      [step] = test["steps"]
+      assert step["name"] == "name"
+      assert step["description"] == "description"
+      assert step["status"] == "QUEUED"
+    end
+  end
+
+  describe "updateTest" do
+    test "owners can update tests" do
+      owner = insert(:user)
+      test  = insert(:test, creator: owner)
+
+      {:ok, %{data: %{"updateTest" => t}}} = run_query("""
+        mutation Update($id: ID!, $attrs: TestAttributes!) {
+          updateTest(id: $id, attributes: $attrs) {
+            id
+            status
+          }
+        }
+      """, %{"id" => test.id, "attrs" => %{"status" => "SUCCEEDED"}}, %{current_user: owner})
+
+      assert t["id"] == test.id
+      assert t["status"] == "SUCCEEDED"
+    end
+  end
+end

--- a/apps/graphql/test/queries/test_queries_test.exs
+++ b/apps/graphql/test/queries/test_queries_test.exs
@@ -1,0 +1,62 @@
+defmodule GraphQl.TestQueriesTest do
+  use Core.SchemaCase, async: true
+  import GraphQl.TestHelpers
+
+  describe "tests" do
+    test "it can list tests for a repository" do
+      repo = insert(:repository)
+      tests = insert_list(3, :test, repository: repo)
+      insert(:test)
+
+      {:ok, %{data: %{"tests" => found}}} = run_query("""
+        query tests($id: ID!) {
+          tests(repositoryId: $id, first: 5) {
+            edges { node { id } }
+          }
+        }
+      """, %{"id" => repo.id}, %{current_user: insert(:user)})
+
+      assert from_connection(found)
+             |> ids_equal(tests)
+    end
+
+    test "it can list tests for a version" do
+      repo = insert(:repository)
+      version = insert(:version, chart: build(:chart, repository: repo))
+      tests = insert_list(3, :test, repository: repo)
+      for test <- tests,
+        do: insert(:test_binding, test: test, version: version)
+      insert(:test, repository: repo)
+
+      {:ok, %{data: %{"tests" => found}}} = run_query("""
+        query tests($id: ID!) {
+          tests(versionId: $id, first: 5) {
+            edges { node { id } }
+          }
+        }
+      """, %{"id" => version.id}, %{current_user: insert(:user)})
+
+      assert from_connection(found)
+             |> ids_equal(tests)
+    end
+  end
+
+  describe "test" do
+    test "it can fetch a test by id" do
+      test = insert(:test)
+      steps = insert_list(3, :test_step, test: test)
+
+      {:ok, %{data: %{"test" => t}}} = run_query("""
+        query Test($id: ID!) {
+          test(id: $id) {
+            id
+            steps { id }
+          }
+        }
+      """, %{"id" => test.id}, %{current_user: insert(:user)})
+
+      assert t["id"] == test.id
+      assert ids_equal(t["steps"], steps)
+    end
+  end
+end

--- a/apps/rtc/lib/rtc/channels/negotiator.ex
+++ b/apps/rtc/lib/rtc/channels/negotiator.ex
@@ -93,3 +93,14 @@ defimpl Rtc.Channels.Negotiator, for: [Core.PubSub.RolloutUpdated, Core.PubSub.R
   defp delta_name(Core.PubSub.RolloutUpdated), do: :update
   defp delta_name(Core.PubSub.RolloutCreated), do: :create
 end
+
+defimpl Rtc.Channels.Negotiator, for: [Core.PubSub.TestUpdated, Core.PubSub.TestCreated] do
+  import Rtc.Channels.NegotiatorHelper
+
+  def negotiate(%{item: test}) do
+    {delta(test, delta_name(@for)), [test_delta: "tests:#{test.repository_id}"]}
+  end
+
+  defp delta_name(Core.PubSub.TestUpdated), do: :update
+  defp delta_name(Core.PubSub.TestCreated), do: :create
+end

--- a/apps/rtc/test/rtc_web/channels/graphql/test_subscriptions_test.exs
+++ b/apps/rtc/test/rtc_web/channels/graphql/test_subscriptions_test.exs
@@ -1,0 +1,34 @@
+defmodule RtcWeb.Channels.TestSubscriptionTest do
+  use RtcWeb.ChannelCase, async: false
+  alias Core.PubSub
+
+  describe "testDelta" do
+    test "an user can view test deltas" do
+      user = insert(:user)
+      repo = insert(:repository)
+      {:ok, socket} = establish_socket(user)
+
+      ref = push_doc(socket, """
+        subscription TestDelta($id: ID!) {
+          testDelta(repositoryId: $id) {
+            delta
+            payload { id }
+          }
+        }
+      """, variables: %{"id" => repo.id})
+
+      assert_reply(ref, :ok, %{subscriptionId: _})
+
+      test = insert(:test, repository: repo)
+      publish_event(%PubSub.TestCreated{item: test})
+      assert_push("subscription:data", %{result: %{data: %{"testDelta" => doc}}})
+      assert doc["delta"] == "CREATE"
+      assert doc["payload"]["id"] == test.id
+
+      publish_event(%PubSub.TestUpdated{item: test})
+      assert_push("subscription:data", %{result: %{data: %{"testDelta" => doc}}})
+      assert doc["delta"] == "UPDATE"
+      assert doc["payload"]["id"] == test.id
+    end
+  end
+end

--- a/bin/delete_eks.py
+++ b/bin/delete_eks.py
@@ -1,3 +1,4 @@
+#!python3
 import boto3
 import click
 import time


### PR DESCRIPTION
## Summary
First steps towards implementing core apis for plural's integration testing harness.  These will ultimately resolve down to argo workflows in-cluster, and are really for surfacing progress in app.plural.sh for public awareness.

We'll also want to add promotions to all bound versions once a test suite is marked succeeded, the logic for that will follow.::

## Test Plan
Unit tests, then integration in future test harness operator

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.