### PR TITLE
ENG-227 - Hide the notification completely when on sidebar element not hovered

### DIFF
--- a/www/src/components/layout/Sidebar.js
+++ b/www/src/components/layout/Sidebar.js
@@ -113,6 +113,8 @@ function SidebarItemRef({
 },
 ref
 ) {
+  const [hovered, setHovered] = useState(false)
+
   function wrapLink(node) {
     if (!linkTo) return node
 
@@ -148,7 +150,8 @@ ref
         placement="right"
         label={tooltip}
         zIndex={1000}
-        display={collapsed ? 'block' : 'none'}
+        visibility={collapsed ? 'visible' : 'hidden'}
+        display={hovered ? 'block' : 'none'}
         whiteSpace="nowrap"
       >
         {node}
@@ -158,6 +161,8 @@ ref
 
   return wrapLink(wrapTooltip(
     <Flex
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       ref={ref}
       py="9.5px" // Give it a square look with a weird padding
       px={0.75}


### PR DESCRIPTION
## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
I guess this is a bit of a workaround. It might be the best to update the original `Tooltip` element that comes from the `honorable` library, so that we do not unknowingly fall into the same trap again when using the `Tooltip` element in other places.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Tested locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.