### PR TITLE
Restore label button for the graph dependency switch

### DIFF
--- a/www/src/components/repos/Chart.js
+++ b/www/src/components/repos/Chart.js
@@ -144,7 +144,7 @@ function ChartHeader({ version: { helm, chart, version, scan, id }, chartInstall
           src={chart.icon || DEFAULT_CHART_ICON}
         />
       </Box>
-      <Box width="100%">
+      <Box flex>
         <Box
           direction="row"
           align="center"

--- a/www/src/components/repos/Dependencies.js
+++ b/www/src/components/repos/Dependencies.js
@@ -71,10 +71,13 @@ export function ShowFull({ onClick, label }) {
   return (
     <Button
       primary
+      width="90px"
+      height="25px"
       size="small"
-      label={label}
       onClick={onClick}
-    />
+    >
+      {label}
+    </Button>
   )
 }
 

--- a/www/src/components/repos/Docker.js
+++ b/www/src/components/repos/Docker.js
@@ -72,10 +72,7 @@ function DockerHeader({ image }) {
           src={DEFAULT_DKR_ICON}
         />
       </Box>
-      <Box
-        fill="horizontal"
-        gap="xxsmall"
-      >
+      <Box flex>
         <Box
           direction="row"
           gap="small"

--- a/www/src/components/repos/Terraform.js
+++ b/www/src/components/repos/Terraform.js
@@ -122,7 +122,7 @@ function TerraformHeader({ terraform: { id, name, description, installation, rep
           src={DEFAULT_TF_ICON}
         />
       </Box>
-      <Box flex={1}>
+      <Box flex>
         <Box
           direction="row"
           gap="small"


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- restore `Full`/`Immediate` label on the dependency switch button
- push to the right the grade badge on the terraform package view (it was next to the name) 

![Zrzut ekranu z 2022-07-06 13-36-08](https://user-images.githubusercontent.com/2285385/177541780-f52136f7-b692-4a56-8956-c6b39bbdaeb4.png)
![Zrzut ekranu z 2022-07-06 13-36-12](https://user-images.githubusercontent.com/2285385/177541785-a932baa8-e7a5-49df-b177-7e7cfb1ea50f.png)
![Zrzut ekranu z 2022-07-06 13-36-14](https://user-images.githubusercontent.com/2285385/177541786-3feae396-8f9c-4ae3-8ffa-a6600f857664.png)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.