### PR TITLE
Increase invite security

### DIFF
--- a/apps/core/lib/core/pubsub/events.ex
+++ b/apps/core/lib/core/pubsub/events.ex
@@ -73,3 +73,5 @@ defmodule Core.PubSub.TestUpdated, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.StepLogs, do: use Piazza.PubSub.Event
 
 defmodule Core.PubSub.CacheUser, do: use Piazza.PubSub.Event
+
+defmodule Core.PubSub.InviteCreated, do: use Piazza.PubSub.Event

--- a/apps/core/lib/core/pubsub/protocols/auditable/accounts.ex
+++ b/apps/core/lib/core/pubsub/protocols/auditable/accounts.ex
@@ -86,3 +86,16 @@ defimpl Core.PubSub.Auditable, for: [Core.PubSub.UserDeleted] do
     }
   end
 end
+
+
+defimpl Core.PubSub.Auditable, for: [Core.PubSub.InviteCreated] do
+  alias Core.Schema.Audit
+
+  def audit(%{item: invite, actor: %{id: actor_id}}) do
+    %Audit{
+      action: "invite:created",
+      actor_id: actor_id,
+      account_id: invite.account_id,
+    }
+  end
+end

--- a/apps/core/lib/core/schema/user.ex
+++ b/apps/core/lib/core/schema/user.ex
@@ -146,9 +146,16 @@ defmodule Core.Schema.User do
 
   def changeset(model, attrs \\ %{}, mode \\ :primary) do
     model
-    |> cast(attrs, fields(mode))
+    |> base_changeset(attrs, mode)
     |> cast_embed(:address)
     |> cast_embed(:roles, with: &roles_changeset/2)
+  end
+
+  def invite_changeset(model, attrs \\ %{}), do: base_changeset(model, attrs, :primary)
+
+  def base_changeset(model, attrs, mode) do
+    model
+    |> cast(attrs, fields(mode))
     |> unique_constraint(:email)
     |> unique_constraint(:external_id)
     |> validate_required([:name, :email])

--- a/apps/core/lib/core/services/accounts.ex
+++ b/apps/core/lib/core/services/accounts.ex
@@ -161,6 +161,7 @@ defmodule Core.Services.Accounts do
       |> when_ok(:insert)
     end)
     |> execute(extract: :invite)
+    |> notify(:create, user)
   end
 
   def delete_invite(id, %User{} = user) do
@@ -251,7 +252,7 @@ defmodule Core.Services.Accounts do
     end)
     |> add_operation(:upsert, fn %{user: user} ->
       user
-      |> User.changeset(attributes)
+      |> User.invite_changeset(attributes)
       |> Ecto.Changeset.change(%{account_id: invite.account_id})
       |> Core.Repo.insert_or_update()
     end)
@@ -553,6 +554,10 @@ defmodule Core.Services.Accounts do
     do: handle_notify(PubSub.GroupMemberCreated, m, actor: user)
   defp notify({:ok, %GroupMember{} = m}, :delete, user),
     do: handle_notify(PubSub.GroupMemberDeleted, m, actor: user)
+
+
+  defp notify({:ok, %Invite{} = inv}, :create, user),
+    do: handle_notify(PubSub.InviteCreated, inv, actor: user)
 
   defp notify({:ok, meeting}, :zoom, user),
     do: handle_notify(PubSub.ZoomMeetingCreated, meeting, actor: user)

--- a/apps/core/test/pubsub/audit/accounts_test.exs
+++ b/apps/core/test/pubsub/audit/accounts_test.exs
@@ -195,6 +195,20 @@ defmodule Core.PubSub.Audits.AccountsTest do
     end
   end
 
