### PR TITLE
Auto-Infer git user via oauth information

### DIFF
--- a/apps/core/lib/core/schema/cloud_shell.ex
+++ b/apps/core/lib/core/schema/cloud_shell.ex
@@ -85,6 +85,19 @@ defmodule Core.Schema.CloudShell do
     end
   end
 
+  defmodule GitInfo do
+    use Piazza.Ecto.Schema
+
+    embedded_schema do
+      field :username, :string
+      field :email,    :string
+    end
+
+    @valid ~w(username email)a
+
+    def changeset(model, attrs \\ %{}), do: cast(model, attrs, @valid)
+  end
+
   schema "cloud_shells" do
     field :provider,        Provider
     field :git_url,         :string
@@ -93,6 +106,7 @@ defmodule Core.Schema.CloudShell do
     field :ssh_public_key,  EncryptedString
     field :ssh_private_key, EncryptedString
 
+    embeds_one :git_info,    GitInfo
     embeds_one :workspace,   Workspace
     embeds_one :credentials, Credentials
 
@@ -109,6 +123,7 @@ defmodule Core.Schema.CloudShell do
     |> cast(attrs, @valid)
     |> cast_embed(:workspace)
     |> cast_embed(:credentials)
+    |> cast_embed(:git_info)
     |> foreign_key_constraint(:demo_id)
     |> foreign_key_constraint(:user_id)
     |> put_new_change(:pod_name, &pod_name/0)

