### PR TITLE
Implement demo project transfer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,3 +73,10 @@ migration:
 
 yarn-add: ## adds a yarn dep to the react interface
 	cd www && yarn add $(dep)
+
+release-vsn: # tags and pushes a new release
+	@read -p "Version: " tag; \
+	git checkout master; \
+	git pull --rebase; \
+	git tag -a $$tag -m "new release"; \
+	git push origin $$tag

--- a/apps/graphql/lib/graphql/resolvers/shell.ex
+++ b/apps/graphql/lib/graphql/resolvers/shell.ex
@@ -17,6 +17,9 @@ defmodule GraphQl.Resolvers.Shell do
   def create_demo_project(_, %{context: %{current_user: user}}),
     do: Shell.Demo.create_demo_project(user)
 
+  def transfer_demo_project(%{organization_id: org}, %{context: %{current_user: user}}),
+    do: Shell.Demo.transfer_demo_project(org, user)
+
   def reboot(_, %{context: %{current_user: user}}), do: Shell.reboot(user.id)
 
   def stop(_, %{context: %{current_user: user}}), do: Shell.stop(user)

--- a/apps/graphql/lib/graphql/schema/shell.ex
+++ b/apps/graphql/lib/graphql/schema/shell.ex
@@ -144,6 +144,13 @@ defmodule GraphQl.Schema.Shell do
       safe_resolve &Shell.create_demo_project/2
     end
 
+    field :transfer_demo_project, :demo_project do
+      middleware Authenticated
+      arg :organization_id, non_null(:string)
+
+      safe_resolve &Shell.transfer_demo_project/2
+    end
+
     field :stop_shell, :boolean do
       middleware Authenticated
       safe_resolve &Shell.stop/2

--- a/apps/worker/mix.exs
+++ b/apps/worker/mix.exs
@@ -56,7 +56,8 @@ defmodule Worker.MixProject do
   defp deps do
     [
       {:k8s_traffic_plug, github: "Financial-Times/k8s_traffic_plug"},
-      {:core, in_umbrella: true}
+      {:core, in_umbrella: true},
+      {:email, in_umbrella: true}
     ]
   end
 end


### PR DESCRIPTION
## Summary

This will allow users to reparent their demo project under their own gcp organization to keep it running instead of recreating the cluster manually

## Test Plan
added unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.