### PR TITLE
Add breadcrumbs to the marketplace repositories - ENG-204

### DIFF
--- a/www/src/components/Breadcrumbs.js
+++ b/www/src/components/Breadcrumbs.js
@@ -1,16 +1,17 @@
-import { createContext, useContext, useMemo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { Anchor, Box, Text } from 'grommet'
+import {createContext, useContext, useMemo, useState} from 'react'
+import {useNavigate} from 'react-router-dom'
+import {Anchor, Box, Text} from 'grommet'
 
-import { lookahead } from '../utils/array'
+import {lookahead} from '../utils/array'
 
 export const BreadcrumbsContext = createContext({
   breadcrumbs: [],
   setBreadcrumbs: () => null,
 })
 
-function CrumbLink({ crumb: { url, text, disable } }) {
+function CrumbLink({crumb: {url, text, disable}}) {
   const navigate = useNavigate()
+  // TODO: new design does not cover the "disabled" state. Should it be removed?
   if (disable) {
     return (
       <Text
@@ -33,34 +34,34 @@ function CrumbLink({ crumb: { url, text, disable } }) {
 }
 
 export function Breadcrumbs() {
-  const { breadcrumbs } = useContext(BreadcrumbsContext)
-
+  const {breadcrumbs} = useContext(BreadcrumbsContext)
   if (breadcrumbs.length === 0) return null
 
   const children = Array.from(lookahead(breadcrumbs, (crumb, next) => {
-    if (next.url) {
-      return [
-        <CrumbLink
-          key={crumb.url + crumb.text}
-          crumb={crumb}
-        />,
-        <Text
-          key={`${crumb.url + crumb.text}next`}
-          size="small"
-        >/
-        </Text>,
-      ]
-    }
+      if (next.url) {
+        return [
+          <CrumbLink
+            key={crumb.url + crumb.text}
+            crumb={crumb}
+          />,
+          <Text
+            key={`${crumb.url + crumb.text}next`}
+            size="small"
+          >/
+          </Text>,
+        ]
+      }
 
-    return (
-      <Text
-        key={crumb.url + crumb.text}
-        size="small"
-        color="dark-6"
-      >{crumb.text}
-      </Text>
-    )
-  })).flat()
+      return (
+        <Text
+          key={crumb.url + crumb.text}
+          size="small"
+          weight={700}
+        >{crumb.text}
+        </Text>
+      )
+    })
+  ).flat()
 
   return (
     <Box
@@ -68,16 +69,16 @@ export function Breadcrumbs() {
       direction="row"
       gap="xsmall"
       align="center"
-      pad={{ right: 'small', left: '1px' }}
+      pad={{right: 'small', left: '1px'}}
     >
       {children}
     </Box>
   )
 }
 
-export default function BreadcrumbProvider({ children }) {
+export default function BreadcrumbProvider({children}) {
   const [breadcrumbs, setBreadcrumbs] = useState([])
-  const value = useMemo(() => ({ breadcrumbs, setBreadcrumbs }), [breadcrumbs])
+  const value = useMemo(() => ({breadcrumbs, setBreadcrumbs}), [breadcrumbs])
 
   return (
     <BreadcrumbsContext.Provider value={value}>

--- a/www/src/components/Breadcrumbs.js
+++ b/www/src/components/Breadcrumbs.js
@@ -1,8 +1,8 @@
-import {createContext, useContext, useMemo, useState} from 'react'
-import {useNavigate} from 'react-router-dom'
-import {Anchor, Box, Text} from 'grommet'
+import { createContext, useContext, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Anchor, Box, Text } from 'grommet'
 
-import {lookahead} from '../utils/array'
+import { lookahead } from '../utils/array'
 
 export const BreadcrumbsContext = createContext({
   breadcrumbs: [],

--- a/www/src/components/repository/Repository.js
+++ b/www/src/components/repository/Repository.js
@@ -12,6 +12,7 @@ import { LoopingLogo } from '../utils/AnimatedLogo'
 import RepositoryHeader from './RepositoryHeader'
 
 import { REPOSITORY_QUERY } from './queries'
+import {Breadcrumbs} from "../Breadcrumbs";
 
 function Repository() {
   const { id } = useParams()
@@ -23,7 +24,7 @@ function Repository() {
   })
 
   useBreadcrumbs(data && [
-    { url: '/explore', text: 'Explore' },
+    { url: '/marketplace', text: 'Marketplace' },
     { url: `/repository/${data.repository.id}`, text: data.repository.name },
   ])
 
@@ -52,6 +53,13 @@ function Repository() {
         direction="column"
         overflowY="hidden"
       >
+        <Flex
+            paddingVertical={18}
+            paddingLeft="xlarge"
+            paddingRight="large"
+            borderBottom="1px solid border">
+          <Breadcrumbs></Breadcrumbs>
+        </Flex>
         <RepositoryHeader flexShrink={0} />
         <Flex
           flexGrow={1}

--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -181,9 +181,10 @@ export const DEFAULT_COLOR_THEME = {
 
 export const DEFAULT_THEME = {
   anchor: {
-    color: 'text',
+    color: '#9095A2',
     hover: {
       textDecoration: 'underline',
+      extend: 'color: #EBEFF0'
     },
     fontWeight: 400,
   },


### PR DESCRIPTION
Restored breadcrumbs for the marketplace repositories.

Normal
![image](https://user-images.githubusercontent.com/2285385/177128247-f447fae0-7950-4b3b-8102-786b185f91a3.png)

Hovered
![image](https://user-images.githubusercontent.com/2285385/177128275-08eab213-5a39-4763-a6cc-f1f56ec754c2.png)

### Questions
1. Should we still consider `disabled` state for breadcrumbs? Design does not cover that. Is it used?
2. What about colors for different themes (dark/light)? Should I ignore that for now and simply reuse colors from the figma?
3. Should the repository application name be always capitalized?