### PR TITLE
ENG-224 - Tighten the fuzzy search criteria threshold

### DIFF
--- a/www/src/components/marketplace/MarketplaceRepositories.js
+++ b/www/src/components/marketplace/MarketplaceRepositories.js
@@ -14,6 +14,7 @@ import { MARKETPLACE_QUERY } from './queries'
 
 const searchOptions = {
   keys: ['name', 'description', 'tags.tag'],
+  threshold: 0.25,
 }
 
 const filterTokenStyles = {


### PR DESCRIPTION
## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
It appears that the default search options for the fusejs are a bit too permissive and allow as much as 60 characters distance between the pattern and matched object. I have updated threshold to make it a bit more restrictive.

![image](https://user-images.githubusercontent.com/2285385/177299750-4a1ef92f-1dfc-4383-8781-f768a72f04e4.png)

![image](https://user-images.githubusercontent.com/2285385/177299814-d3ea1db7-2f7d-44a9-a101-2d5c15854166.png)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Tested locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.