### PR TITLE
Fix OIDC redirect when logging in with external IDP

### DIFF
--- a/www/src/components/users/MagicLogin.js
+++ b/www/src/components/users/MagicLogin.js
@@ -229,7 +229,6 @@ export function handleOauthChallenge(client, challenge) {
   }).catch(err => {
     console.error(err)
     wipeChallenge()
-    window.location = window.location.pathname
   })
 }
 
@@ -316,8 +315,9 @@ export function Login() {
     wipeChallenge()
     wipeDeviceToken()
 
-    if (data && data.loginMethod && data.loginMethod.authorizeUrl) {
-      if (challenge) saveChallenge(challenge)
+    if (challenge) saveChallenge(challenge)
+
+    if (data?.loginMethod?.authorizeUrl) {
       if (deviceToken) saveDeviceToken(deviceToken)
       window.location = data.loginMethod.authorizeUrl
     }


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Fixed redirect when logging in with OIDC
[Nagranie ekranu z 29.08.2022 15:59:52.webm](https://user-images.githubusercontent.com/2285385/187219323-fdcc2568-595a-4a51-910d-092f6ec094ce.webm)

`challenge` was only set when user used the standard log in flow (username/password) and was ignored when login with provider button was clicked. I have changed the logic to always save it if it is available.

- Removed the redirect to the plural app when there is an OIDC error
[Nagranie ekranu z 29.08.2022 16:02:03.webm](https://user-images.githubusercontent.com/2285385/187219489-07b76b6e-fce3-48a4-9371-eb742a97c064.webm)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.