### PR TITLE
Fix error message when a version is locked

### DIFF
--- a/apps/core/test/services/dependencies_test.exs
+++ b/apps/core/test/services/dependencies_test.exs
@@ -24,7 +24,7 @@ defmodule Core.Services.DependenciesTest do
       assert Dependencies.valid?(terraform.dependencies, user)
     end
 
-    test "If a dependency is locked, it will return false" do
+    test "If a dependency is locked, it will return a locked tuple" do
       chart     = insert(:chart)
       terraform = insert(:terraform)
       user      = insert(:user)
@@ -43,7 +43,7 @@ defmodule Core.Services.DependenciesTest do
         %{type: :terraform, repo: terraform.repository.name, name: terraform.name}
       ]})
 
-      refute Dependencies.valid?(terraform.dependencies, user)
+      {:locked, _} = Dependencies.valid?(terraform.dependencies, user)
     end
 
     test "If a dependency is missing it returns false" do


### PR DESCRIPTION
## Summary

This was previously providing a fairly cryptic message suggesting the version wasn't installed, we should instead explain explicitly its locked and how to unlock it


## Test Plan
changed unit test, ensured existing tests pass


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.