### PR TITLE
Add new version of oidc request queries

### DIFF
--- a/apps/core/lib/core/services/oauth.ex
+++ b/apps/core/lib/core/services/oauth.ex
@@ -13,8 +13,9 @@ defmodule Core.Services.OAuth do
   """
   @spec get_login(binary) :: {:ok, OIDCProvider.t} | error
   def get_login(challenge) do
-    with {:ok, %{client: client}} <- Hydra.get_login(challenge) do
-      {:ok, Repositories.get_oidc_provider_by_client!(client.client_id)}
+    with {:ok, %{client: client} = login} <- Hydra.get_login(challenge),
+         provider <- Repositories.get_oidc_provider_by_client!(client.client_id) do
+      {:ok, %{provider | login: login}}
     end
   end
 

--- a/apps/graphql/lib/graphql/schema/oauth.ex
+++ b/apps/graphql/lib/graphql/schema/oauth.ex
@@ -30,6 +30,11 @@ defmodule GraphQl.Schema.OAuth do
     field :skip,            :boolean
   end
 
+  object :login_request do
+    field :requested_scope, list_of(:string)
+    field :subject,         :string
+  end
+
   object :oidc_login do
     field :id,        non_null(:id)
     field :ip,        :string
@@ -45,6 +50,12 @@ defmodule GraphQl.Schema.OAuth do
     timestamps()
   end
 
+  object :oidc_step_response do
+    field :repository, :repository
+    field :login,      :login_request
+    field :consent,    :consent_request
+  end
+
   connection node_type: :oidc_login
 
   object :oauth_queries do
@@ -58,6 +69,18 @@ defmodule GraphQl.Schema.OAuth do
       arg :challenge, non_null(:string)
 
       resolve &OAuth.resolve_consent/2
+    end
+
+    field :oidc_login, :oidc_step_response do
+      arg :challenge, non_null(:string)
+
+      resolve &OAuth.resolve_oidc_login/2
+    end
+
+    field :oidc_consent, :oidc_step_response do
+      arg :challenge, non_null(:string)
+
+      resolve &OAuth.resolve_oidc_consent/2
     end
 
     field :oauth_urls, list_of(:oauth_info) do

--- a/apps/graphql/test/queries/oauth_queries_test.exs
+++ b/apps/graphql/test/queries/oauth_queries_test.exs
@@ -39,6 +39,50 @@ defmodule GraphQl.OAuthQueriesTest do
     end
   end
 
+  describe "oidcLogin" do
+    test "it can fetch an oauth login's details" do
+      provider = insert(:oidc_provider)
+      expect(HTTPoison, :get, fn _, _ ->
+        body = Jason.encode!(%{client: %{client_id: provider.client_id}, requested_scope: ["openid"]})
+        {:ok, %{status_code: 200, body: body}}
+      end)
+
+      {:ok, %{data: %{"oidcLogin" => result}}} = run_query("""
+        query Login($challenge: String!) {
+          oidcLogin(challenge: $challenge) {
+            repository { id }
+            login { requestedScope }
+          }
+        }
+      """, %{"challenge" => "challenge"})
+
+      assert result["repository"]["id"] == provider.installation.repository_id
+      assert result["login"]["requestedScope"] == ["openid"]
+    end
+  end
+
+  describe "oidcConsent" do
+    test "it can fetch an oauth login's details" do
+      provider = insert(:oidc_provider)
+      expect(HTTPoison, :get, fn _, _ ->
+        body = Jason.encode!(%{client: %{client_id: provider.client_id}, requested_scope: ["openid"]})
+        {:ok, %{status_code: 200, body: body}}
+      end)
+
+      {:ok, %{data: %{"oidcConsent" => result}}} = run_query("""
+        query Login($challenge: String!) {
+          oidcConsent(challenge: $challenge) {
+            repository { id }
+            consent { requestedScope }
+          }
+        }
+      """, %{"challenge" => "challenge"})
+
+      assert result["repository"]["id"] == provider.installation.repository_id
+      assert result["consent"]["requestedScope"] == ["openid"]
+    end
+  end
+
   describe "oidcLogins" do
     test "it can list logins for an account" do
       user   = insert(:user)


### PR DESCRIPTION
## Summary

The previous way to extract hydra login/consent requests had only the repo as a return value which
is genuinely too constrained, this introduces a simple joint type that can drive the entire flow consistently


## Test Plan
added unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.