### PR TITLE
Redesign invite view

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -58,7 +58,7 @@
     "moment": "2.29.4",
     "phoenix": "1.6.11",
     "pluralsh-absinthe-socket-apollo-link": "0.2.0",
-    "pluralsh-design-system": "1.190.0",
+    "pluralsh-design-system": "1.191.0",
     "prop-types": "15.8.1",
     "query-string": "7.1.1",
     "randomcolor": "0.6.2",

--- a/www/src/components/Invite.js
+++ b/www/src/components/Invite.js
@@ -11,6 +11,7 @@ import { UserFragment } from '../models/user'
 
 import { initials } from './users/Avatar'
 import { LabelledInput, LoginPortal } from './users/MagicLogin'
+import { WelcomeHeader } from './utils/WelcomeHeader'
 
 const SIGNUP = gql`
   mutation Signup($attributes: UserAttributes!, $inviteId: String!) {
@@ -208,12 +209,7 @@ export default function Invite() {
                 header="Something went wrong!"
               />
             )}
-            <Box
-              justify="center"
-              align="center"
-            >
-              <Text size="large">Accept your invite</Text>
-            </Box>
+            <WelcomeHeader heading="Accept your invitation" />
             <Box
               direction="row"
               gap="small"

--- a/www/src/components/Invite.js
+++ b/www/src/components/Invite.js
@@ -202,7 +202,7 @@ export default function Invite() {
                 placeholder="Enter password"
                 onChange={password => setAttributes({ ...attributes, password })}
                 error={passwordTooShort}
-                hint={passwordTooShort ? 'Password too short, use min 10 characters.' : ''}
+                hint={passwordTooShort ? 'Password is too short. Use at least 10 characters.' : ''}
                 required
               />
               <LabelledInput

--- a/www/src/components/Invite.js
+++ b/www/src/components/Invite.js
@@ -122,9 +122,10 @@ export default function Invite() {
   if (inviteError) return <InvalidInvite />
   if (!data) return null
 
-  const passwordTooShort = attributes.password.length > 0 && attributes.password.length < 10
+  const isNameValid = attributes.name.length > 0
+  const isPasswordValid = attributes.password.length > 10
   const passwordMatch = attributes.password === passwordConfirmation
-  const valid = attributes.name.length > 0 && attributes.password.length > 0 && passwordMatch
+  const isValid = isNameValid && isPasswordValid && passwordMatch
 
   if (data.invite.user) {
     return (
@@ -141,7 +142,7 @@ export default function Invite() {
         fill
         pad="medium"
       >
-        <Keyboard onEnter={valid && mutation}>
+        <Keyboard onEnter={isValid && mutation}>
           <Box
             flex={false}
             gap="small"
@@ -201,8 +202,8 @@ export default function Invite() {
                 value={attributes.password}
                 placeholder="Enter password"
                 onChange={password => setAttributes({ ...attributes, password })}
-                error={passwordTooShort}
-                hint={passwordTooShort ? 'Password is too short. Use at least 10 characters.' : ''}
+                error={attributes.password.length > 0 && !isPasswordValid}
+                hint={attributes.password.length > 0 && !isPasswordValid ? 'Password is too short. Use at least 10 characters.' : ''}
                 required
               />
               <LabelledInput
@@ -220,7 +221,7 @@ export default function Invite() {
               primary
               width="100%"
               loading={loading}
-              disabled={!valid}
+              disabled={!isValid}
               onClick={mutation}
             >
               Sign up

--- a/www/src/components/Invite.js
+++ b/www/src/components/Invite.js
@@ -161,7 +161,7 @@ export default function Invite() {
               margin={{ vertical: '32px' }}
             >
               <AppIcon
-                name={attributes.name}
+                name={attributes.name || 'John Doe'}
                 size="xsmall"
                 hue="default"
               />
@@ -171,7 +171,7 @@ export default function Invite() {
                   fontFamily="Monument Semi-Mono, monospace"
                   fontWeight="500"
                 >
-                  {attributes.name}
+                  {attributes.name || 'John Doe'}
                 </Text>
                 <Text
                   caption

--- a/www/src/components/Invite.js
+++ b/www/src/components/Invite.js
@@ -188,6 +188,7 @@ export default function Invite() {
               <LabelledInput
                 label="Email"
                 value={data.invite.email}
+                disabled
               />
               <LabelledInput
                 label="Name"

--- a/www/src/components/Invite.js
+++ b/www/src/components/Invite.js
@@ -2,8 +2,9 @@ import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { gql, useMutation, useQuery } from '@apollo/client'
 import { Box, Keyboard, Text } from 'grommet'
-import { Button, GqlError, SecondaryButton } from 'forge-core'
+import { GqlError } from 'forge-core'
 import { Checkmark, StatusCritical } from 'grommet-icons'
+import { Button } from 'pluralsh-design-system'
 
 import { setToken } from '../helpers/authentication'
 
@@ -56,7 +57,6 @@ function InvalidInvite() {
 }
 
 export function disableState(password, confirm) {
-  if (password.length === 0) return { disabled: true, reason: 'enter a password' }
   if (password.length < 10) return { disabled: true, reason: 'password is too short' }
   if (password !== confirm) return { disabled: true, reason: 'passwords do not match' }
 
@@ -164,7 +164,6 @@ export default function Invite() {
   const { inviteId } = useParams()
   const [attributes, setAttributes] = useState({ name: '', password: '' })
   const [confirm, setConfirm] = useState('')
-  const [editPassword, setEditPassword] = useState(false)
   const [mutation, { loading, error }] = useMutation(SIGNUP, {
     variables: { inviteId, attributes },
     onCompleted: ({ signup: { jwt } }) => {
@@ -179,7 +178,7 @@ export default function Invite() {
   if (!data) return null
 
   const { disabled, reason } = disableState(attributes.password, confirm)
-  const { email } = data.invite
+  const valid = attributes.name.length > 0 && attributes.password.length > 0 && attributes.password === confirm
 
   if (data.invite.user) {
     return (
@@ -190,15 +189,13 @@ export default function Invite() {
     )
   }
 
-  const filled = attributes.name.length > 0
-
   return (
     <LoginPortal style={{ minWidth: '50%' }}>
       <Box
         fill
         pad="medium"
       >
-        <Keyboard onEnter={editPassword && filled ? mutation : null}>
+        <Keyboard onEnter={valid && mutation}>
           <Box
             flex={false}
             gap="small"
@@ -214,6 +211,7 @@ export default function Invite() {
               direction="row"
               gap="small"
               align="center"
+              margin={{ vertical: '32px' }}
             >
               <DummyAvatar name={attributes.name} />
               <Box>
@@ -225,84 +223,61 @@ export default function Invite() {
                 <Text
                   size="small"
                   color="dark-3"
-                >{email}
+                >{data.invite.email}
                 </Text>
               </Box>
             </Box>
-            {editPassword ? (
-              <Box animation={{ type: 'fadeIn', duration: 500 }}>
-                <Box
-                  gap="small"
-                  fill="horizontal"
-                >
-                  <LabelledInput
-                    width="100%"
-                    type="password"
-                    label="password"
-                    value={attributes.password}
-                    placeholder="battery horse fire stapler"
-                    onChange={password => setAttributes({ ...attributes, password })}
-                  />
-                  <LabelledInput
-                    width="100%"
-                    type="password"
-                    label="confirm"
-                    value={confirm}
-                    placeholder="type it again"
-                    onChange={setConfirm}
-                  />
-                </Box>
-              </Box>
-            ) : (
-              <Box animation={{ type: 'fadeIn', duration: 500 }}>
-                <Box
-                  gap="small"
-                  fill="horizontal"
-                >
-                  <LabelledInput
-                    width="100%"
-                    label="Email"
-                    value={email}
-                  />
-                  <LabelledInput
-                    width="100%"
-                    label="Name"
-                    value={attributes.name}
-                    placeholder="John Doe"
-                    onChange={name => setAttributes({ ...attributes, name })}
-                  />
-                </Box>
-              </Box>
-            )}
             <Box
-              direction="row"
-              justify="end"
+              gap="small"
+              fill="horizontal"
+            >
+              <LabelledInput
+                label="Email"
+                value={data.invite.email}
+              />
+              <LabelledInput
+                label="Name"
+                value={attributes.name}
+                placeholder="John Doe"
+                onChange={name => setAttributes({ ...attributes, name })}
+              />
+              <LabelledInput
+                type="password"
+                label="Password"
+                value={attributes.password}
+                placeholder="Enter password"
+                onChange={password => setAttributes({ ...attributes, password })}
+              />
+              <LabelledInput
+                type="password"
+                label="Confirm password"
+                value={confirm}
+                placeholder="Enter password again"
+                onChange={setConfirm}
+              />
+            </Box>
+            <Box
               align="center"
               gap="small"
             >
-              {editPassword && (
-                <PasswordStatus
-                  disabled={disabled}
-                  reason={reason}
-                />
-              )}
+              <PasswordStatus
+                disabled={disabled}
+                reason={reason}
+              />
               <Box
-                flex={false}
+                fill="horizontal"
                 direction="row"
                 gap="small"
               >
-                {editPassword && (
-                  <SecondaryButton
-                    label="Go Back"
-                    onClick={() => setEditPassword(false)}
-                  />
-                )}
                 <Button
+                  primary
+                  width="100%"
                   loading={loading}
-                  disabled={editPassword ? disabled : !filled}
-                  label={editPassword ? 'Sign up' : 'Continue'}
-                  onClick={editPassword ? mutation : () => setEditPassword(true)}
-                />
+                  disabled={!valid}
+                  onClick={mutation}
+                >
+                  Sign up
+                </Button>
               </Box>
             </Box>
           </Box>

--- a/www/src/components/Invite.js
+++ b/www/src/components/Invite.js
@@ -193,6 +193,7 @@ export default function Invite() {
                 value={attributes.name}
                 placeholder="John Doe"
                 onChange={name => setAttributes({ ...attributes, name })}
+                required
               />
               <LabelledInput
                 type="password"
@@ -202,6 +203,7 @@ export default function Invite() {
                 onChange={password => setAttributes({ ...attributes, password })}
                 error={passwordTooShort}
                 hint={passwordTooShort ? 'Password too short, use min 10 characters.' : ''}
+                required
               />
               <LabelledInput
                 type="password"
@@ -211,6 +213,7 @@ export default function Invite() {
                 onChange={setPasswordConfirmation}
                 error={passwordConfirmation && !passwordMatch}
                 hint={passwordConfirmation && !passwordMatch ? 'Passwords do not match.' : ''}
+                required
               />
             </Box>
             <Button

--- a/www/src/components/Invite.js
+++ b/www/src/components/Invite.js
@@ -79,26 +79,15 @@ function ExistingInvite({ invite: { account }, id }) {
               header="Something went wrong!"
             />
           )}
-          <Box
-            justify="center"
-            align="center"
+          <Box align="center">You were invited to join another account</Box>
+          <Button
+            onClick={mutation}
+            loading={loading}
+            width="100%"
+            padding="medium"
           >
-            <Text>You were invited to join another account</Text>
-          </Box>
-          <Box
-            direction="row"
-            fill="horizontal"
-          >
-            <Button
-              onClick={mutation}
-              loading={loading}
-              fill="horizontal"
-              size="small"
-              round="xsmall"
-              pad={{ vertical: 'xsmall', horizontal: 'medium' }}
-              label={`Join ${account.name}`}
-            />
-          </Box>
+            Join {account.name}
+          </Button>
         </Box>
       </Box>
     </LoginPortal>

--- a/www/src/components/profile/MyProfile.js
+++ b/www/src/components/profile/MyProfile.js
@@ -40,7 +40,7 @@ export function MyProfile() {
       <ResponsiveLayoutSidenavContainer width={240}>
         <PageCard
           heading={me.name}
-          icon={{ name: me.avatar, url: me.avatar, spacing: 'none' }}
+          icon={{ name: me.name, url: me.avatar, spacing: 'none' }}
           subheading={me?.roles?.admin && (
             `Admin${me?.account?.name && ` at ${me?.account?.name}`}`
           )}

--- a/www/src/components/users/MagicLogin.js
+++ b/www/src/components/users/MagicLogin.js
@@ -43,14 +43,16 @@ import { METHOD_ICONS } from './OauthEnabler'
 import { finishedDeviceLogin } from './DeviceLoginNotif'
 
 export function LabelledInput({
-  label, value, onChange, placeholder, type, caption, hint,
+  label, value, onChange, placeholder, type, caption, hint, error = undefined, required = false,
 }) {
   return (
     <FormField
       label={label}
       caption={caption}
       hint={hint}
-      marginBottom="medium"
+      marginBottom="small"
+      error={error}
+      required={required}
     >
       <Input
         width="100%"
@@ -59,6 +61,7 @@ export function LabelledInput({
         value={value || ''}
         onChange={onChange && (({ target: { value } }) => onChange(value))}
         placeholder={placeholder}
+        error={error}
       />
     </FormField>
   )

--- a/www/src/components/users/MagicLogin.js
+++ b/www/src/components/users/MagicLogin.js
@@ -366,7 +366,7 @@ export function Login() {
 
   return (
     <LoginPortal>
-      <WelcomeHeader />
+      <WelcomeHeader marginBottom="xxlarge" />
       {passwordless && (
         <Div>
           <LoginPoller
@@ -510,7 +510,7 @@ export function Signup() {
 
   return (
     <LoginPortal>
-      <WelcomeHeader />
+      <WelcomeHeader marginBottom="xxlarge" />
       <Keyboard onEnter={mutation}>
         <Form onSubmit={mutation}>
           {error && (

--- a/www/src/components/users/MagicLogin.js
+++ b/www/src/components/users/MagicLogin.js
@@ -15,8 +15,10 @@ import {
 } from 'react-router-dom'
 import queryString from 'query-string'
 import {
-  A, Article, Button, Div, Flex, H1, H2, Icon, Img, Input, P,
+  A, Article, Button, Div, Flex, H2, Icon, Img, Input, P,
 } from 'honorable'
+
+import { WelcomeHeader } from 'components/utils/WelcomeHeader'
 
 import { fetchToken, setToken } from '../../helpers/authentication'
 import { Alert, AlertStatus, GqlError } from '../utils/Alert'
@@ -613,16 +615,5 @@ export function Signup() {
         </A>
       </P>
     </LoginPortal>
-  )
-}
-
-function WelcomeHeader({ heading = 'Welcome to Plural', subheading = 'We\'re glad to see you here.' }) {
-  return (
-    <Div marginBottom="xxlarge">
-      <H1 title1>
-        {heading}
-      </H1>
-      <P body1>{subheading}</P>
-    </Div>
   )
 }

--- a/www/src/components/users/MagicLogin.js
+++ b/www/src/components/users/MagicLogin.js
@@ -43,7 +43,7 @@ import { METHOD_ICONS } from './OauthEnabler'
 import { finishedDeviceLogin } from './DeviceLoginNotif'
 
 export function LabelledInput({
-  label, value, onChange, placeholder, type, caption, hint, error = undefined, required = false,
+  label, value, onChange, placeholder, type, caption, hint, error = undefined, required = false, disabled = false,
 }) {
   return (
     <FormField
@@ -62,6 +62,7 @@ export function LabelledInput({
         onChange={onChange && (({ target: { value } }) => onChange(value))}
         placeholder={placeholder}
         error={error}
+        disabled={disabled}
       />
     </FormField>
   )

--- a/www/src/components/utils/WelcomeHeader.tsx
+++ b/www/src/components/utils/WelcomeHeader.tsx
@@ -1,8 +1,8 @@
 import { Div, H1, P } from 'honorable'
 
-export function WelcomeHeader({ heading = 'Welcome to Plural', subheading = 'We\'re glad to see you here.' }) {
+export function WelcomeHeader({ heading = 'Welcome to Plural', subheading = 'We\'re glad to see you here.', ...props }) {
   return (
-    <Div marginBottom="xxlarge">
+    <Div {...props}>
       <H1 title1>{heading}</H1>
       <P
         body1

--- a/www/src/components/utils/WelcomeHeader.tsx
+++ b/www/src/components/utils/WelcomeHeader.tsx
@@ -1,0 +1,15 @@
+import { Div, H1, P } from 'honorable'
+
+export function WelcomeHeader({ heading = 'Welcome to Plural', subheading = 'We\'re glad to see you here.' }) {
+  return (
+    <Div marginBottom="xxlarge">
+      <H1 title1>{heading}</H1>
+      <P
+        body1
+        color="text-light"
+      >
+        {subheading}
+      </P>
+    </Div>
+  )
+}

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -15112,9 +15112,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pluralsh-design-system@npm:1.190.0":
-  version: 1.190.0
-  resolution: "pluralsh-design-system@npm:1.190.0"
+"pluralsh-design-system@npm:1.191.0":
+  version: 1.191.0
+  resolution: "pluralsh-design-system@npm:1.191.0"
   dependencies:
     "@floating-ui/react-dom-interactions": 0.8.1
     "@react-aria/button": 3.6.0
@@ -15151,7 +15151,7 @@ __metadata:
     react-dom: ">=16.0.0"
     react-transition-group: ">=4.4.2"
     styled-components: ">=5.3.5"
-  checksum: 90f4d6dd4076fe6a6d5e5c954bc8b3b04f21d158b2e1a137d041d1f8030ed6c0c75740de1bb702ac36fabe1b02b0b150bff4b664867d09e1518b97ac904e2ece
+  checksum: 4cf949b76a207193e4c772da19d31ee541a73635a4e44f9c5e1c5da4799824fe1a79cbb874ff608fbfd487875bf0f51612c110995bca4a7531277568764339db
   languageName: node
   linkType: hard
 
@@ -21058,7 +21058,7 @@ __metadata:
     moment: 2.29.4
     phoenix: 1.6.11
     pluralsh-absinthe-socket-apollo-link: 0.2.0
-    pluralsh-design-system: 1.190.0
+    pluralsh-design-system: 1.191.0
     postcss-import: 8.2.0
     prop-types: 15.8.1
     query-string: 7.1.1


### PR DESCRIPTION
## Summary
Closes ENG-566.

- Bump design system version
- Fix typo in my profile causing letters to not appear on the avatar
- Export welcome header and update subheading color
- Move all fields of invite form to one view
- Use form fields to display validation errors

Note: Form field labels have 700 weight at the moment, we will have to change that to 600 to match Figma designs.

Edit: I have changed email field to disabled state as it may be confusing to keep it enabled but not possible to edit. See first screenshot.

<img width="460" alt="Zrzut ekranu 2022-08-30 o 11 59 54" src="https://user-images.githubusercontent.com/2823399/187408849-af459722-a2d5-486a-b309-57d071a38b70.png">
<img width="519" alt="Zrzut ekranu 2022-08-30 o 11 56 00" src="https://user-images.githubusercontent.com/2823399/187407964-7b7d0ab0-4c58-480f-a67a-59c4cf4b3629.png">
<img width="530" alt="Zrzut ekranu 2022-08-30 o 11 56 34" src="https://user-images.githubusercontent.com/2823399/187407951-7e3de2d6-2b03-46c2-91b8-ccf4bbb3b367.png">
<img width="458" alt="Zrzut ekranu 2022-08-30 o 11 32 07" src="https://user-images.githubusercontent.com/2823399/187403340-6ce12484-8638-4440-9c50-aa9acb01178c.png">

## Test Plan
Tested manually.

## Checklist
- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.