### PR TITLE
Expire stale tests

### DIFF
--- a/apps/core/lib/core/schema/test.ex
+++ b/apps/core/lib/core/schema/test.ex
@@ -2,6 +2,8 @@ defmodule Core.Schema.Test do
   use Piazza.Ecto.Schema
   alias Core.Schema.{Repository, User, TestBinding, TestStep}
 
+  @expiry 1 # hour
+
   defenum Status, queued: 0, running: 1, succeeded: 2, failed: 3
 
   schema "tests" do
@@ -17,6 +19,11 @@ defmodule Core.Schema.Test do
     has_many :steps,    TestStep
 
     timestamps()
+  end
+
+  def stale(query \\ __MODULE__) do
+    expiry = Timex.now() |> Timex.shift(hours: -@expiry)
+    from(t in query, where: t.status not in ^[:succeeded, :failed] and t.inserted_at < ^expiry)
   end
 
   def for_repository(query \\ __MODULE__, repo_id) do

--- a/apps/core/test/services/tests_test.exs
+++ b/apps/core/test/services/tests_test.exs
@@ -107,6 +107,24 @@ defmodule Core.Services.TestsTest do
     end
   end
 
+  describe "#expire/1" do
+    test "it can expire a test and all unfailed steps" do
+      test = insert(:test, status: :running)
+      step = insert(:test_step, test: test, status: :running)
+      step2 = insert(:test_step, test: test, status: :queued)
+      ignore1 = insert(:test_step, test: test, status: :succeeded)
+
+      {:ok, res} = Tests.expire(test)
+
+      assert res.id == test.id
+      assert res.status == :failed
+
+      assert refetch(step).status == :failed
+      assert refetch(step2).status == :failed
+      assert refetch(ignore1).status == :succeeded
+    end
+  end
+
   describe "#publish_logs/3" do
     test "test creators can publish logs" do
       user = insert(:user)

--- a/apps/cron/lib/cron/task/stale_tests.ex
+++ b/apps/cron/lib/cron/task/stale_tests.ex
@@ -1,0 +1,17 @@
+defmodule Cron.Task.StaleTests do
+  @moduledoc """
+  Grabs all images pending scan and schedules a new scan
+  """
+  use Cron
+  alias Core.Schema.Test
+  alias Core.Services.Tests
+
+  def run() do
+    Test.stale()
+    |> Test.ordered(asc: :id)
+    |> Core.Repo.stream(method: :keyset)
+    |> Flow.from_enumerable(stages: 2, max_demand: 5)
+    |> Flow.map(&Tests.expire/1)
+    |> log()
+  end
+end

--- a/apps/cron/test/cron/task/stale_tests_test.exs
+++ b/apps/cron/test/cron/task/stale_tests_test.exs
@@ -1,0 +1,18 @@
+defmodule Cron.Task.StaleTestsTest do
+  use Core.SchemaCase, async: false
+  alias Cron.Task.StaleTests
+
+  describe "#run/0" do
+    test "it will scan old images" do
+      old = Timex.now() |> Timex.shift(hours: -2)
+      tests = insert_list(3, :test, status: :running, inserted_at: old)
+      insert(:test, status: :running)
+      insert(:test, status: :succeeded, inserted_at: old)
+
+      3 = StaleTests.run()
+
+      for t <- tests,
+        do: assert refetch(t).status == :failed
+    end
+  end
+end

--- a/plural/helm/plural/Chart.yaml
+++ b/plural/helm/plural/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: plural
 description: A helm chart for installing plural
 appVersion: "1.0"
-version: 0.8.39
+version: 0.8.40
 dependencies:
 - name: hydra
   repository: https://k8s.ory.sh/helm/charts

--- a/plural/helm/plural/values.yaml
+++ b/plural/helm/plural/values.yaml
@@ -359,6 +359,10 @@ crons:
   cronModule: Prune.Queues
   crontab: "0 15 * * *"
   envVars: []
+- cronName: plrl-stale-tests
+  cronModule: Task.StaleTests
+  crontab: "0 30 * * *"
+  envVars: []
 
 hydraSecrets:
   dsn: memory


### PR DESCRIPTION
## Summary
Occasionally the test harness doesn't complete a tests workflow and leaves its state hanging.  It's not clear why this is, but plural itself should infer the test has failed and mark it after a sufficiently long time window


## Test Plan
added unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.