### PR TITLE
add default tags to repositories

### DIFF
--- a/apps/core/lib/core/schema/repository.ex
+++ b/apps/core/lib/core/schema/repository.ex
@@ -38,6 +38,7 @@ defmodule Core.Schema.Repository do
     field :private,       :boolean, default: false
     field :category,      Category
     field :notes,         :binary
+    field :default_tag,   :string, default: "latest"
 
     embeds_one :oauth_settings, OAuthSettings, on_replace: :update do
       field :uri_format,  :string
@@ -141,7 +142,7 @@ defmodule Core.Schema.Repository do
   def ordered(query \\ __MODULE__, order \\ [asc: :name]),
     do: from(r in query, order_by: ^order)
 
-  @valid ~w(name publisher_id description documentation secrets private category notes)a
+  @valid ~w(name publisher_id description documentation secrets private category notes default_tag)a
 
   def changeset(model, attrs \\ %{}) do
     model

--- a/apps/core/lib/core/services/repositories.ex
+++ b/apps/core/lib/core/services/repositories.ex
@@ -315,12 +315,18 @@ defmodule Core.Services.Repositories do
   """
   @spec create_installation(map, binary, User.t) :: {:ok, Installation.t} | {:error, term}
   def create_installation(attrs, repository_id, %User{} = user) do
+    repo = get_repository!(repository_id)
+    attrs = add_track_tag(attrs, repo)
     %Installation{repository_id: repository_id, user_id: user.id, auto_upgrade: true}
     |> Installation.changeset(Map.put_new(attrs, :context, %{}))
     |> allow(user, :create)
     |> when_ok(:insert)
     |> notify(:create, user)
   end
+
+  defp add_track_tag(attrs, %Repository{default_tag: tag}) when is_binary(tag) and byte_size(tag) > 0,
+    do: Map.put(attrs, :track_tag, tag)
+  defp add_track_tag(attrs, _), do: attrs
 
   @doc """
   Updates the given installation.

--- a/apps/core/priv/repo/migrations/20220408035748_add_default_tag.exs
+++ b/apps/core/priv/repo/migrations/20220408035748_add_default_tag.exs
@@ -1,0 +1,9 @@
+defmodule Core.Repo.Migrations.AddDefaultTag do
+  use Ecto.Migration
+
+  def change do
+    alter table(:repositories) do
+      add :default_tag, :string, default: "latest"
+    end
+  end
+end

--- a/apps/core/test/services/repositories_test.exs
+++ b/apps/core/test/services/repositories_test.exs
@@ -112,7 +112,21 @@ defmodule Core.Services.RepositoriesTest do
       assert installation.user_id == user.id
       assert installation.repository_id == repo.id
       assert installation.license_key
-      assert is_map(installation.context)
+      assert installation.track_tag == "latest"
+
+      assert_receive {:event, %PubSub.InstallationCreated{item: ^installation, actor: ^user}}
+    end
+
+    test "repositories can delegate track_tag", %{user: user} do
+      repo = insert(:repository, default_tag: "stable")
+
+      {:ok, installation} = Repositories.create_installation(%{}, repo.id, user)
+
+      assert installation.auto_upgrade
+      assert installation.user_id == user.id
+      assert installation.repository_id == repo.id
+      assert installation.license_key
+      assert installation.track_tag == "stable"
 
       assert_receive {:event, %PubSub.InstallationCreated{item: ^installation, actor: ^user}}
     end

--- a/apps/graphql/lib/graphql/schema/repository.ex
+++ b/apps/graphql/lib/graphql/schema/repository.ex
@@ -25,6 +25,7 @@ defmodule GraphQl.Schema.Repository do
     field :tags,           list_of(:tag_attributes)
     field :private,        :boolean
     field :notes,          :string
+    field :default_tag,    :string
     field :oauth_settings, :oauth_settings_attributes
     field :integration_resource_definition, :resource_definition_attributes
   end
@@ -131,6 +132,7 @@ defmodule GraphQl.Schema.Repository do
     field :category,       :category
     field :private,        :boolean
     field :notes,          :string
+    field :default_tag,    :string
     field :publisher,      :publisher, resolve: dataloader(User)
     field :plans,          list_of(:plan), resolve: dataloader(Payments)
     field :tags,           list_of(:tag), resolve: dataloader(Repository)


### PR DESCRIPTION
## Summary
This will allow us to migrate repo-by-repo to non-latest tags as we enable integration testing

## Test Plan
wrote unit tests

## Checklist

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.