### PR TITLE
Frontend for existing user invites

### DIFF
--- a/apps/core/lib/core/services/accounts.ex
+++ b/apps/core/lib/core/services/accounts.ex
@@ -170,6 +170,12 @@ defmodule Core.Services.Accounts do
     |> when_ok(:delete)
   end
 
+  def delete_invite_by_id(id, %User{} = user) do
+    Core.Repo.get!(Invite, id)
+    |> allow(user, :delete)
+    |> when_ok(:delete)
+  end
+
   @doc """
   Creates a service account for the user's account, which is an assumable identity allowing multiple
   users to share credentials for instance to manage a set of installations

--- a/apps/graphql/lib/graphql/resolvers/account.ex
+++ b/apps/graphql/lib/graphql/resolvers/account.ex
@@ -96,6 +96,8 @@ defmodule GraphQl.Resolvers.Account do
 
   def delete_invite(%{secure_id: id}, %{context: %{current_user: user}}),
     do: Accounts.delete_invite(id, user)
+  def delete_invite(%{id: id}, %{context: %{current_user: user}}),
+    do: Accounts.delete_invite_by_id(id, user)
 
   def realize_invite(%{id: id}, _) do
     Accounts.realize_invite(%{}, id)

--- a/apps/graphql/lib/graphql/schema/account.ex
+++ b/apps/graphql/lib/graphql/schema/account.ex
@@ -311,7 +311,8 @@ defmodule GraphQl.Schema.Account do
     end
 
     field :delete_invite, :invite do
-      arg :secure_id, non_null(:string)
+      arg :id, :id
+      arg :secure_id, :string
 
       resolve safe_resolver(&Account.delete_invite/2)
     end

--- a/www/src/components/account/InviteUser.js
+++ b/www/src/components/account/InviteUser.js
@@ -1,4 +1,4 @@
-import { Button, Div } from 'honorable'
+import { Button, Div, Span } from 'honorable'
 import {
   Codeline, MailIcon, Modal, ModalActions, ModalHeader, ValidatedInput,
 } from 'pluralsh-design-system'
@@ -48,7 +48,8 @@ export function InviteUser() {
             header="Failed to invite user"
           />
         )}
-        {invite && <Codeline marginTop="small">{inviteLink(invite)}</Codeline>}
+        {invite?.secureId && <Codeline marginTop="small">{inviteLink(invite)}</Codeline>}
+        {invite && !invite.secureId && <Span>An email was sent to {email} to accept the invite</Span>}
         <ModalActions>
           <Button
             secondary

--- a/www/src/components/account/Invites.js
+++ b/www/src/components/account/Invites.js
@@ -18,7 +18,7 @@ import { Confirm } from './Confirm'
 function DeleteInvite({ invite }) {
   const [confirm, setConfirm] = useState(false)
   const [mutation, { loading, error }] = useMutation(DELETE_INVITE, {
-    variables: { id: invite.secureId },
+    variables: { id: invite.id },
     onCompleted: () => setConfirm(false),
     update: (cache, { data: { deleteInvite } }) => updateCache(cache, {
       query: INVITES_Q,
@@ -43,6 +43,18 @@ function DeleteInvite({ invite }) {
         error={error}
       />
     </>
+  )
+}
+
+function LinkCell({ invite }) {
+  if (!invite.secureId) return <TableData>Email sent to user</TableData>
+
+  return (
+    <TableData><Copyable
+      text={inviteLink(invite)}
+      pillText="Copied invite link"
+    />
+    </TableData>
   )
 }
 
@@ -78,11 +90,7 @@ export function Invites() {
                 suffix={<DeleteInvite invite={node} />}
               >
                 <TableData>{node.email}</TableData>
-                <TableData><Copyable
-                  text={inviteLink(node)}
-                  pillText="Copied invite link"
-                />
-                </TableData>
+                <LinkCell invite={node} />
                 <TableData>{moment(node.timestamp).format('lll')}</TableData>
               </TableRow>
             )}

--- a/www/src/components/accounts/queries.js
+++ b/www/src/components/accounts/queries.js
@@ -325,8 +325,8 @@ export const INVITES_Q = gql`
 `
 
 export const DELETE_INVITE = gql`
-  mutation Delete($id: String!) {
-    deleteInvite(secureId: $id) { ...InviteFragment }
+  mutation Delete($id: ID!) {
+    deleteInvite(id: $id) { ...InviteFragment }
   }
   ${InviteFragment}
 `


### PR DESCRIPTION
## Summary

We don't expose the secure id for invites to existing users and instead deliver emails, this should handle that path on the frontend


## Test Plan
validated locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.