### PR TITLE
Allow oauth users to bypass icon validation

### DIFF
--- a/apps/core/lib/core/oauth.ex
+++ b/apps/core/lib/core/oauth.ex
@@ -12,7 +12,7 @@ defmodule Core.OAuth do
     client = strategy.get_token!(redirect, code)
 
     with {:ok, result} <- strategy.get_user(client),
-      do: Core.Services.Users.bootstrap_user(strat, Map.delete(result, :avatar))
+      do: Core.Services.Users.bootstrap_user(strat, Map.put(result, :trusted_icon, true))
   end
 
   def strategy(:github), do: Core.OAuth.Github

--- a/apps/core/lib/core/schema/user.ex
+++ b/apps/core/lib/core/schema/user.ex
@@ -40,6 +40,7 @@ defmodule Core.Schema.User do
     field :phone,           :string
     field :external_id,     :string
     field :demo_count,      :integer, default: 0
+    field :trusted_icon,    :boolean, default: false, virtual: true
 
     field :email_confirmed,  :boolean, default: false
     field :email_confirm_by, :utc_datetime_usec
@@ -131,7 +132,7 @@ defmodule Core.Schema.User do
   def ordered(query \\ __MODULE__, order \\ [asc: :name]),
     do: from(p in query, order_by: ^order)
 
-  @valid ~w(name email password phone login_method demoed demo_count)a
+  @valid ~w(name email password phone login_method demoed demo_count trusted_icon)a
 
   def changeset(model, attrs \\ %{}) do
     model

--- a/apps/core/lib/core/services/storage.ex
+++ b/apps/core/lib/core/services/storage.ex
@@ -20,6 +20,7 @@ defmodule Core.Storage do
   @versions [:original]
   @extension_whitelist ~w(.jpg .jpeg .gif .png)
 
+  def validate({_, %User{trusted_icon: true}}), do: true
   def validate({file, %User{}}) do
     file_extension = file.file_name |> Path.extname |> String.downcase
     Enum.member?(@extension_whitelist, file_extension)

--- a/apps/core/test/oauth_test.exs
+++ b/apps/core/test/oauth_test.exs
@@ -1,0 +1,18 @@
+defmodule Core.OAuthTest do
+  use Core.SchemaCase, async: true
+  use Mimic
+  alias Core.OAuth.Github
+
+  describe "#callback/3" do
+    test "it will properly bootstrap a user" do
+      expect(Github, :get_token!, fn "https://example.com", "code" -> "token" end)
+      expect(Github, :get_user, fn "token" -> {:ok, %{name: "someone", email: "someone@gmail.com"}} end)
+
+      {:ok, user} = Core.OAuth.callback(:github, "https://example.com", "code")
+
+      assert user.name == "someone"
+      assert user.email == "someone@gmail.com"
+      assert user.trusted_icon
+    end
+  end
+end

--- a/apps/core/test/test_helper.exs
+++ b/apps/core/test/test_helper.exs
@@ -25,5 +25,6 @@ Mimic.copy(GoogleApi.CloudBilling.V1.Api.BillingAccounts)
 Mimic.copy(GoogleApi.ServiceUsage.V1.Api.Services)
 Mimic.copy(GoogleApi.ServiceUsage.V1.Api.Operations)
 Mimic.copy(OAuth2.Client)
+Mimic.copy(Core.OAuth.Github)
 
 {:ok, _} = Application.ensure_all_started(:ex_machina)


### PR DESCRIPTION
## Summary

There apparently are some gmail accounts with extensionless avatars, and regardless whether that is common, we can trust those files to be proper images and ensure minimum signup glitches.

## Test Plan
regression on existing tests

## Checklist

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.

Closes #247 