### PR TITLE
Klink/eng 72 implement repository description

### DIFF
--- a/www/src/components/repository/RepositoryDescription.js
+++ b/www/src/components/repository/RepositoryDescription.js
@@ -1,6 +1,35 @@
+import { useContext } from 'react'
+import { Flex, H2 } from 'honorable'
+
+import RepositoryContext from '../../contexts/RepositoryContext'
+
+import RepositoryDescriptionMarkdown from './RepositoryDescriptionMarkdown'
+
 function RepositoryDescription() {
+  const repository = useContext(RepositoryContext)
+
   return (
-    'RepositoryDescription'
+    <Flex
+      direction="column"
+      height="100%"
+    >
+      <H2>
+        Description
+      </H2>
+      <Flex
+        mt={2}
+        direction="column"
+        flexGrow={1}
+        maxWidth="700px"
+      >
+        {repository.readme && (
+          <RepositoryDescriptionMarkdown
+            text={repository.readme}
+            gitUrl={repository.git_url}
+          />
+        )}
+      </Flex>
+    </Flex>
   )
 }
 

--- a/www/src/components/repository/RepositoryDescriptionMarkdown.js
+++ b/www/src/components/repository/RepositoryDescriptionMarkdown.js
@@ -1,0 +1,118 @@
+import React, { memo } from 'react'
+import { Markdown } from 'grommet'
+import {
+} from 'pluralsh-design-system'
+import { A, Blockquote, Box, Code, H1, H2, H3, H4, H5, H6, 
+  Li, Ol, Pre, Ul } from 'honorable'
+
+function MdImg({ src, gitUrl, ...props }) {
+  // Convert local image paths to full path on github
+  // Only works if primary git branch is named "master"
+  if (src && !src.match(/^https*/)) {
+    src = `${gitUrl}/raw/master/${src}`
+  }
+
+  return (
+    <img
+      src={src}
+      maxWidth="100%"
+      display="inline"
+      {...props}
+    />
+  )
+}
+
+function MdP({ ...props }) {
+  return <p {...props} />
+}
+
+function MdCode({ ...props }) {
+  return <Code {...props} />
+}
+
+function getDeepestChild(children) {
+  let lastChild = null
+  React.Children.forEach(children, child => {
+    if (child.props && child.props.children) {
+      lastChild = getDeepestChild(child.props.children)
+    }
+    else {
+      lastChild = child
+    }
+  })
+
+  return lastChild
+}
+
+function MdPre({ children, ...props }) {
+  return (
+    <Box mb={1}>
+      <Pre
+        {...props}
+      >
+        {getDeepestChild(children)}
+      </Pre>
+    </Box>
+  )
+}
+
+const codeStyle = {
+  background: 'background-light',
+  borderRadius: '4px',
+}
+
+export default memo(({ text, gitUrl }) => (
+  <Markdown
+    components={{
+      blockquote: {
+        component: Blockquote,
+        props: {
+          borderLeft: '4px solid',
+          borderColor: 'border',
+          mx: 0,
+          pl: '1em',
+        } },
+      ul: { component: Ul, props: { pl: '2em' } },
+      ol: { component: Ol, props: { pl: '2em' } },
+      li: { component: Li, props: { mt: 0.25 } },
+      h1: { component: H1, props: { mt: 2, mb: 0.5 } },
+      h2: { component: H2, props: { mt: 2, mb: 0.5 } },
+      h3: { component: H3, props: { mt: 2, mb: 0.5 } },
+      h4: { component: H4, props: { mt: 2, mb: 0.5 } },
+      h5: { component: H5, props: { mt: 2, mb: 0.5 } },
+      h6: { component: H6, props: { mt: 2, mb: 0.5 } },
+      img: {
+        component: MdImg,
+        props: {
+          gitUrl, style: { maxWidth: '100%' },
+        },
+      },
+      p: { component: MdP },
+      a: {
+        component: A,
+        props: {
+          display: 'inline', color: 'text-light', size: 'small', target: '_blank',
+        },
+      },
+      span: { props: { style: { verticalAlign: 'bottom' } } },
+      code: {
+        component: MdCode,
+        props: {
+          ...codeStyle,
+          ...{
+            mx: '0.2em',
+            px: '0.3em',
+            py: '0.25em',
+          },
+        } },
+      pre: {
+        component: MdPre,
+        props: {
+          ...codeStyle, ...{ px: '1em', py: '0.65em' },
+        },
+      },
+    }}
+  >
+    {text}
+  </Markdown>
+))

--- a/www/src/components/repository/RepositoryHeader.js
+++ b/www/src/components/repository/RepositoryHeader.js
@@ -303,24 +303,35 @@ function RepositoryHeader(props) {
           mt={0.5}
           align="center"
         >
-          <A>
-            <LinksIcon
-              color="text"
-              size={12}
-            />
-            <Span ml={0.25}>
-              airbyte.com
-            </Span>
-          </A>
-          <A ml={1}>
-            <GitHubIcon
-              color="text"
-              size={12}
-            />
-            <Span ml={0.25}>
-              github.com/airbytehq/airbyte
-            </Span>
-          </A>
+          {repository.homepage && (
+            <A
+              target="_blank"
+              href={repository.homepage}
+            >
+              <LinksIcon
+                color="text"
+                size={12}
+              />
+              <Span ml={0.25}>
+                {repository.homepage && repository.homepage.replace(/^https?:\/\//, '').replace(/\/+$/, '')}
+              </Span>
+            </A>
+          )}
+          {repository.git_url && (
+            <A
+              ml={1}
+              target="_blank"
+              href={repository.git_url}
+            >
+              <GitHubIcon
+                color="text"
+                size={12}
+              />
+              <Span ml={0.25}>
+                {repository.git_url && repository.git_url.replace(/^https?:\/\//, '').replace(/\/+$/, '')}
+              </Span>
+            </A>
+          )}
         </Flex>
         <Flex
           mt={1}

--- a/www/src/components/repository/RepositoryHeader.js
+++ b/www/src/components/repository/RepositoryHeader.js
@@ -278,7 +278,7 @@ function RepositoryHeader(props) {
           color="text-xlight"
         >
           <P>
-            Publised by {repository.publisher?.name?.toUpperCase()}
+            Published by {repository.publisher?.name?.toUpperCase()}
           </P>
           <P ml={1}>
             Available bundles

--- a/www/src/components/repository/queries.js
+++ b/www/src/components/repository/queries.js
@@ -33,6 +33,8 @@ export const REPOSITORY_QUERY = gql`
       tags {
         tag
       }
+      git_url
+      homepage
     }
   }
   ${RepoFragment}

--- a/www/src/components/repository/queries.js
+++ b/www/src/components/repository/queries.js
@@ -33,6 +33,7 @@ export const REPOSITORY_QUERY = gql`
       tags {
         tag
       }
+      readme
       git_url
       homepage
     }


### PR DESCRIPTION
# Implement Repository Description
https://linear.app/pluralsh/issue/ENG-72/implement-repository-description
## Summary

- Render the markdown in the `readme` api key and display in a repository's "Description" tab.
- Show a repository's homepage and github urls in the repository header if available.

## Known issues
Images hosted on github won't load unless the project's primary branch is named `master`. I'm detecting images with local paths and adding the relevant github url in front of those image urls, but the url needs to include a branch name, and I don't have any way of knowing what the primary branch name of each project is. Currently defaulting to `master` since it seems to cover the most cases.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.