### PR TITLE
hydra: add offline_access scope for refresh tokens

### DIFF
--- a/apps/core/lib/core/services/oauth.ex
+++ b/apps/core/lib/core/services/oauth.ex
@@ -49,7 +49,7 @@ defmodule Core.Services.OAuth do
   Consents to the scopes granted in the login exchanges and hydrates an id token
   """
   @spec consent(binary, [binary], User.t) :: oauth_resp
-  def consent(challenge, scopes \\ ["profile"], %User{} = user) do
+  def consent(challenge, scopes \\ ["profile", "offline_access"], %User{} = user) do
     user = Core.Repo.preload(user, [:groups])
     with {:ok, provider} <- get_consent(challenge),
          {:ok, _} = res <- Hydra.accept_consent(user, challenge, scopes),

--- a/apps/core/lib/core/services/repositories.ex
+++ b/apps/core/lib/core/services/repositories.ex
@@ -389,7 +389,7 @@ defmodule Core.Services.Repositories do
     end)
   end
 
-  @oidc_scopes "profile code openid"
+  @oidc_scopes "profile code openid offline_access"
 
   @doc """
   Creates a new oidc provider for a given installation, enabling a log-in with plural experience


### PR DESCRIPTION
## Summary
Currently the Plural OIDC provider does not support returning refresh tokens. This PR adds the `offline_access` scope to OIDC clients when they are created, as well as too the app consent following https://www.ory.sh/docs/hydra/debug#oauth-20-refresh-token-is-missing.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.