### PR TITLE
Add empty states and other design improvements

### DIFF
--- a/www/src/components/account/Domains.js
+++ b/www/src/components/account/Domains.js
@@ -182,6 +182,7 @@ function DnsRecords({ domain, setDomain }) {
         pad="small"
         background="fill-one"
         border
+        round="xsmall"
       >
         <Icon
           icon={<Return size="15px" />}
@@ -194,6 +195,7 @@ function DnsRecords({ domain, setDomain }) {
         sizes={['20%', '20%', '20%', '20%', '20%']}
         background="fill-one"
         border="1px solid border"
+        marginTop="medium"
         width="100%"
         height="100%"
       >
@@ -261,6 +263,37 @@ function DnsRecords({ domain, setDomain }) {
   )
 }
 
+function Domain({ node, last, setDomain }) {
+  return (
+    <TableRow
+      last={last}
+      suffix={(
+        <DomainOptions
+          domain={node}
+          setDomain={setDomain}
+        />
+      )}
+    >
+      <TableData>{node.name}</TableData>
+      <TableData>
+        <Box
+          direction="row"
+          gap="xsmall"
+          align="center"
+        >
+          <Avatar
+            src={node.creator.avatar}
+            name={node.creator.name}
+            size={30}
+          />
+          <Span color="text-light">{node.creator.name}</Span>
+        </Box>
+      </TableData>
+      <TableData>{moment(node.insertedAt).format('lll')}</TableData>
+    </TableRow>
+  )
+}
+
 export function Domains() {
   const [listRef, setListRef] = useState(null)
   const [domain, setDomain] = useState(null)
@@ -291,7 +324,6 @@ export function Domains() {
           height="calc(100% - 16px)"
         >
           <Box fill>
-
             <StandardScroller
               listRef={listRef}
               setListRef={setListRef}
@@ -300,32 +332,11 @@ export function Domains() {
               loading={loading}
               placeholder={Placeholder}
               mapper={({ node }, { next }) => (
-                <TableRow
+                <Domain
+                  node={node}
                   last={!next.node}
-                  suffix={(
-                    <DomainOptions
-                      domain={node}
-                      setDomain={setDomain}
-                    />
-                  )}
-                >
-                  <TableData>{node.name}</TableData>
-                  <TableData>
-                    <Box
-                      direction="row"
-                      gap="xsmall"
-                      align="center"
-                    >
-                      <Avatar
-                        src={node.creator.avatar}
-                        name={node.creator.name}
-                        size={30}
-                      />
-                      <Span color="text-light">{node.creator.name}</Span>
-                    </Box>
-                  </TableData>
-                  <TableData>{moment(node.insertedAt).format('lll')}</TableData>
-                </TableRow>
+                  setDomain={setDomain}
+                />
               )}
               loadNextPage={() => pageInfo.hasNextPage && fetchMore({
                 variables: { cursor: pageInfo.endCursor },

--- a/www/src/components/account/Domains.js
+++ b/www/src/components/account/Domains.js
@@ -281,57 +281,60 @@ export function Domains() {
 
   return (
     <Container type="table">
-      <Table
-        headers={['Name', 'Creator', 'Created On']}
-        sizes={['33%', '33%', '33%']}
-        background="fill-one"
-        border="1px solid border"
-        width="100%"
-        height="calc(100% - 16px)"
-      >
-        <Box fill>
-          <StandardScroller
-            listRef={listRef}
-            setListRef={setListRef}
-            hasNextPage={pageInfo.hasNextPage}
-            items={edges}
-            loading={loading}
-            placeholder={Placeholder}
-            mapper={({ node }, { next }) => (
-              <TableRow
-                last={!next.node}
-                suffix={(
-                  <DomainOptions
-                    domain={node}
-                    setDomain={setDomain}
-                  />
-                )}
-              >
-                <TableData>{node.name}</TableData>
-                <TableData>
-                  <Box
-                    direction="row"
-                    gap="xsmall"
-                    align="center"
-                  >
-                    <Avatar
-                      src={node.creator.avatar}
-                      name={node.creator.name}
-                      size={30}
+      {edges?.length ? (
+        <Table
+          headers={['Name', 'Creator', 'Created On']}
+          sizes={['33%', '33%', '33%']}
+          background="fill-one"
+          border="1px solid border"
+          width="100%"
+          height="calc(100% - 16px)"
+        >
+          <Box fill>
+
+            <StandardScroller
+              listRef={listRef}
+              setListRef={setListRef}
+              hasNextPage={pageInfo.hasNextPage}
+              items={edges}
+              loading={loading}
+              placeholder={Placeholder}
+              mapper={({ node }, { next }) => (
+                <TableRow
+                  last={!next.node}
+                  suffix={(
+                    <DomainOptions
+                      domain={node}
+                      setDomain={setDomain}
                     />
-                    <Span color="text-light">{node.creator.name}</Span>
-                  </Box>
-                </TableData>
-                <TableData>{moment(node.insertedAt).format('lll')}</TableData>
-              </TableRow>
-            )}
-            loadNextPage={() => pageInfo.hasNextPage && fetchMore({
-              variables: { cursor: pageInfo.endCursor },
-              updateQuery: (prev, { fetchMoreResult: { invites } }) => extendConnection(prev, invites, 'invites'),
-            })}
-          />
-        </Box>
-      </Table>
+                  )}
+                >
+                  <TableData>{node.name}</TableData>
+                  <TableData>
+                    <Box
+                      direction="row"
+                      gap="xsmall"
+                      align="center"
+                    >
+                      <Avatar
+                        src={node.creator.avatar}
+                        name={node.creator.name}
+                        size={30}
+                      />
+                      <Span color="text-light">{node.creator.name}</Span>
+                    </Box>
+                  </TableData>
+                  <TableData>{moment(node.insertedAt).format('lll')}</TableData>
+                </TableRow>
+              )}
+              loadNextPage={() => pageInfo.hasNextPage && fetchMore({
+                variables: { cursor: pageInfo.endCursor },
+                updateQuery: (prev, { fetchMoreResult: { invites } }) => extendConnection(prev, invites, 'invites'),
+              })}
+            />
+          </Box>
+        </Table>
+      ) : (<Span>You do not have any domains set yet.</Span>)}
     </Container>
   )
 }

--- a/www/src/components/account/Groups.js
+++ b/www/src/components/account/Groups.js
@@ -1,5 +1,7 @@
 import { useMutation, useQuery } from '@apollo/client'
+import { EmptyState } from 'components/utils/EmptyState'
 import { Box } from 'grommet'
+import { isEmpty } from 'lodash'
 import {
   Button, GlobeIcon, Input, Modal, ModalHeader, SearchIcon,
 } from 'pluralsh-design-system'
@@ -154,29 +156,35 @@ function GroupsInner({ q }) {
       fill
       pad={{ bottom: 'small' }}
     >
-      <StandardScroller
-        listRef={listRef}
-        setListRef={setListRef}
-        items={edges}
-        mapper={({ node: group }, { prev, next }) => (
-          <ListItem
-            first={!prev.node}
-            last={!next.node}
-          >
-            <Group
-              group={group}
-              q={q}
-            />
-          </ListItem>
-        )}
-        loadNextPage={() => pageInfo.hasNextPage && fetchMore({
-          variables: { cursor: pageInfo.endCursor },
-          updateQuery: (prev, { fetchMoreResult: { groups } }) => extendConnection(prev, groups, 'groups'),
-        })}
-        hasNextPage={pageInfo.hasNextPage}
-        loading={loading}
-        placeholder={Placeholder}
-      />
+      {edges?.length ? (
+        <StandardScroller
+          listRef={listRef}
+          setListRef={setListRef}
+          items={edges}
+          mapper={({ node: group }, { prev, next }) => (
+            <ListItem
+              first={!prev.node}
+              last={!next.node}
+            >
+              <Group
+                group={group}
+                q={q}
+              />
+            </ListItem>
+          )}
+          loadNextPage={() => pageInfo.hasNextPage && fetchMore({
+            variables: { cursor: pageInfo.endCursor },
+            updateQuery: (prev, { fetchMoreResult: { groups } }) => extendConnection(prev, groups, 'groups'),
+          })}
+          hasNextPage={pageInfo.hasNextPage}
+          loading={loading}
+          placeholder={Placeholder}
+        />
+      ) : (
+        <EmptyState message={isEmpty(q) ? "Looks like you don't have any groups yet." : "Looks like you don't have any groups matching search criteria."}>
+          <CreateGroup q={q} />
+        </EmptyState>
+      )}
     </Box>
   )
 }

--- a/www/src/components/account/Groups.js
+++ b/www/src/components/account/Groups.js
@@ -181,7 +181,7 @@ function GroupsInner({ q }) {
           placeholder={Placeholder}
         />
       ) : (
-        <EmptyState message={isEmpty(q) ? "Looks like you don't have any groups yet." : "Looks like you don't have any groups matching search criteria."}>
+        <EmptyState message={isEmpty(q) ? "Looks like you don't have any groups yet." : `No roles found for ${q}`}>
           <CreateGroup q={q} />
         </EmptyState>
       )}

--- a/www/src/components/account/Groups.js
+++ b/www/src/components/account/Groups.js
@@ -181,7 +181,7 @@ function GroupsInner({ q }) {
           placeholder={Placeholder}
         />
       ) : (
-        <EmptyState message={isEmpty(q) ? "Looks like you don't have any groups yet." : `No roles found for ${q}`}>
+        <EmptyState message={isEmpty(q) ? "Looks like you don't have any groups yet." : `No groups found for ${q}`}>
           <CreateGroup q={q} />
         </EmptyState>
       )}

--- a/www/src/components/account/Roles.js
+++ b/www/src/components/account/Roles.js
@@ -144,7 +144,7 @@ function RolesInner({ q }) {
           placeholder={Placeholder}
         />
       ) : (
-        <EmptyState message={isEmpty(q) ? "Looks like you don't have any roles yet." : "Looks like you don't have any roles matching search criteria."}>
+        <EmptyState message={isEmpty(q) ? "Looks like you don't have any roles yet." : `No roles found for ${q}`}>
           <CreateRole q={q} />
         </EmptyState>
       )}

--- a/www/src/components/account/Roles.js
+++ b/www/src/components/account/Roles.js
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from '@apollo/client'
 import { EmptyState } from 'components/utils/EmptyState'
 import { Box } from 'grommet'
 import { isEmpty } from 'lodash'
-import { Button, Input, SearchIcon } from 'pluralsh-design-system'
+import { Input, SearchIcon } from 'pluralsh-design-system'
 import { useContext, useState } from 'react'
 
 import { extendConnection, removeConnection, updateCache } from '../../utils/graphql'

--- a/www/src/components/account/Roles.js
+++ b/www/src/components/account/Roles.js
@@ -1,6 +1,8 @@
 import { useMutation, useQuery } from '@apollo/client'
+import { EmptyState } from 'components/utils/EmptyState'
 import { Box } from 'grommet'
-import { Input, SearchIcon } from 'pluralsh-design-system'
+import { isEmpty } from 'lodash'
+import { Button, Input, SearchIcon } from 'pluralsh-design-system'
 import { useContext, useState } from 'react'
 
 import { extendConnection, removeConnection, updateCache } from '../../utils/graphql'
@@ -117,29 +119,35 @@ function RolesInner({ q }) {
       fill
       pad={{ bottom: 'small' }}
     >
-      <StandardScroller
-        listRef={listRef}
-        setListRef={setListRef}
-        items={edges}
-        mapper={({ node: role }, { prev, next }) => (
-          <ListItem
-            first={!prev.node}
-            last={!next.node}
-          >
-            <Role
-              role={role}
-              q={q}
-            />
-          </ListItem>
-        )}
-        loadNextPage={() => pageInfo.hasNextPage && fetchMore({
-          variables: { cursor: pageInfo.endCursor },
-          updateQuery: (prev, { fetchMoreResult: { roles } }) => extendConnection(prev, roles, 'roles'),
-        })}
-        hasNextPage={pageInfo.hasNextPage}
-        loading={loading}
-        placeholder={Placeholder}
-      />
+      {edges?.length ? (
+        <StandardScroller
+          listRef={listRef}
+          setListRef={setListRef}
+          items={edges}
+          mapper={({ node: role }, { prev, next }) => (
+            <ListItem
+              first={!prev.node}
+              last={!next.node}
+            >
+              <Role
+                role={role}
+                q={q}
+              />
+            </ListItem>
+          )}
+          loadNextPage={() => pageInfo.hasNextPage && fetchMore({
+            variables: { cursor: pageInfo.endCursor },
+            updateQuery: (prev, { fetchMoreResult: { roles } }) => extendConnection(prev, roles, 'roles'),
+          })}
+          hasNextPage={pageInfo.hasNextPage}
+          loading={loading}
+          placeholder={Placeholder}
+        />
+      ) : (
+        <EmptyState message={isEmpty(q) ? "Looks like you don't have any roles yet." : "Looks like you don't have any roles matching search criteria."}>
+          <CreateRole q={q} />
+        </EmptyState>
+      )}
     </Box>
   )
 }

--- a/www/src/components/account/ServiceAccounts.js
+++ b/www/src/components/account/ServiceAccounts.js
@@ -1,6 +1,8 @@
 import { useQuery } from '@apollo/client'
+import { EmptyState } from 'components/utils/EmptyState'
 import { Box } from 'grommet'
 import { Input } from 'honorable'
+import { isEmpty } from 'lodash'
 import { SearchIcon } from 'pluralsh-design-system'
 import { useCallback, useState } from 'react'
 
@@ -60,29 +62,35 @@ function ServiceAccountsInner({ q }) {
       fill
       pad={{ bottom: 'small' }}
     >
-      <StandardScroller
-        listRef={listRef}
-        setListRef={setListRef}
-        items={edges}
-        mapper={({ node: user }, { prev, next }) => (
-          <ListItem
-            first={!prev.node}
-            last={!next.node}
-          >
-            <ServiceAccount
-              user={user}
-              update={update}
-            />
-          </ListItem>
-        )}
-        loadNextPage={() => pageInfo.hasNextPage && fetchMore({
-          variables: { cursor: pageInfo.endCursor },
-          updateQuery: (prev, { fetchMoreResult: { users } }) => extendConnection(prev, users, 'users'),
-        })}
-        hasNextPage={pageInfo.hasNextPage}
-        loading={loading}
-        placeholder={Placeholder}
-      />
+      {edges?.length ? (
+        <StandardScroller
+          listRef={listRef}
+          setListRef={setListRef}
+          items={edges}
+          mapper={({ node: user }, { prev, next }) => (
+            <ListItem
+              first={!prev.node}
+              last={!next.node}
+            >
+              <ServiceAccount
+                user={user}
+                update={update}
+              />
+            </ListItem>
+          )}
+          loadNextPage={() => pageInfo.hasNextPage && fetchMore({
+            variables: { cursor: pageInfo.endCursor },
+            updateQuery: (prev, { fetchMoreResult: { users } }) => extendConnection(prev, users, 'users'),
+          })}
+          hasNextPage={pageInfo.hasNextPage}
+          loading={loading}
+          placeholder={Placeholder}
+        />
+      ) : (
+        <EmptyState message={isEmpty(q) ? "Looks like you don't have any service accounts yet." : "Looks like you don't have any service accounts matching search criteria."}>
+          <CreateServiceAccount q={q} />
+        </EmptyState>
+      )}
     </Box>
   )
 }

--- a/www/src/components/audits/AuditChloropleth.js
+++ b/www/src/components/audits/AuditChloropleth.js
@@ -24,10 +24,7 @@ export function AuditChloropleth() {
 
   return (
     <Box fill>
-      <PageTitle
-        heading="Audit logs"
-        fontFamily="Monument Semi-Mono, monospace"
-      >
+      <PageTitle heading="Geodistribution">
         <ButtonGroup style={{ border: '0px' }}>
           <Button
             tertiary
@@ -50,6 +47,7 @@ export function AuditChloropleth() {
         fill
         round="xsmall"
         background="fill-one"
+        overflow="hidden"
       >
         <Chloropleth data={metrics} />
       </Box>

--- a/www/src/components/audits/AuditChloropleth.js
+++ b/www/src/components/audits/AuditChloropleth.js
@@ -3,15 +3,16 @@ import { useState } from 'react'
 
 import lookup from 'country-code-lookup'
 import { Box } from 'grommet'
-import { Div } from 'honorable'
+import { Button, ButtonGroup } from 'honorable'
 
-import { ButtonGroup } from '../utils/ButtonGroup'
+import { PageTitle } from 'pluralsh-design-system'
+
 import { Chloropleth } from '../utils/Chloropleth'
 
 import { AUDIT_METRICS, LOGIN_METRICS } from './queries'
 
 export function AuditChloropleth() {
-  const [tab, setTab] = useState('Audits')
+  const [tab, setTab] = useState('Audit logs')
   const { data } = useQuery(tab === 'Logins' ? LOGIN_METRICS : AUDIT_METRICS, { fetchPolicy: 'cache-and-network' })
 
   if (!data) return null
@@ -22,20 +23,29 @@ export function AuditChloropleth() {
   }))
 
   return (
-    <Box
-      fill
-      gap="medium"
-    >
-      <Div
-        width="150px"
+    <Box fill>
+      <PageTitle
+        heading="Audit logs"
         fontFamily="Monument Semi-Mono, monospace"
       >
-        <ButtonGroup
-          tabs={['Audits', 'Logins']}
-          default={tab}
-          onChange={setTab}
-        />
-      </Div>
+        <ButtonGroup style={{ border: '0px' }}>
+          <Button
+            tertiary
+            background={tab === 'Audit logs' ? 'fill-one' : ''}
+            onClick={() => setTab('Audit logs')}
+          >
+            Audit logs
+          </Button>
+          <Button
+            tertiary
+            background={tab === 'Logins' ? 'fill-one' : ''}
+            onClick={() => setTab('Logins')}
+            style={{ border: '0px' }}
+          >
+            Logins
+          </Button>
+        </ButtonGroup>
+      </PageTitle>
       <Box
         fill
         round="xsmall"

--- a/www/src/components/audits/AuditDirectory.js
+++ b/www/src/components/audits/AuditDirectory.js
@@ -7,7 +7,7 @@ import { Container } from '../utils/Container'
 import { SidebarTabs } from '../utils/SidebarTabs'
 
 const DIRECTORY = [
-  { path: '/audits/logs', label: 'Audit Logs' },
+  { path: '/audits/logs', label: 'Audit logs' },
   { path: '/audits/logins', label: 'Logins' },
   { path: '/audits/geo', label: 'Geodistribution' },
 ]

--- a/www/src/components/audits/AuditDirectory.js
+++ b/www/src/components/audits/AuditDirectory.js
@@ -1,5 +1,5 @@
 import { ResponsiveLayoutContentContainer, ResponsiveLayoutSidenavContainer, ResponsiveLayoutSpacer } from 'components/layout/ResponsiveLayout'
-import { Div, Flex } from 'honorable'
+import { Flex } from 'honorable'
 import { Tab } from 'pluralsh-design-system'
 import { Link, Outlet, useLocation } from 'react-router-dom'
 

--- a/www/src/components/audits/AuditDirectory.js
+++ b/www/src/components/audits/AuditDirectory.js
@@ -1,10 +1,7 @@
+import { ResponsiveLayoutContentContainer, ResponsiveLayoutSidenavContainer, ResponsiveLayoutSpacer } from 'components/layout/ResponsiveLayout'
 import { Div, Flex } from 'honorable'
 import { Tab } from 'pluralsh-design-system'
 import { Link, Outlet, useLocation } from 'react-router-dom'
-
-import { Container } from '../utils/Container'
-
-import { SidebarTabs } from '../utils/SidebarTabs'
 
 const DIRECTORY = [
   { path: '/audits/logs', label: 'Audit logs' },
@@ -19,9 +16,13 @@ export function AuditDirectory() {
     <Flex
       height="100%"
       width="100%"
+      padding="16px"
       overflowY="hidden"
     >
-      <SidebarTabs>
+      <ResponsiveLayoutSidenavContainer
+        marginTop={90}
+        width={240}
+      >
         {DIRECTORY.map(({ label, path }) => (
           <Link
             key={label}
@@ -36,19 +37,10 @@ export function AuditDirectory() {
             </Tab>
           </Link>
         ))}
-      </SidebarTabs>
-      <Div
-        flexGrow={1}
-        py={1.5}
-        pr={1.5}
-        height="100%"
-        maxHeight="100%"
-        overflowY="auto"
-      >
-        <Container type="table">
-          <Outlet />
-        </Container>
-      </Div>
+      </ResponsiveLayoutSidenavContainer>
+      <ResponsiveLayoutSpacer />
+      <ResponsiveLayoutContentContainer paddingTop="large"><Outlet /></ResponsiveLayoutContentContainer>
+      <ResponsiveLayoutSpacer />
     </Flex>
   )
 }

--- a/www/src/components/audits/Audits.js
+++ b/www/src/components/audits/Audits.js
@@ -3,7 +3,7 @@ import { Box } from 'grommet'
 import { Link } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
 
-import { A, Span } from 'honorable'
+import { A, Div, Span } from 'honorable'
 
 import { PageTitle } from 'pluralsh-design-system'
 
@@ -78,9 +78,16 @@ export function Placeholder() {
 function Audit({ audit, last }) {
   return (
     <TableRow last={last}>
-      <TableData>{audit.action}</TableData>
+      <TableData>
+        <Resource audit={audit} />
+        <Div
+          caption
+          color="text-xlight"
+        >
+          {audit.action}
+        </Div>
+      </TableData>
       <TableData>{audit.actor && <AuditUser user={audit.actor} />}</TableData>
-      <TableData><Resource audit={audit} /></TableData>
       <TableData><Date date={audit.insertedAt} /></TableData>
       <TableData>
         <Location
@@ -115,11 +122,11 @@ export function Audits() {
       fill
     >
       <PageTitle heading="Audit logs" />
-      {!edges.length
+      {edges.length
         ? (
           <Table
-            headers={['Action', 'Actor', 'Resource', 'Event Time', 'Location']}
-            sizes={['20%', '20%', '20%', '20%', '20%']}
+            headers={['Package / Action', 'Actor', 'Event time', 'Location / IP']}
+            sizes={['30%', '25%', '25%', '20%']}
             width="100%"
             height="100%"
             background="fill-one"

--- a/www/src/components/audits/Audits.js
+++ b/www/src/components/audits/Audits.js
@@ -3,7 +3,9 @@ import { Box } from 'grommet'
 import { Link } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
 
-import { A } from 'honorable'
+import { A, Span } from 'honorable'
+
+import { PageTitle } from 'pluralsh-design-system'
 
 import { extendConnection } from '../../utils/graphql'
 import { StandardScroller } from '../utils/SmoothScroller'
@@ -112,38 +114,42 @@ export function Audits() {
     <Box
       fill
     >
-      <Table
-        headers={['Action', 'Actor', 'Resource', 'Event Time', 'Location']}
-        sizes={['20%', '20%', '20%', '20%', '20%']}
-        width="100%"
-        height="100%"
-        background="fill-one"
-        border="1px solid border"
-      >
-        <Box fill>
-          {scrolled && <ReturnToBeginning beginning={returnToBeginning} />}
-          <StandardScroller
-            listRef={listRef}
-            setListRef={setListRef}
-            hasNextPage={pageInfo.hasNextPage}
-            items={edges}
-            loading={loading}
-            handleScroll={setScrolled}
-            placeholder={Placeholder}
-            mapper={({ node: audit }, { next }) => (
-              <Audit
-                last={!next.node}
-                key={audit.id}
-                audit={audit}
+      <PageTitle heading="Audit logs" />
+      {!edges.length
+        ? (
+          <Table
+            headers={['Action', 'Actor', 'Resource', 'Event Time', 'Location']}
+            sizes={['20%', '20%', '20%', '20%', '20%']}
+            width="100%"
+            height="100%"
+            background="fill-one"
+            border="1px solid border"
+          >
+            <Box fill>
+              {scrolled && <ReturnToBeginning beginning={returnToBeginning} />}
+              <StandardScroller
+                listRef={listRef}
+                setListRef={setListRef}
+                hasNextPage={pageInfo.hasNextPage}
+                items={edges}
+                loading={loading}
+                handleScroll={setScrolled}
+                placeholder={Placeholder}
+                mapper={({ node: audit }, { next }) => (
+                  <Audit
+                    last={!next.node}
+                    key={audit.id}
+                    audit={audit}
+                  />
+                )}
+                loadNextPage={() => pageInfo.hasNextPage && fetchMore({
+                  variables: { cursor: pageInfo.endCursor },
+                  updateQuery: (prev, { fetchMoreResult: { audits } }) => extendConnection(prev, audits, 'audits'),
+                })}
               />
-            )}
-            loadNextPage={() => pageInfo.hasNextPage && fetchMore({
-              variables: { cursor: pageInfo.endCursor },
-              updateQuery: (prev, { fetchMoreResult: { audits } }) => extendConnection(prev, audits, 'audits'),
-            })}
-          />
-        </Box>
-      </Table>
+            </Box>
+          </Table>
+        ) : <Span>You do not have any audit logs yet.</Span>}
     </Box>
   )
 }

--- a/www/src/components/audits/LoginAudits.js
+++ b/www/src/components/audits/LoginAudits.js
@@ -2,6 +2,10 @@ import { useQuery } from '@apollo/client'
 import { Box, Text } from 'grommet'
 import { useCallback, useState } from 'react'
 
+import { PageTitle } from 'pluralsh-design-system'
+
+import { Span } from 'honorable'
+
 import { Placeholder } from '../accounts/Audits'
 
 import { RepoIcon } from '../repos/Repositories'
@@ -62,54 +66,50 @@ export function LoginAudits() {
   const [listRef, setListRef] = useState(null)
   const [scrolled, setScrolled] = useState(false)
   const { data, loading, fetchMore } = useQuery(LOGINS_Q, { fetchPolicy: 'cache-and-network' })
-  const returnToBeginning = useCallback(() => {
-    listRef.scrollToItem(0)
-  }, [listRef])
+  const returnToBeginning = useCallback(() => listRef.scrollToItem(0), [listRef])
 
-  if (!data) {
-    return (
-      <LoopingLogo />
-    )
-  }
+  if (!data) return <LoopingLogo />
 
   const { edges, pageInfo } = data.oidcLogins
 
-  console.log(edges)
-
   return (
     <Box fill>
-      <Table
-        headers={['User', 'Event Time', 'Owner', 'Repository', 'Location']}
-        sizes={['20%', '20%', '20%', '20%', '20%']}
-        background="fill-one"
-        border="1px solid border"
-        width="100%"
-        height="100%"
-      >
-        <Box fill>
-          {scrolled && <ReturnToBeginning beginning={returnToBeginning} />}
-          <StandardScroller
-            listRef={listRef}
-            setListRef={setListRef}
-            hasNextPage={pageInfo.hasNextPage}
-            items={edges}
-            loading={loading}
-            handleScroll={setScrolled}
-            placeholder={Placeholder}
-            mapper={({ node }, { next }) => (
-              <LoginRow
-                key={node.id}
-                login={node}
-                last={!next.node}
+      <PageTitle heading="Logins" />
+      {edges.length
+        ? (
+          <Table
+            headers={['User', 'Event Time', 'Owner', 'Repository', 'Location']}
+            sizes={['20%', '20%', '20%', '20%', '20%']}
+            background="fill-one"
+            border="1px solid border"
+            width="100%"
+            height="100%"
+          >
+            <Box fill>
+              {scrolled && <ReturnToBeginning beginning={returnToBeginning} />}
+              <StandardScroller
+                listRef={listRef}
+                setListRef={setListRef}
+                hasNextPage={pageInfo.hasNextPage}
+                items={edges}
+                loading={loading}
+                handleScroll={setScrolled}
+                placeholder={Placeholder}
+                mapper={({ node }, { next }) => (
+                  <LoginRow
+                    key={node.id}
+                    login={node}
+                    last={!next.node}
+                  />
+                )}
+                loadNextPage={() => pageInfo.hasNextPage && fetchMore({
+                  variables: { cursor: pageInfo.endCursor },
+                  updateQuery: (prev, { fetchMoreResult: { oidcLogins } }) => extendConnection(prev, oidcLogins, 'oidcLogins'),
+                })}
               />
-            )}
-            loadNextPage={() => pageInfo.hasNextPage && fetchMore({
-              variables: { cursor: pageInfo.endCursor },
-              updateQuery: (prev, { fetchMoreResult: { oidcLogins } }) => extendConnection(prev, oidcLogins, 'oidcLogins'),
-            })}
-          />
-        </Box>
-      </Table>
+            </Box>
+          </Table>
+        ) : <Span>You do not have any user logins yet.</Span>}
     </Box>
   )
 }

--- a/www/src/components/audits/LoginAudits.js
+++ b/www/src/components/audits/LoginAudits.js
@@ -78,7 +78,7 @@ export function LoginAudits() {
       {edges.length
         ? (
           <Table
-            headers={['User', 'Event Time', 'Owner', 'Repository', 'Location']}
+            headers={['User', 'Event time', 'Owner', 'Repository', 'Location / IP']}
             sizes={['20%', '20%', '20%', '20%', '20%']}
             background="fill-one"
             border="1px solid border"

--- a/www/src/components/clusters/Clusters.tsx
+++ b/www/src/components/clusters/Clusters.tsx
@@ -1,7 +1,13 @@
 import { useQuery } from '@apollo/client'
-import { Flex } from 'honorable'
+import { EmptyState } from 'components/utils/EmptyState'
+import { Box } from 'grommet'
+import {
+  A, Br, Flex, Span,
+} from 'honorable'
+import { Button } from 'pluralsh-design-system'
 import LoadingSpinner from 'pluralsh-design-system/dist/components/LoadingSpinner'
 import { ReactElement, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 
 import QueueContext from '../../contexts/QueueContext'
 import {
@@ -27,7 +33,7 @@ export interface Queue {
 
 export function Clusters(): ReactElement | null {
   const [queue, setQueue] = useState({} as Queue)
-  const { data, subscribeToMore } = useQuery(QUEUES, { fetchPolicy: 'cache-and-network' })
+  const { data, loading, subscribeToMore } = useQuery(QUEUES, { fetchPolicy: 'cache-and-network' })
 
   useEffect(() => subscribeToMore({
     document: UPGRADE_QUEUE_SUB,
@@ -45,8 +51,37 @@ export function Clusters(): ReactElement | null {
 
   useEffect(() => (data ? setQueue(data?.upgradeQueues[0]) : data), [data])
 
+  if (loading) return <LoadingSpinner />
+
   if (!data || !queue) {
-    return <LoadingSpinner />
+    return (
+      <Box margin={{ top: '152px' }}>
+        <EmptyState
+          message="Looks like you don't have any clusters registered yet."
+          description={(
+            <Span>
+              Clusters are registered here once you've installed and deployer Plural
+              <Br />Console. If you need support installing it, read our&nbsp;
+              <A
+                inline
+                href="https://docs.plural.sh/getting-started/getting-started"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                quickstart guide
+              </A>.
+            </Span>
+          )}
+        >
+          <Button
+            as={Link}
+            to="/marketplace"
+          >
+            Install Plural Console
+          </Button>
+        </EmptyState>
+      </Box>
+    )
   }
 
   return (

--- a/www/src/components/clusters/Clusters.tsx
+++ b/www/src/components/clusters/Clusters.tsx
@@ -75,7 +75,7 @@ export function Clusters(): ReactElement | null {
         >
           <Button
             as={Link}
-            to="/marketplace"
+            to="/repository/a051a0bf-61b5-4ab5-813d-2c541c83a979"
           >
             Install Plural Console
           </Button>

--- a/www/src/components/marketplace/MarketplaceRepositories.js
+++ b/www/src/components/marketplace/MarketplaceRepositories.js
@@ -5,7 +5,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import {
   A,
   Br,
-  Button, Div, Flex, H1, P,
+  Button, Div, Flex, H1, Span,
 } from 'honorable'
 import {
   FiltersIcon, Input, MagnifyingGlassIcon, RepositoryCard,
@@ -367,7 +367,7 @@ function MarketplaceRepositories({ installed }) {
               <EmptyState
                 message="Looks like you haven't installed your first app yet."
                 description={(
-                  <P textAlign="center">
+                  <Span>
                     Head back to the marketplace to select your first application! If you need
                     <Br />support installing your first app, read our&nbsp;
                     <A
@@ -378,7 +378,7 @@ function MarketplaceRepositories({ installed }) {
                     >
                       quickstart guide
                     </A>.
-                  </P>
+                  </Span>
                 )}
               >
                 <Button

--- a/www/src/components/marketplace/MarketplaceRepositories.js
+++ b/www/src/components/marketplace/MarketplaceRepositories.js
@@ -3,13 +3,19 @@ import {
 } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import {
-  Button, Div, Flex, H1,
+  A,
+  Br,
+  Button, Div, Flex, H1, P,
 } from 'honorable'
 import {
   FiltersIcon, Input, MagnifyingGlassIcon, RepositoryCard,
   Tab, Token,
 } from 'pluralsh-design-system'
 import Fuse from 'fuse.js'
+
+import { EmptyState } from 'components/utils/EmptyState'
+
+import { isEmpty } from 'lodash'
 
 import { capitalize } from '../../utils/string'
 
@@ -356,6 +362,32 @@ function MarketplaceRepositories({ installed }) {
               >
                 <LoopingLogo />
               </Flex>
+            )}
+            {!resultRepositories?.length && installed && ![...searchParams]?.length && isEmpty(search) && (
+              <EmptyState
+                message="Looks like you haven't installed your first app yet."
+                description={(
+                  <P textAlign="center">
+                    Head back to the marketplace to select your first application! If you need
+                    <Br />support installing your first app, read our&nbsp;
+                    <A
+                      inline
+                      href="https://docs.plural.sh/getting-started/getting-started"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      quickstart guide
+                    </A>.
+                  </P>
+                )}
+              >
+                <Button
+                  as={Link}
+                  to="/marketplace"
+                >
+                  Go to marketplace
+                </Button>
+              </EmptyState>
             )}
           </Div>
         </Flex>

--- a/www/src/components/profile/AccessTokens.js
+++ b/www/src/components/profile/AccessTokens.js
@@ -10,6 +10,8 @@ import {
   CopyIcon, GraphIcon, InfoIcon, ListIcon, Modal, ModalHeader, PageTitle, Tooltip,
 } from 'pluralsh-design-system'
 
+import { EmptyState } from 'components/utils/EmptyState'
+
 import {
   appendConnection, deepUpdate, extendConnection, removeConnection, updateCache,
 } from '../../utils/graphql'
@@ -293,7 +295,20 @@ export function AccessTokens() {
                 updateQuery: (prev, { fetchMoreResult: { tokens } }) => extendConnection(prev, tokens, 'tokens'),
               })}
             />
-          ) : (<Div body2>No access tokens found.</Div>)}
+          ) : (
+            <EmptyState message="Looks like you don't have any access tokens yet.">
+              <Button
+                onClick={() => {
+                  setDisplayNewBanner(true)
+                  setTimeout(() => setDisplayNewBanner(false), 1000)
+                  mutation()
+                }}
+                loading={loading}
+              >
+                Create access token
+              </Button>
+            </EmptyState>
+          )}
       </Box>
     </Box>
   )

--- a/www/src/components/profile/AccessTokens.js
+++ b/www/src/components/profile/AccessTokens.js
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@apollo/client'
 import { Box } from 'grommet'
-import { Button, Div, Span } from 'honorable'
+import { Button, Span } from 'honorable'
 import moment from 'moment'
 import { useState } from 'react'
 import lookup from 'country-code-lookup'

--- a/www/src/components/profile/EabCredentials.js
+++ b/www/src/components/profile/EabCredentials.js
@@ -4,7 +4,7 @@ import { useState } from 'react'
 
 import { InfoIcon, PageTitle, Tooltip } from 'pluralsh-design-system'
 
-import { Div } from 'honorable'
+import { Span } from 'honorable'
 
 import { updateCache } from '../../utils/graphql'
 import { Confirm } from '../account/Confirm'
@@ -100,7 +100,7 @@ export function EabCredentials() {
                 />
               ))}
             </Table>
-          ) : (<Div body2>No EAB credentials found.</Div>)}
+          ) : (<Span>You do not have any EAB credentials keys yet.</Span>)}
       </Box>
     </Box>
   )

--- a/www/src/components/profile/MyProfile.js
+++ b/www/src/components/profile/MyProfile.js
@@ -6,7 +6,7 @@ import { Box } from 'grommet'
 
 import { useContext } from 'react'
 
-import { ResponsiveLayoutContentContainer, ResponsiveLayoutSpacer } from '../layout/ResponsiveLayout'
+import { ResponsiveLayoutContentContainer, ResponsiveLayoutSidenavContainer, ResponsiveLayoutSpacer } from '../layout/ResponsiveLayout'
 import { CurrentUserContext } from '../login/CurrentUser'
 
 const DIRECTORY = [
@@ -26,15 +26,10 @@ export function MyProfile() {
       height="100%"
       width="100%"
       overflowY="hidden"
-      paddingTop="50px"
+      padding={32}
+      paddingTop={88}
     >
-      <Flex
-        px={1}
-        py={1}
-        width={240}
-        flexShrink={0}
-        direction="column"
-      >
+      <ResponsiveLayoutSidenavContainer width={240}>
         <Box
           direction="row"
           gap="small"
@@ -72,19 +67,10 @@ export function MyProfile() {
             </Tab>
           </Link>
         ))}
-      </Flex>
-      <Flex
-        flexGrow={1}
-        pt={1.5}
-        pr={1.5}
-        height="100%"
-        maxHeight="100%"
-        overflowY="auto"
-      >
-        <ResponsiveLayoutSpacer />
-        <ResponsiveLayoutContentContainer><Outlet /></ResponsiveLayoutContentContainer>
-        <ResponsiveLayoutSpacer />
-      </Flex>
+      </ResponsiveLayoutSidenavContainer>
+      <ResponsiveLayoutSpacer />
+      <ResponsiveLayoutContentContainer><Outlet /></ResponsiveLayoutContentContainer>
+      <ResponsiveLayoutSpacer />
     </Flex>
   )
 }

--- a/www/src/components/profile/PublicKeys.js
+++ b/www/src/components/profile/PublicKeys.js
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@apollo/client'
 import { Box } from 'grommet'
-import { Div, Span, Text } from 'honorable'
+import { Span, Text } from 'honorable'
 import moment from 'moment'
 import { useState } from 'react'
 
@@ -134,7 +134,7 @@ export function PublicKeys() {
                 updateQuery: (prev, { fetchMoreResult: { publicKeys } }) => extendConnection(prev, publicKeys, 'publicKeys'),
               })}
             />
-          ) : (<Div body2>No public keys found.</Div>)}
+          ) : (<Span>You do not have any public keys yet.</Span>)}
       </Box>
     </Box>
   )

--- a/www/src/components/repos/Docker.js
+++ b/www/src/components/repos/Docker.js
@@ -138,9 +138,7 @@ function DockerSidebar({ image: { dockerRepository: docker, ...image }, filter, 
             Pull Command
           </Text>
           <Stack anchor="right">
-            <Codeline>
-              docker pull {truncate(imageName, { length: 40 })}
-            </Codeline>
+            <Codeline>{`docker pull ${imageName}`}</Codeline>
             <Box
               flex={false}
               margin={{ right: 'small' }}

--- a/www/src/components/repos/Docker.js
+++ b/www/src/components/repos/Docker.js
@@ -11,7 +11,7 @@ import {
   Anchor, Box, Collapsible, Stack, Text,
 } from 'grommet'
 import { Language } from 'grommet-icons'
-import truncate from 'lodash/truncate'
+
 import Toggle from 'react-toggle'
 
 import { Codeline } from 'pluralsh-design-system'

--- a/www/src/components/repos/common/misc.js
+++ b/www/src/components/repos/common/misc.js
@@ -133,7 +133,7 @@ export function PackageVersionPicker({
       </Select>
       <Box
         direction="row"
-        gap="xxsmall"
+        gap="8px"
       >
         {version?.tags.map(({ tag }, i) => <Chip key={i}><Span fontWeight="400">{tag}</Span></Chip>)}
       </Box>

--- a/www/src/components/repository/RepositoryDeployments.js
+++ b/www/src/components/repository/RepositoryDeployments.js
@@ -1,6 +1,6 @@
 import { useContext, useEffect } from 'react'
 import moment from 'moment'
-import { Flex } from 'honorable'
+import { Div, Flex, Span } from 'honorable'
 
 import { Chip, StatusIpIcon, StatusOkIcon } from 'pluralsh-design-system'
 
@@ -102,31 +102,39 @@ function RepositoryDeployments() {
       direction="column"
     >
       <RepositoryHeader>Deployments</RepositoryHeader>
-      <Table
-        headers={['Event', 'Clusters Updated', 'Last Ping', 'Status']}
-        sizes={['27.5%', '27.5%', '27.5%', '17.5%']}
-        background="fill-one"
-        width="100%"
-        height="calc(100% - 16px)"
+      <Div
+        fill
+        paddingTop="medium"
       >
-        <InfiniteScroller
-          pb={4}
-          loading={loadingRollouts}
-          hasMore={hasMoreRollouts}
-          loadMore={fetchMoreRollouts}
+        {rollouts?.length ? (
+          <Table
+            headers={['Event', 'Clusters Updated', 'Last Ping', 'Status']}
+            sizes={['27.5%', '27.5%', '27.5%', '17.5%']}
+            background="fill-one"
+            width="100%"
+            height="calc(100% - 16px)"
+
+          >
+            <InfiniteScroller
+              pb={4}
+              loading={loadingRollouts}
+              hasMore={hasMoreRollouts}
+              loadMore={fetchMoreRollouts}
           // Allow for scrolling in a flexbox layout
-          flexGrow={1}
-          height={0}
-        >
-          {rollouts.map((rollout, i) => (
-            <Rollout
-              last={i === len - 1}
-              key={rollout.id}
-              rollout={rollout}
-            />
-          ))}
-        </InfiniteScroller>
-      </Table>
+              flexGrow={1}
+              height={0}
+            >
+              {rollouts.map((rollout, i) => (
+                <Rollout
+                  last={i === len - 1}
+                  key={rollout.id}
+                  rollout={rollout}
+                />
+              ))}
+            </InfiniteScroller>
+          </Table>
+        ) : <Span>This repository does not have any deployments yet.</Span>}
+      </Div>
     </Flex>
   )
 }

--- a/www/src/components/repository/RepositoryDeployments.js
+++ b/www/src/components/repository/RepositoryDeployments.js
@@ -104,7 +104,8 @@ function RepositoryDeployments() {
       <RepositoryHeader>Deployments</RepositoryHeader>
       <Div
         fill
-        paddingTop="medium"
+        marginTop="medium"
+        marginBottom="medium"
       >
         {rollouts?.length ? (
           <Table
@@ -112,8 +113,7 @@ function RepositoryDeployments() {
             sizes={['27.5%', '27.5%', '27.5%', '17.5%']}
             background="fill-one"
             width="100%"
-            height="calc(100% - 16px)"
-
+            height="100%"
           >
             <InfiniteScroller
               pb={4}

--- a/www/src/components/repository/RepositoryDescription.js
+++ b/www/src/components/repository/RepositoryDescription.js
@@ -7,14 +7,13 @@ import RepositoryDescriptionMarkdown from './RepositoryDescriptionMarkdown'
 
 import RepositoryHeader from './RepositoryHeader.tsx'
 
-function RepositoryDescription() {
+export default function RepositoryDescription() {
   const repository = useContext(RepositoryContext)
 
   return (
     <Flex
       direction="column"
       color="text-light"
-      borderRadius="large"
       position="relative"
       overflowY="hidden"
     >
@@ -26,7 +25,6 @@ function RepositoryDescription() {
         marginTop="medium"
         marginBottom="medium"
         paddingRight="small"
-
       >
         {repository.readme ? (
           <RepositoryDescriptionMarkdown
@@ -38,5 +36,3 @@ function RepositoryDescription() {
     </Flex>
   )
 }
-
-export default RepositoryDescription

--- a/www/src/components/repository/RepositoryDescription.js
+++ b/www/src/components/repository/RepositoryDescription.js
@@ -14,7 +14,6 @@ function RepositoryDescription() {
     <Flex
       direction="column"
       color="text-light"
-      paddingRight="small"
       borderRadius="large"
       position="relative"
       overflowY="hidden"
@@ -24,8 +23,10 @@ function RepositoryDescription() {
         direction="column"
         flexGrow={1}
         overflowY="auto"
-        paddingTop="medium"
-        paddingBottom="xlarge"
+        marginTop="medium"
+        marginBottom="medium"
+        paddingRight="small"
+
       >
         {repository.readme ? (
           <RepositoryDescriptionMarkdown

--- a/www/src/components/repository/RepositoryDescription.js
+++ b/www/src/components/repository/RepositoryDescription.js
@@ -32,7 +32,7 @@ function RepositoryDescription() {
             text={repository.readme}
             gitUrl={repository.git_url}
           />
-        ) : <P>No description available</P>}
+        ) : <P>This repository does not have a Readme yet.</P>}
       </Flex>
     </Flex>
   )

--- a/www/src/components/repository/RepositoryPackages.js
+++ b/www/src/components/repository/RepositoryPackages.js
@@ -44,7 +44,10 @@ export default function RepositoryPackages() {
       height="100%"
     >
       <RepositoryHeader>Packages</RepositoryHeader>
-      <Flex justifyContent="space-between">
+      <Flex
+        justifyContent="space-between"
+        paddingTop="medium"
+      >
         <Input
           flexBasis="350px"
           marginRight="medium"

--- a/www/src/components/repository/RepositoryPackages.js
+++ b/www/src/components/repository/RepositoryPackages.js
@@ -46,7 +46,7 @@ export default function RepositoryPackages() {
       <RepositoryHeader>Packages</RepositoryHeader>
       <Flex
         justifyContent="space-between"
-        paddingTop="medium"
+        marginTop="medium"
       >
         <Input
           flexBasis="350px"
@@ -69,6 +69,7 @@ export default function RepositoryPackages() {
       <Flex
         mt={1}
         direction="column"
+        marginBottom="medium"
         flexGrow={1}
       >
         <Outlet context={[q, setQ]} />

--- a/www/src/components/repository/RepositoryTests.js
+++ b/www/src/components/repository/RepositoryTests.js
@@ -286,32 +286,35 @@ function RepositoryTests() {
       <Flex
         direction="column"
         flexGrow={1}
+        paddingTop="medium"
       >
-        <Table
-          headers={['Promote To', 'Name', 'Created On', 'Last Updated On', 'Progress']}
-          sizes={['20%', '20%', '20%', '20%', '20%']}
-          background="fill-one"
-          width="100%"
-          height="100%"
-        >
-          <InfiniteScroller
-            pb={4}
-            loading={loadingTests}
-            hasMore={hasMoreTests}
-            loadMore={fetchMoreTests}
-          // Allow for scrolling in a flexbox layout
-            flexGrow={1}
-            height={0}
+        {tests?.length ? (
+          <Table
+            headers={['Promote To', 'Name', 'Created On', 'Last Updated On', 'Progress']}
+            sizes={['20%', '20%', '20%', '20%', '20%']}
+            background="fill-one"
+            width="100%"
+            height="100%"
           >
-            {tests.map(test => (
-              <Test
-                key={test.id}
-                test={test}
-                setTest={setTest}
-              />
-            ))}
-          </InfiniteScroller>
-        </Table>
+            <InfiniteScroller
+              pb={4}
+              loading={loadingTests}
+              hasMore={hasMoreTests}
+              loadMore={fetchMoreTests}
+          // Allow for scrolling in a flexbox layout
+              flexGrow={1}
+              height={0}
+            >
+              {tests.map(test => (
+                <Test
+                  key={test.id}
+                  test={test}
+                  setTest={setTest}
+                />
+              ))}
+            </InfiniteScroller>
+          </Table>
+        ) : <Span>This repository does not have any tests yet.</Span>}
       </Flex>
     </Flex>
   )

--- a/www/src/components/repository/RepositoryTests.js
+++ b/www/src/components/repository/RepositoryTests.js
@@ -280,13 +280,13 @@ function RepositoryTests() {
     <Flex
       direction="column"
       flexGrow={1}
-      paddingBottom="xlarge"
     >
       <RepositoryHeader>Tests</RepositoryHeader>
       <Flex
         direction="column"
         flexGrow={1}
-        paddingTop="medium"
+        marginTop="medium"
+        marginBottom="medium"
       >
         {tests?.length ? (
           <Table

--- a/www/src/components/utils/EmptyState.js
+++ b/www/src/components/utils/EmptyState.js
@@ -1,7 +1,7 @@
 import { Box } from 'grommet'
 import { Text } from 'honorable'
 
-export function EmptyState({ message, children }) {
+export function EmptyState({ message, description, children }) {
   return (
     <Box
       pad="64px"
@@ -9,6 +9,13 @@ export function EmptyState({ message, children }) {
       align="center"
     >
       <Text subtitle1>{message}</Text>
+      {description && (
+        <Text
+          body1
+          color="text-light"
+        >{description}
+        </Text>
+      )}
       <Box>{children}</Box>
     </Box>
   )

--- a/www/src/components/utils/EmptyState.js
+++ b/www/src/components/utils/EmptyState.js
@@ -1,0 +1,15 @@
+import { Box } from 'grommet'
+import { Text } from 'honorable'
+
+export function EmptyState({ message, children }) {
+  return (
+    <Box
+      pad="64px"
+      gap="24px"
+      align="center"
+    >
+      <Text subtitle1>{message}</Text>
+      <Box>{children}</Box>
+    </Box>
+  )
+}

--- a/www/src/components/utils/EmptyState.js
+++ b/www/src/components/utils/EmptyState.js
@@ -8,11 +8,17 @@ export function EmptyState({ message, description, children }) {
       gap="24px"
       align="center"
     >
-      <Text subtitle1>{message}</Text>
+      <Text
+        subtitle1
+        textAlign="center"
+      >
+        {message}
+      </Text>
       {description && (
         <Text
           body1
           color="text-light"
+          textAlign="center"
         >{description}
         </Text>
       )}

--- a/www/src/components/utils/SidebarTabs.js
+++ b/www/src/components/utils/SidebarTabs.js
@@ -11,7 +11,6 @@ export function SidebarTabs({ width = 250, children }) {
       direction="column"
     >
       <Div
-        pt={1}
         borderRight="1px solid border"
       />
       { children }


### PR DESCRIPTION
## Summary
Closes ENG-382.

[Design](https://www.figma.com/file/ThREg5Q4RMkKt5haMwQ4Ar/Notifications%2C-Updates%2C-Empty-States?node-id=14%3A3962).

- Add empty state component
- Add empty states for:
  - Clusters
  - Marketplace installations
  - Audits
  - Repository readme, tests and deployments
  - Account groups, roles, service accounts and domains
  - Profile access tokens, public keys and EAB credentials
- Redesign audits to use the new layout, add some missing paddings, page titles etc.
- Adjust space between chips in packages (closes ENG-460)
- Fix scrollbar on repo readmes (closes ENG-461)
- Fix Docker pull codeline (fixes ENG-403)

<img width="707" alt="Zrzut ekranu 2022-08-4 o 15 01 55" src="https://user-images.githubusercontent.com/2823399/182853395-99c2d47a-7a4e-45c3-ae76-013c47a1889b.png">
<img width="700" alt="Zrzut ekranu 2022-08-4 o 15 29 02" src="https://user-images.githubusercontent.com/2823399/182859732-4a4249c4-4f4b-479d-ac35-baec79ee7cc7.png">
<img width="1424" alt="Zrzut ekranu 2022-08-4 o 13 44 46" src="https://user-images.githubusercontent.com/2823399/182839113-f7657549-1222-40bb-be05-840a23f01b19.png">
<img width="1424" alt="Zrzut ekranu 2022-08-4 o 13 44 30" src="https://user-images.githubusercontent.com/2823399/182839127-52380763-5674-418f-81b0-6786acbd3253.png">

## Test Plan
Tested manually.

## Checklist
- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.