### PR TITLE
Autodelete installations when demo projects are created

### DIFF
--- a/apps/core/lib/core/services/upgrades.ex
+++ b/apps/core/lib/core/services/upgrades.ex
@@ -16,6 +16,11 @@ defmodule Core.Services.Upgrades do
 
   def get_queue(user_id, name), do: Core.Repo.get_by(UpgradeQueue, user_id: user_id, name: name)
 
+  def queue_count(user_id) do
+    UpgradeQueue.for_user(user_id)
+    |> Core.Repo.aggregate(:count, :id)
+  end
+
   def authorize(id, %User{id: user_id}) do
     case get_queue(id) do
       %UpgradeQueue{user_id: ^user_id} = q -> {:ok, q}

--- a/apps/core/test/services/charts_test.exs
+++ b/apps/core/test/services/charts_test.exs
@@ -163,7 +163,7 @@ defmodule Core.Services.ChartsTest do
       installation = insert(:installation, repository: chart.repository, user: user)
       chart_inst = insert(:chart_installation, installation: installation, chart: chart, version: v)
 
-      {:ok, ci} = Charts.delete_chart_installation( chart_inst.id, user)
+      {:ok, _} = Charts.delete_chart_installation( chart_inst.id, user)
 
       refute refetch(chart_inst)
     end


### PR DESCRIPTION
## Summary

Technically your demo installations can linger, which can create a frustrating experience if you move into prod with a different cloud provider or different apps.  We need to hedge a bit against the case a user already did create another cluster, which we can proxy based on > 1 upgrade queue.


## Test Plan
added unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.