### PR TITLE
Add licenses to repos

### DIFF
--- a/www/src/components/repository/RepositoryHeader.js
+++ b/www/src/components/repository/RepositoryHeader.js
@@ -1,6 +1,6 @@
 import { useContext, useState } from 'react'
 import { A, Button, Div, Flex, H1, Img, P, Span } from 'honorable'
-import { GearTrainIcon, GitHubIcon, LinksIcon, Tag } from 'pluralsh-design-system'
+import { GearTrainIcon, GitHubIcon, InvoicesIcon, LinksIcon, Tag } from 'pluralsh-design-system'
 
 import RepositoryContext from '../../contexts/RepositoryContext'
 
@@ -145,6 +145,21 @@ function RepositoryHeader(props) {
               />
               <Span ml={0.25}>
                 {repository.git_url && repository.git_url.replaceAll(/(^https?:\/\/)|(\/+$)/g, '')}
+              </Span>
+            </A>
+          )}
+          {repository.license && (
+            <A
+              ml={1}
+              target="_blank"
+              href={repository.license.url}
+            >
+              <InvoicesIcon
+                color="text"
+                size={12}
+              />
+              <Span ml={0.25}>
+                {repository.license.name}
               </Span>
             </A>
           )}

--- a/www/src/components/repository/RepositoryHeader.js
+++ b/www/src/components/repository/RepositoryHeader.js
@@ -118,6 +118,7 @@ function RepositoryHeader(props) {
         <Flex
           mt={0.5}
           align="center"
+          gap="16px"
         >
           {repository.homepage && (
             <A
@@ -135,7 +136,6 @@ function RepositoryHeader(props) {
           )}
           {repository.git_url && (
             <A
-              ml={1}
               target="_blank"
               href={repository.git_url}
             >
@@ -150,7 +150,6 @@ function RepositoryHeader(props) {
           )}
           {repository.license && (
             <A
-              ml={1}
               target="_blank"
               href={repository.license.url}
             >

--- a/www/src/components/repository/queries.js
+++ b/www/src/components/repository/queries.js
@@ -39,6 +39,10 @@ export const REPOSITORY_QUERY = gql`
       readme
       git_url
       homepage
+      license {
+        name
+        url
+      }
     }
   }
   ${RepoFragment}


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
Fixes ENG-99.

- Adds license info to repository pages
- Fixes small spacing issue

<img width="575" alt="Zrzut ekranu 2022-07-11 o 11 40 59" src="https://user-images.githubusercontent.com/2823399/178236249-bdac0e8d-220a-415d-9d11-dc5280320329.png">
<img width="630" alt="Zrzut ekranu 2022-07-11 o 11 40 15" src="https://user-images.githubusercontent.com/2823399/178236259-3aa29c6f-7542-41e0-99bb-11254aa3edf2.png">

## Test Plan
Tested manually.

## Checklist
- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.