### PR TITLE
Allow Users to create a fixed number of demo projects

### DIFF
--- a/apps/core/lib/core/policies/account.ex
+++ b/apps/core/lib/core/policies/account.ex
@@ -36,7 +36,7 @@ defmodule Core.Policies.Account do
 
     with false <- Enum.any?(users, & &1.user_id == user.id),
          true <- MapSet.disjoint?(group_set, user_group_set) do
-      {:error, "forbidden"}
+      {:error, "you're not allowed to impersonate this service account, please verify your user is on its access policy"}
     else
       _ -> :pass
     end

--- a/apps/core/lib/core/schema/user.ex
+++ b/apps/core/lib/core/schema/user.ex
@@ -38,6 +38,7 @@ defmodule Core.Schema.User do
     field :customer_id,     :string
     field :phone,           :string
     field :external_id,     :string
+    field :demo_count,      :integer, default: 0
 
     field :email_confirmed,  :boolean, default: false
     field :email_confirm_by, :utc_datetime_usec
@@ -104,7 +105,7 @@ defmodule Core.Schema.User do
   def ordered(query \\ __MODULE__, order \\ [asc: :name]),
     do: from(p in query, order_by: ^order)
 
-  @valid ~w(name email password phone login_method demoed)a
+  @valid ~w(name email password phone login_method demoed demo_count)a
 
   def changeset(model, attrs \\ %{}) do
     model

--- a/apps/core/priv/repo/migrations/20220513214234_demo-project-counts.exs
+++ b/apps/core/priv/repo/migrations/20220513214234_demo-project-counts.exs
@@ -1,0 +1,9 @@
+defmodule :"Elixir.Core.Repo.Migrations.Demo-project-counts" do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :demo_count, :integer, default: 0
+    end
+  end
+end

--- a/apps/core/test/services/shell/demo_test.exs
+++ b/apps/core/test/services/shell/demo_test.exs
@@ -25,11 +25,13 @@ defmodule Core.Services.Shell.DemoTest do
       assert is_binary(demo.project_id)
       assert demo.operation_id == "123"
       assert demo.state == :created
+
+      assert refetch(user).demo_count == 1
       refute demo.ready
     end
 
     test "users that have already created demoes cannot create" do
-      user = insert(:user, demoed: true)
+      user = insert(:user, demo_count: 3)
 
       {:error, _} = Demo.create_demo_project(user)
     end
@@ -47,7 +49,6 @@ defmodule Core.Services.Shell.DemoTest do
       {:ok, _} = Demo.delete_demo_project(demo)
 
       refute refetch(demo)
-      assert refetch(demo.user).demoed
     end
   end
 


### PR DESCRIPTION
## Summary
We currently limit this number to one, this will allow for >1 but still finite demo projects be created


## Test Plan
rewired unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.

Fixes PLU-34