### PR TITLE
ENG-248 Fix border margins

### DIFF
--- a/www/src/components/repository/Repository.js
+++ b/www/src/components/repository/Repository.js
@@ -9,10 +9,11 @@ import useBreadcrumbs from '../../hooks/useBreadcrumbs'
 
 import { LoopingLogo } from '../utils/AnimatedLogo'
 
+import { Breadcrumbs } from '../Breadcrumbs'
+
 import RepositoryHeader from './RepositoryHeader'
 
 import { REPOSITORY_QUERY } from './queries'
-import {Breadcrumbs} from "../Breadcrumbs";
 
 function Repository() {
   const { id } = useParams()
@@ -54,11 +55,14 @@ function Repository() {
         overflowY="hidden"
       >
         <Flex
-            paddingVertical={18}
-            paddingLeft="xlarge"
-            paddingRight="large"
-            borderBottom="1px solid border">
-          <Breadcrumbs></Breadcrumbs>
+          paddingVertical={18}
+          marginLeft="xlarge"
+          marginRight="xlarge"
+          paddingLeft="xsmall"
+          paddingRight="xsmall"
+          borderBottom="1px solid border"
+        >
+          <Breadcrumbs />
         </Flex>
         <RepositoryHeader flexShrink={0} />
         <Flex

--- a/www/src/components/repository/RepositoryHeader.js
+++ b/www/src/components/repository/RepositoryHeader.js
@@ -60,7 +60,8 @@ function RepositoryHeader(props) {
   return (
     <Flex
       py={2}
-      px={2}
+      marginLeft="xlarge"
+      marginRight="xlarge"
       align="flex-start"
       borderBottom="1px solid border"
       {...props}


### PR DESCRIPTION
## Summary
Adds missing margins for borders on repository page:

<img width="1471" alt="Zrzut ekranu 2022-07-5 o 14 02 08" src="https://user-images.githubusercontent.com/2823399/177323133-1a7b797c-0026-46f7-ae0a-eb1d3c151779.png">
<img width="1471" alt="Zrzut ekranu 2022-07-5 o 14 01 45" src="https://user-images.githubusercontent.com/2823399/177323150-99fb0bf3-952a-40ec-84f3-4f24c01de49a.png">

## Test Plan
Tested manually.

## Checklist
- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.