### PR TITLE
Fix service worker issues with CRA build

### DIFF
--- a/www/src/service-worker.js
+++ b/www/src/service-worker.js
@@ -12,7 +12,10 @@ clientsClaim()
 // Their URLs are injected into the manifest variable below.
 // This variable must be present somewhere in your service worker file,
 // even if you decide not to use precaching. See https://cra.link/PWA
-precacheAndRoute(self.__WB_MANIFEST)
+// Filter out the "index.html" so that it is not cached as it breaks
+// the application when the code changes and SW caches it
+const precache = self.__WB_MANIFEST.filter(file => !file.url.includes('index.html'))
+precacheAndRoute(precache)
 
 const isSameOrigin = (url) => url.origin === self.location.origin;
 const shouldCache = (pathname) => Boolean(


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
This fixes an occasional issue with SW that could stop the page from loading after code changes.
### Explanation
1. CRA creates `main.xyz.js` and `main.xyz.css` files during build.
2. `index.html` gets updated to reference new `main.xyz.js` file.
3. User opens the `app.plural.sh` page
4. Service worker caches the `index.html`
5. Code gets updated and new build results in generating `main.abc.js` and `main.abc.css` files
6. User opens the page again but `index.html` is served from the SW cache and it references `main.xyz.js` files that is no longer available

Since the SW cache expires after some time and different browsers handle cache differently many users might not have seen this issue. Still, it had to be fixed :slightly_smiling_face: 

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Tested locally the prod build and SW.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.