### PR TITLE
ENG-447 - Add restart and expose stop API for cloud shell

### DIFF
--- a/apps/core/lib/core/services/shell.ex
+++ b/apps/core/lib/core/services/shell.ex
@@ -136,4 +136,20 @@ defmodule Core.Services.Shell do
   end
 
   def stop(_), do: {:error, :not_found}
+
+  @doc """
+  Restarts the cloud shell pod for a given user
+  """
+  @spec restart(User.t) :: {:ok, true} | error
+  def restart(%User{id: user_id}) do
+    get_shell(user_id)
+    |> do_restart()
+  end
+
+  defp do_restart(%CloudShell{} = shell) do
+    with {:ok, _} <- stop(shell),
+         {:ok, _} <- reboot(shell) do
+      {:ok, true}
+    end
+  end
 end

--- a/apps/graphql/lib/graphql/resolvers/shell.ex
+++ b/apps/graphql/lib/graphql/resolvers/shell.ex
@@ -19,6 +19,10 @@ defmodule GraphQl.Resolvers.Shell do
 
   def reboot(_, %{context: %{current_user: user}}), do: Shell.reboot(user.id)
 
+  def stop(_, %{context: %{current_user: user}}), do: Shell.stop(user)
+
+  def restart(_, %{context: %{current_user: user}}), do: Shell.restart(user)
+
   def liveness(shell), do: {:ok, Shell.alive?(shell)}
 
   def status(shell), do: {:ok, Shell.status(shell)}

--- a/apps/graphql/lib/graphql/schema/shell.ex
+++ b/apps/graphql/lib/graphql/schema/shell.ex
@@ -143,5 +143,15 @@ defmodule GraphQl.Schema.Shell do
 
       safe_resolve &Shell.create_demo_project/2
     end
+
+    field :stop_shell, :boolean do
+      middleware Authenticated
+      safe_resolve &Shell.stop/2
+    end
+
+    field :restart_shell, :boolean do
+      middleware Authenticated
+      safe_resolve &Shell.restart/2
+    end
   end
 end

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
-export CFLAGS="-O2 -g -fno-stack-check"
-export KERL_CONFIGURE_OPTIONS="--with-ssl=$(brew --prefix openssl) --without-javac --enable-m64-build"
+# "-Wno-deprecated-declarations" is required in Ubuntu 22.04
+# Related to OpenSSL 3 and erlang-crypto issues
+export CFLAGS="-O2 -g -fno-stack-check -Wno-deprecated-declarations"
+export KERL_CONFIGURE_OPTIONS="--with-ssl=$(brew --prefix openssl@1.1) --without-javac --enable-m64-build"
 asdf install


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Added new `restartShell` mutation and API
- Exposed existing API for stopping shell through `stopShell` mutation
- Added tests
- Updated `install.sh` script to work with Ubuntu 22 and OpenSSL 3. It still requires a brew to install and link OpenSSL@1 that is used by the erlang <24 and some crypto packages.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Run `mix test`

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.