--- a/apps/core/lib/core/services/shell.ex
+++ b/apps/core/lib/core/services/shell.ex
@@ -37,9 +37,9 @@ defmodule Core.Services.Shell do
     |> add_operation(:git, fn
       %{fetch: nil, create: shell} ->
         %{provider: p, token: t, name: n} = args = attrs[:scm]
-        with {:ok, url, pub, priv} <- Scm.setup_repository(p, user.email, t, args[:org], n) do
+        with {:ok, url, pub, priv, user} <- Scm.setup_repository(p, user.email, t, args[:org], n) do
           shell
-          |> CloudShell.changeset(%{git_url: url, ssh_public_key: pub, ssh_private_key: priv})
+          |> CloudShell.changeset(%{git_url: url, ssh_public_key: pub, ssh_private_key: priv, git_info: user})
           |> Core.Repo.update()
         end
       %{create: shell} -> {:ok, shell}

--- a/apps/core/lib/core/services/shell/demo.ex
+++ b/apps/core/lib/core/services/shell/demo.ex
@@ -114,7 +114,6 @@ defmodule Core.Services.Shell.Demo do
   def poll_demo_project(%DemoProject{state: :ready, enabled_op_id: op_id} = proj) do
     svcs_conn()
     |> SvcsOperations.serviceusage_operations_get(op_id)
-    |> IO.inspect()
     |> case do
       {:error, %Tesla.Env{status: 404}} -> enable(proj)
       {:ok, %{done: true}} -> enable(proj)

--- a/apps/core/lib/core/services/shell/scm.ex
+++ b/apps/core/lib/core/services/shell/scm.ex
@@ -25,13 +25,14 @@ defmodule Core.Shell.Scm do
   @doc """
   Sets up a repository against a common SCM system for use in the shell
   """
-  @spec setup_repository(provider, binary, binary, binary, binary) :: {:ok, binary, binary, binary} | error
+  @spec setup_repository(provider, binary, binary, binary, binary) :: {:ok, binary, binary, binary, map} | error
   def setup_repository(:github, email, token, org, name) do
     client = Github.client(token)
     with {:ok, private, public} <- keypair(email),
          {:ok, %{"ssh_url" => url} = repo} <- Github.create_repository(client, name, org),
          :ok <- Github.register_keys(client, public, repo),
-      do: {:ok, url, public, private}
+         {:ok, user} <- Core.OAuth.Github.get_user(client),
+      do: {:ok, url, public, private, git_info(user)}
   end
 
   @doc """
@@ -41,4 +42,7 @@ defmodule Core.Shell.Scm do
   def get_token(:github, code), do: Github.get_token(code)
 
   defp authorize_url(:github), do: Github.authorize_url()
+
+  defp git_info(%{email: email} = user), do: %{username: user[:name], email: email}
+  defp git_info(_), do: nil
 end

--- a/apps/core/lib/core/services/shell/scm/github.ex
+++ b/apps/core/lib/core/services/shell/scm/github.ex
@@ -29,7 +29,7 @@ defmodule Core.Shell.Scm.Github do
 
   def authorize_url() do
     oauth_client()
-    |> OAuth2.Client.authorize_url!(scope: "repo read:org")
+    |> OAuth2.Client.authorize_url!(scope: "user user:email user:name repo read:org")
   end
 
   def get_token(code) do

--- a/apps/core/priv/repo/migrations/20220511165641_shell_git_info.exs
+++ b/apps/core/priv/repo/migrations/20220511165641_shell_git_info.exs
@@ -1,0 +1,9 @@
+defmodule Core.Repo.Migrations.ShellGitInfo do
+  use Ecto.Migration
+
+  def change do
+    alter table(:cloud_shells) do
+      add :git_info, :map
+    end
+  end
+end

--- a/apps/core/test/services/shell_test.exs
+++ b/apps/core/test/services/shell_test.exs
@@ -22,6 +22,11 @@ defmodule Core.Services.ShellTest do
           {:ok, %HTTPoison.Response{status_code: 200, body: "OK"}}
       end)
 
+      expect(OAuth2.Client, :get, 2, fn
+        _, "/user" -> {:ok, %OAuth2.Response{body: %{"name" => "name"}}}
+        _, "/user/emails" -> {:ok, %OAuth2.Response{body: [%{"primary" => true, "email" => "me@example.com"}]}}
+      end)
+
       {:ok, shell} = Shell.create_shell(%{
         provider: :aws,
         credentials: %{
@@ -42,6 +47,8 @@ defmodule Core.Services.ShellTest do
       assert shell.ssh_private_key
       assert shell.git_url == "git@github.com:pluralsh/installations.git"
       assert shell.provider == :aws
+      assert shell.git_info.username == "name"
+      assert shell.git_info.email == "me@example.com"
       assert shell.credentials.aws.access_key_id == "access_key"
       assert shell.credentials.aws.secret_access_key == "secret"
       assert shell.workspace.cluster == "plural"

--- a/apps/core/test/test_helper.exs
+++ b/apps/core/test/test_helper.exs
@@ -24,5 +24,6 @@ Mimic.copy(GoogleApi.IAM.V1.Api.Projects)
 Mimic.copy(GoogleApi.CloudBilling.V1.Api.BillingAccounts)
 Mimic.copy(GoogleApi.ServiceUsage.V1.Api.Services)
 Mimic.copy(GoogleApi.ServiceUsage.V1.Api.Operations)
+Mimic.copy(OAuth2.Client)
 
 {:ok, _} = Application.ensure_all_started(:ex_machina)

--- a/apps/graphql/test/mutations/shell_mutations_test.exs
+++ b/apps/graphql/test/mutations/shell_mutations_test.exs
@@ -11,7 +11,7 @@ defmodule GraphQl.ShellMutationsTest do
       expect(Pods, :fetch, fn _ -> {:ok, Pods.pod("plrl-shell-1", e)} end)
       expect(Core.Shell.Scm, :setup_repository, fn
         :github, ^e, "tok", nil, "demo" ->
-          {:ok, "git@github.com:pluralsh/demo.git", "pub-key", "priv-key"}
+          {:ok, "git@github.com:pluralsh/demo.git", "pub-key", "priv-key", nil}
       end)
 
       attrs = %{


### PR DESCRIPTION
## Summary

We technically get git user/email during the oauth handshake, so we can auto fill those in your console configuration if you've already oauthed.


## Test Plan
Added unit test

## Checklist
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.

Fixes PLU-25