### PR TITLE
Add trending flag and update erlang version to 23.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 23.2
+erlang 23.3
 elixir 1.11.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,8 @@ asdf can be finnicky when instlalling erlang with mac, in which case you can res
 
 ```sh
 brew install erlang@23
-cp -r /opt/homebrew/opt/erlang@23/lib/erlang ~/.asdf/installs/erlang/23.2
-asdf reshim erlang 23.2
+cp -r /opt/homebrew/opt/erlang@23/lib/erlang ~/.asdf/installs/erlang/23.3
+asdf reshim erlang 23.3
 ```
 
 <!-- >

--- a/apps/core/lib/core/schema/repository.ex
+++ b/apps/core/lib/core/schema/repository.ex
@@ -37,6 +37,7 @@ defmodule Core.Schema.Repository do
     field :secrets,       :map
     field :private,       :boolean, default: false
     field :verified,      :boolean, default: false
+    field :trending,      :boolean, default: false
     field :category,      Category
     field :notes,         :binary
     field :git_url,       :string
@@ -181,7 +182,7 @@ defmodule Core.Schema.Repository do
   def ordered(query \\ __MODULE__, order \\ [asc: :name]),
     do: from(r in query, order_by: ^order)
 
-  @valid ~w(name publisher_id description documentation secrets private category verified notes default_tag git_url homepage readme main_branch)a
+  @valid ~w(name publisher_id description documentation secrets private category verified trending notes default_tag git_url homepage readme main_branch)a
 
   def changeset(model, attrs \\ %{}) do
     model

--- a/apps/core/priv/repo/migrations/20220915140425_add_trending_flag.exs
+++ b/apps/core/priv/repo/migrations/20220915140425_add_trending_flag.exs
@@ -1,0 +1,9 @@
+defmodule Core.Repo.Migrations.AddTrendingFlag do
+  use Ecto.Migration
+
+  def change do
+    alter table(:repositories) do
+      add :trending, :boolean, default: false
+    end
+  end
+end

--- a/apps/graphql/lib/graphql/schema/repository.ex
+++ b/apps/graphql/lib/graphql/schema/repository.ex
@@ -25,6 +25,7 @@ defmodule GraphQl.Schema.Repository do
     field :tags,           list_of(:tag_attributes)
     field :private,        :boolean
     field :verified,       :boolean
+    field :trending,       :boolean
     field :notes,          :string
     field :default_tag,    :string
     field :git_url,        :string
@@ -156,6 +157,7 @@ defmodule GraphQl.Schema.Repository do
     field :category,       :category
     field :private,        :boolean
     field :verified,       :boolean
+    field :trending,       :boolean
     field :notes,          :string
     field :default_tag,    :string
     field :git_url,        :string


### PR DESCRIPTION
## Summary
Closes ENG-635.

I needed to update erlang as right now brew installs `23.3.4.17` when using `erlang@23`.

## Test Plan

## Checklist
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.