### PR TITLE
Don't include avatar when bootstrapping from oauth

### DIFF
--- a/apps/core/lib/core/oauth.ex
+++ b/apps/core/lib/core/oauth.ex
@@ -12,7 +12,7 @@ defmodule Core.OAuth do
     client = strategy.get_token!(redirect, code)
 
     with {:ok, result} <- strategy.get_user(client),
-      do: Core.Services.Users.bootstrap_user(strat, result)
+      do: Core.Services.Users.bootstrap_user(strat, Map.delete(result, :avatar))
   end
 
   def strategy(:github), do: Core.OAuth.Github


### PR DESCRIPTION
## Summary

Apparently there are some gmail avatars that can break user creation, so might want to hold off on this

## Test Plan
unit test

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.

Closes #247 