### PR TITLE
Fix some broken repo Readme images

### DIFF
--- a/www/src/components/repository/RepositoryDescription.js
+++ b/www/src/components/repository/RepositoryDescription.js
@@ -23,6 +23,7 @@ function RepositoryDescription() {
         <RepositoryDescriptionMarkdown
           text={repository.readme}
           gitUrl={repository.git_url}
+          mainBranch={repository.main_branch}
         />
       ) : <P>No description available</P>}
     </Flex>

--- a/www/src/components/repository/RepositoryDescription.js
+++ b/www/src/components/repository/RepositoryDescription.js
@@ -22,8 +22,8 @@ function RepositoryDescription() {
       {repository.readme ? (
         <RepositoryDescriptionMarkdown
           text={repository.readme}
-          gitUrl={repository.git_url}
-          mainBranch={repository.main_branch}
+          gitUrl={repository.gitUrl}
+          mainBranch={repository.mainBranch}
         />
       ) : <P>No description available</P>}
     </Flex>

--- a/www/src/components/repository/RepositoryDescriptionMarkdown.js
+++ b/www/src/components/repository/RepositoryDescriptionMarkdown.js
@@ -5,11 +5,13 @@ import rehypeRaw from 'rehype-raw'
 
 import MultilineCode from '../utils/Code'
 
-function MdImg({ src, gitUrl, ...props }) {
+function MdImg({
+  src, gitUrl, mainBranch = 'master', ...props
+}) {
   // Convert local image paths to full path on github
   // Only works if primary git branch is named "master"
-  if (src && !src.match(/^https*/)) {
-    src = `${gitUrl}/raw/master/${src}`
+  if (gitUrl && src && !src.match(/^https*/)) {
+    src = `${gitUrl}/raw/${mainBranch}/${src}`
   }
 
   return (
@@ -71,7 +73,7 @@ const toReactMarkdownComponent = ({ component: Component, props }) =>
       />
     )
   }
-export default memo(({ text, gitUrl }) => (
+export default memo(({ text, gitUrl, mainBranch }) => (
   <Div>
     <ReactMarkdown
       rehypePlugins={[rehypeRaw]}
@@ -152,6 +154,7 @@ export default memo(({ text, gitUrl }) => (
               ...props,
               ...{
                 gitUrl,
+                mainBranch,
                 style: { maxWidth: '100%' },
               },
             }}

--- a/www/src/components/repository/queries.js
+++ b/www/src/components/repository/queries.js
@@ -37,6 +37,7 @@ export const REPOSITORY_QUERY = gql`
         name: tag
       }
       readme
+      main_branch
       git_url
       homepage
       license {

--- a/www/src/components/repository/queries.js
+++ b/www/src/components/repository/queries.js
@@ -37,8 +37,8 @@ export const REPOSITORY_QUERY = gql`
         name: tag
       }
       readme
-      main_branch
-      git_url
+      mainBranch
+      gitUrl
       homepage
       license {
         name


### PR DESCRIPTION
If the repo’s main branch was anything other than `master`, URLs for readme images would be incorrect. This fixes that by pulling in the new `main_branch` field for repos.