### PR TITLE
Refresh Cache on Role Updates

### DIFF
--- a/apps/core/lib/core/pubsub/events.ex
+++ b/apps/core/lib/core/pubsub/events.ex
@@ -71,3 +71,5 @@ defmodule Core.PubSub.InstallationLocked, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.TestCreated, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.TestUpdated, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.StepLogs, do: use Piazza.PubSub.Event
+
+defmodule Core.PubSub.CacheUser, do: use Piazza.PubSub.Event

--- a/apps/core/lib/core/pubsub/protocols/cacheable.ex
+++ b/apps/core/lib/core/pubsub/protocols/cacheable.ex
@@ -15,7 +15,7 @@ defimpl Core.PubSub.Cacheable, for: [Core.PubSub.GroupMemberCreated, Core.PubSub
   end
 end
 
-defimpl Core.PubSub.Cacheable, for: [Core.PubSub.UserUpdated, Core.PubSub.EmailConfirmed] do
+defimpl Core.PubSub.Cacheable, for: [Core.PubSub.UserUpdated, Core.PubSub.EmailConfirmed, Core.PubSub.CacheUser] do
   def cache(%{item: user}) do
     user = Core.Services.Rbac.preload(user)
     {:set, {:login, user.id}, user}

--- a/apps/core/lib/core/pubsub/protocols/fanout.ex
+++ b/apps/core/lib/core/pubsub/protocols/fanout.ex
@@ -148,3 +148,15 @@ defimpl Core.PubSub.Fanout, for: [Core.PubSub.RepositoryCreated, Core.PubSub.Rep
     end
   end
 end
+
+defimpl Core.PubSub.Fanout, for: [Core.PubSub.RoleCreated, Core.PubSub.RoleUpdated] do
+  alias Core.Schema.User
+  alias Core.PubSub.CacheUser
+
+  def fanout(%{item: role}) do
+    User.for_role(role)
+    |> Core.Repo.all()
+    |> Enum.map(&Core.PubSub.Broadcaster.notify(%CacheUser{item: &1}))
+    |> Enum.count()
+  end
+end

--- a/apps/core/test/pubsub/cache/users_test.exs
+++ b/apps/core/test/pubsub/cache/users_test.exs
@@ -15,6 +15,18 @@ defmodule Core.PubSub.Consumers.Cache.UsersTest do
     end
   end
 
+  describe "CacheUser" do
+    test "it will overwrite the login cache" do
+      user = insert(:user)
+
+      event = %PubSub.CacheUser{item: user}
+      Cache.handle_event(event)
+
+      found = Core.Cache.get({:login, user.id})
+      assert found.id == user.id
+    end
+  end
+
   describe "EmailConfirmed" do
     test "it will overwrite the login cache" do
       user = insert(:user)

--- a/apps/core/test/pubsub/fanout/accounts_test.exs
+++ b/apps/core/test/pubsub/fanout/accounts_test.exs
@@ -40,4 +40,40 @@ defmodule Core.PubSub.Fanout.AccountsTest do
       :ignore = PubSub.Fanout.fanout(event)
     end
   end
+
+  describe "RoleCreated" do
+    test "it will cache all associated users" do
+      role = insert(:role)
+      group = insert(:group)
+      %{user: user1} = insert(:role_binding, role: role, user: build(:user))
+      insert(:role_binding, group: group, role: role)
+      %{user: user2} = insert(:group_member, group: group)
+
+      event = %PubSub.RoleCreated{item: role}
+      2 = PubSub.Fanout.fanout(event)
+
+      assert_receive {:event, %PubSub.CacheUser{item: found1}}
+      assert_receive {:event, %PubSub.CacheUser{item: found2}}
+
+      assert ids_equal([user1, user2], [found1, found2])
+    end
+  end
+
+  describe "RoleUpdated" do
+    test "it will cache all associated users" do
+      role = insert(:role)
+      group = insert(:group)
+      %{user: user1} = insert(:role_binding, role: role, user: build(:user))
+      insert(:role_binding, group: group, role: role)
+      %{user: user2} = insert(:group_member, group: group)
+
+      event = %PubSub.RoleUpdated{item: role}
+      2 = PubSub.Fanout.fanout(event)
+
+      assert_receive {:event, %PubSub.CacheUser{item: found1}}
+      assert_receive {:event, %PubSub.CacheUser{item: found2}}
+
+      assert ids_equal([user1, user2], [found1, found2])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

We currently wait until cache eviction for this to occur, which is a subpar experience for sure.  This will get near realtime updates into cache and ensure users get permissions quickly.

## Test Plan
added unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.