### PR TITLE
Add accessible protocol for gql authz

### DIFF
--- a/apps/core/lib/core/services/accounts.ex
+++ b/apps/core/lib/core/services/accounts.ex
@@ -15,13 +15,14 @@ defmodule Core.Services.Accounts do
     DomainMapping
   }
 
-  @type account_resp :: {:ok, Account.t} | {:error, term}
-  @type group_resp :: {:ok, Group.t} | {:error, term}
-  @type group_member_resp :: {:ok, GroupMember.t} | {:error, term}
-  @type invite_resp :: {:ok, Invite.t} | {:error, term}
-  @type role_resp :: {:ok, Role.t} | {:error, term}
-  @type user_resp :: {:ok, User.t} | {:error, term}
-  @type webhook_resp :: {:ok, IntegrationWebhook.t} | {:error, term}
+  @type error :: {:error, term}
+  @type account_resp :: {:ok, Account.t} | error
+  @type group_resp :: {:ok, Group.t} | error
+  @type group_member_resp :: {:ok, GroupMember.t} | error
+  @type invite_resp :: {:ok, Invite.t} | error
+  @type role_resp :: {:ok, Role.t} | error
+  @type user_resp :: {:ok, User.t} | error
+  @type webhook_resp :: {:ok, IntegrationWebhook.t} | error
 
   def get_account!(id), do: Core.Repo.get!(Account, id)
 

--- a/apps/graphql/lib/graphql/accessible.ex
+++ b/apps/graphql/lib/graphql/accessible.ex
@@ -1,0 +1,34 @@
+defmodule GraphQl.Accessible do
+  alias Core.Services.{Accounts}
+  def load(id, :role), do: Accounts.get_role!(id)
+  def load(id, :group), do: Accounts.get_group!(id)
+
+  def accessible(id, user, type) do
+    resource = load(id, type)
+    case GraphQl.Accessible.Resource.accessible(resource, user) do
+      :ok -> {:ok, resource}
+      :error -> {:error, "forbidden"}
+    end
+  end
+end
+
+defprotocol GraphQl.Accessible.Resource do
+  @fallback_to_any true
+  def accessible(resource, user)
+end
+
+defimpl GraphQl.Accessible.Resource, for: Any do
+  def accessible(_, _), do: :error
+end
+
+defimpl GraphQl.Accessible.Resource, for: Core.Schema.Group do
+  alias Core.Schema.{User, Group}
+  def accessible(%Group{account_id: aid}, %User{account_id: aid}), do: :ok
+  def accessible(_, _), do: :error
+end
+
+defimpl GraphQl.Accessible.Resource, for: Core.Schema.Role do
+  alias Core.Schema.{User, Role}
+  def accessible(%Role{account_id: aid}, %User{account_id: aid}), do: :ok
+  def accessible(_, _), do: :error
+end

--- a/apps/graphql/lib/graphql/resolvers/base.ex
+++ b/apps/graphql/lib/graphql/resolvers/base.ex
@@ -15,7 +15,9 @@ defmodule GraphQl.Resolvers.Base do
   defmacro __using__(model: model) do
     quote do
       import GraphQl.Resolvers.Base
+      alias GraphQl.Accessible
       alias unquote(model)
+
       def data(args \\ %{}),
         do: Dataloader.Ecto.new(Core.Repo, query: &query/2, default_params: filter_context(args))
 

--- a/apps/graphql/test/queries/account_queries_test.exs
+++ b/apps/graphql/test/queries/account_queries_test.exs
@@ -54,6 +54,19 @@ defmodule GraphQl.AccountQueriesTest do
       assert from_connection(found)
              |> ids_equal(members)
     end
+
+    test "users outside the roles account cannot view", %{user: user} do
+      group = insert(:group)
+      insert_list(3, :group_member, group: group)
+
+      {:ok, %{errors: [_ | _]}} = run_query("""
+        query members($id: ID!) {
+          groupMembers(first: 5, groupId: $id) {
+            edges { node { id } }
+          }
+        }
+      """, %{"id" => group.id}, %{current_user: user})
+    end
   end
 
   describe "invite" do
@@ -82,6 +95,16 @@ defmodule GraphQl.AccountQueriesTest do
       """, %{"id" => role.id}, %{current_user: user})
 
       assert found["id"] == role.id
+    end
+
+    test "users outside the roles account cannot view", %{user: user} do
+      role = insert(:role)
+
+      {:ok, %{errors: [_ | _]}} = run_query("""
+        query Role($id: ID!) {
+          role(id: $id) { id }
+        }
+      """, %{"id" => role.id}, %{current_user: user})
     end
   end
 


### PR DESCRIPTION
## Summary

We have some inconsistent behavior in authing gql queries, and a natural solve is a protocol based implementation. This covers a few fields that weren't properly authed (relied on uuid entropy), and we can reimplement auth elsewhere using it as well.


## Test Plan
added a few unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.