+  describe "InviteCreated" do
+    test "it can post a message about the meeting" do
+      actor = insert(:user)
+      invite  = insert(:invite)
+
+      event = %PubSub.InviteCreated{item: invite, actor: actor}
+      {:ok, audit} = Audits.handle_event(event)
+
+      assert audit.action == "invite:created"
+      assert audit.actor_id == actor.id
+      assert audit.account_id == invite.account_id
+    end
+  end
+
   def set_context(_) do
     ctx = %Core.Schema.AuditContext{
       ip: "1.2.3.4",

--- a/apps/core/test/services/accounts_test.exs
+++ b/apps/core/test/services/accounts_test.exs
@@ -307,6 +307,23 @@ defmodule Core.Services.AccountsTest do
 
       assert_receive {:event, %PubSub.UserCreated{item: ^user}}
     end
+
+    test "it will ignore privileged fields", %{user: user, account: account} do
+      {:ok, invite} = Accounts.create_invite(%{email: "some@example.com"}, user)
+
+      {:ok, user} = Accounts.realize_invite(%{
+        password: "some long password",
+        name: "Some User",
+        roles: %{admin: true}
+      }, invite.secure_id)
+
+      assert user.email == invite.email
+      assert user.account_id == account.id
+      assert user.name == "Some User"
+      refute user.roles
+
+      assert_receive {:event, %PubSub.UserCreated{item: ^user}}
+    end
   end
 
   describe "#create_role/2" do

--- a/apps/email/lib/email/builder/invite.ex
+++ b/apps/email/lib/email/builder/invite.ex
@@ -1,0 +1,14 @@
+defmodule Email.Builder.Invite do
+  use Email.Builder.Base
+
+  def email(invite) do
+    %{user: user, account: account} = invite = Core.Repo.preload(invite, [:user, account: :root_user])
+    base_email()
+    |> to(user)
+    |> subject("You've been invited to join #{account.root_user.email}'s account")
+    |> assign(:user, user)
+    |> assign(:account, account)
+    |> assign(:inv, invite)
+    |> render(:invite)
+  end
+end

--- a/apps/email/lib/email/deliverable/users.ex
+++ b/apps/email/lib/email/deliverable/users.ex
@@ -5,3 +5,8 @@ end
 defimpl Email.Deliverable, for: Core.PubSub.PasswordlessLoginCreated do
   def email(%{item: login}), do: Email.Builder.PasswordlessLogin.email(login)
 end
+
+defimpl Email.Deliverable, for: Core.PubSub.InviteCreated do
+  def email(%{item: %{user_id: id} = invite}) when is_binary(id), do: Email.Builder.Invite.email(invite)
+  def email(_), do: :ok
+end

--- a/apps/email/lib/email_web/templates/email/invite.html.eex
+++ b/apps/email/lib/email_web/templates/email/invite.html.eex
@@ -1,0 +1,16 @@
+<%= row do %>
+  <%= text bold: true do %>
+    Join <%= @account.name %>
+  <% end %>
+<% end %>
+<%= row do %>
+  <%= text do %>
+    Click below to join <%= @account.name %> (owned by <%= @account.root_user.name %>).  This will transfer your user from your previous account to their account.
+  <% end %>
+<% end %>
+<%= space() %>
+<%= row do %>
+  <%= btn url: url("/invite/#{@inv.secure_id}") do %>
+    Confirm
+  <% end %>
+<% end %>

--- a/apps/email/lib/email_web/templates/email/invite.text.eex
+++ b/apps/email/lib/email_web/templates/email/invite.text.eex
@@ -1,0 +1,3 @@
+You were invited to join <%= @account.root_user.email %>'s Plural account.  This will transfer you to the new account.
+
+Accept the invite here: <%= url("/invite/#{@inv.secure_id}") %>

--- a/apps/email/test/email/deliverable/users_test.exs
+++ b/apps/email/test/email/deliverable/users_test.exs
@@ -35,4 +35,26 @@ defmodule Email.Deliverable.UsersTest do
       assert_delivered_email Email.Builder.PasswordlessLogin.email(login)
     end
   end
+
+  describe "InviteCreated" do
+    test "it can send an invite created email for existing users" do
+      account = insert(:account, root_user: build(:user))
+      invite = insert(:invite, account: account, user: build(:user))
+
+      event = %PubSub.InviteCreated{item: invite}
+      Consumer.handle_event(event)
+
+      assert_delivered_email Email.Builder.Invite.email(invite)
+    end
+
+    test "it will ignore email delivery for non existing users" do
+      account = insert(:account, root_user: build(:user))
+      invite = insert(:invite, account: account)
+
+      event = %PubSub.InviteCreated{item: invite}
+      Consumer.handle_event(event)
+
+      refute_delivered_email Email.Builder.Invite.email(invite)
+    end
+  end
 end

--- a/apps/graphql/lib/graphql/schema/account.ex
+++ b/apps/graphql/lib/graphql/schema/account.ex
@@ -107,7 +107,15 @@ defmodule GraphQl.Schema.Account do
 
   object :invite do
     field :id,        non_null(:id)
-    field :secure_id, non_null(:string)
+    field :secure_id, :string, resolve: fn
+      %{user_id: id}, _, _ when is_binary(id) -> {:ok, nil} # obfuscate for existing users
+      %{secure_id: id}, _, _ -> {:ok, id}
+    end
+
+    field :existing,  non_null(:boolean), resolve: fn
+      %{user_id: id}, _, _ when is_binary(id) -> {:ok, true}
+      _, _, _ -> {:ok, false}
+    end
     field :email,     :string
 
     field :account, :account, resolve: dataloader(Account)


### PR DESCRIPTION
## Summary

Limit the scope of the changeset in an invite, and only expose secure id on new user invites.  The goal of the secure id obfuscation is to prevent a potential abuse vector where someone invites a random user then forces them onto their account. This will require a follow-up frontend pr

## Test Plan
added unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.