### PR TITLE
Shell Bucket Prefix Uniqueness, Install Permissions

### DIFF
--- a/apps/core/lib/core/policies/repository.ex
+++ b/apps/core/lib/core/policies/repository.ex
@@ -73,7 +73,7 @@ defmodule Core.Policies.Repository do
 
   def can?(%User{} = user, %Installation{} = inst, :create) do
     %{repository: repo} = Core.Repo.preload(inst, [:repository])
-    check_rbac(user, :install, repository: repo.name)
+    check_rbac(user, :install, repository: repo.name, account: user.account)
     |> error("your user cannot install, perhaps create a role with the appropriate permissions?")
   end
 

--- a/apps/core/lib/core/policies/shell.ex
+++ b/apps/core/lib/core/policies/shell.ex
@@ -1,0 +1,15 @@
+defmodule Core.Policies.Shell do
+  use Piazza.Policy
+  import Core.Policies.Utils
+  alias Core.Schema.{User, CloudShell}
+
+  def can?(%User{} = user, %CloudShell{}, :create) do
+    check_rbac(user, :install, repository: "console", account: user.account)
+    |> error("users without install permissions cannot create cloud shells")
+  end
+
+  def can?(user, %Ecto.Changeset{} = cs, action),
+    do: can?(user, apply_changes(cs), action)
+
+  def can?(_, _, _), do: {:error, :forbidden}
+end

--- a/apps/core/lib/core/services/shell.ex
+++ b/apps/core/lib/core/services/shell.ex
@@ -1,5 +1,7 @@
 defmodule Core.Services.Shell do
   use Core.Services.Base
+  import Core.Policies.Shell
+
   alias Core.Schema.{CloudShell, User}
   alias Core.Services.{Shell.Pods, Dns}
   alias Core.Shell.Scm
@@ -28,7 +30,8 @@ defmodule Core.Services.Shell do
       %{fetch: nil} ->
         %CloudShell{user_id: user_id}
         |> CloudShell.changeset(attrs)
-        |> Core.Repo.insert()
+        |> allow(user, :create)
+        |> when_ok(:insert)
       %{fetch: %CloudShell{} = s} -> {:ok, s}
     end)
     |> add_operation(:dns, fn %{create: %CloudShell{workspace: %CloudShell.Workspace{subdomain: sub}}} ->

--- a/apps/core/priv/repo/migrations/20220518205019_bucket_uniq.exs
+++ b/apps/core/priv/repo/migrations/20220518205019_bucket_uniq.exs
@@ -1,0 +1,11 @@
+defmodule Core.Repo.Migrations.BucketUniq do
+  use Ecto.Migration
+
+  def change do
+    alter table(:cloud_shells) do
+      add :bucket_prefix, :string
+    end
+
+    create unique_index(:cloud_shells, [:bucket_prefix])
+  end
+end

--- a/apps/graphql/test/mutations/shell_mutations_test.exs
+++ b/apps/graphql/test/mutations/shell_mutations_test.exs
@@ -6,7 +6,7 @@ defmodule GraphQl.ShellMutationsTest do
 
   describe "createShell" do
     test "it will create a new shell instance" do
-      %{email: e} = user = insert(:user)
+      %{email: e} = user = insert(:user, roles: %{admin: true})
 
       expect(Pods, :fetch, fn _ -> {:ok, Pods.pod("plrl-shell-1", e)} end)
       expect(Core.Shell.Scm, :setup_repository, fn


### PR DESCRIPTION
## Summary
Enforcement bucket_prefix uniqueness in cloud shells, and validate install permissions are present on create

Fixes PLU-45, PLU-46


## Test Plan
rewrote unit tests to check install perms, and ensure bucket_prefix is correctly placed

## Checklist

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.