### PR TITLE
Fix some icon sizes

### DIFF
--- a/www/src/components/repos/CreateRepository.js
+++ b/www/src/components/repos/CreateRepository.js
@@ -60,7 +60,7 @@ function ImagePicker({
             src={image.previewUrl}
           />
         )
-          : <PlusIcon size="20px" />}
+          : <PlusIcon size={20} />}
       </Box>
       <Box gap="xsmall">
         <Text size="small">{image ? image.file.name : 'Select an image'}</Text>

--- a/www/src/components/repos/EditInstallation.js
+++ b/www/src/components/repos/EditInstallation.js
@@ -106,7 +106,7 @@ export function EditInstallation({ installation, repository, onUpdate }) {
             <Text>Configuration saved</Text>
             <CloseIcon
               style={{ cursor: 'pointer' }}
-              size="15px"
+              size={15}
               onClick={() => setNotif(false)}
             />
           </Box>

--- a/www/src/components/repos/Integrations.js
+++ b/www/src/components/repos/Integrations.js
@@ -180,7 +180,7 @@ function SourceLink({ sourceUrl }) {
             color="focus"
           >Source code
           </Text>
-          <ArrowRightIcon size="12px" />
+          <ArrowRightIcon size={12} />
         </Box>
       </Anchor>
     </Box>
@@ -227,7 +227,7 @@ export function TagHeader({ tag, setTag }) {
         direction="row"
         onClick={() => setTag(null)}
       >
-        <CaretLeftIcon size="20px" />
+        <CaretLeftIcon size={20} />
         <Text weight={500}># {tag}</Text>
       </Box>
     </HoveredBackground>
@@ -323,7 +323,7 @@ function ViewAll({ repositoryId }) {
             view all
           </Text>
           <ArrowRightIcon
-            size="15px"
+            size={15}
             color="focus"
           />
         </Box>

--- a/www/src/components/repos/common/ImageVulnerabilities.js
+++ b/www/src/components/repos/common/ImageVulnerabilities.js
@@ -342,7 +342,7 @@ export default function ImageVulnerabilities() {
             description="...and feels pretty damn good about it."
             icon={(
               <DockerTagIcon
-                size="64px"
+                size={64}
                 color="text-primary-accent"
               />
             )}

--- a/www/src/components/shell/onboarding/cloud/gcp.js
+++ b/www/src/components/shell/onboarding/cloud/gcp.js
@@ -77,7 +77,7 @@ function FileInput({ updateCreds, gcp, setProject }) {
       textAlign="center"
     >
       <FileIcon
-        size="48"
+        size={48}
         color={loaded ? 'icon-success' : 'text'}
       />
       <Text

--- a/www/src/components/utils/List.tsx
+++ b/www/src/components/utils/List.tsx
@@ -13,7 +13,7 @@ type Hue = Required<CardProps>['hue']
 
 const ListContext = createContext<{ hue: Hue }>({ hue: 'default' })
 
-const LiBare = styled.li(({ $extendStyle }) => ({
+const LiBare = styled.li(({ $extendStyle }: { $extendStyle?: Record<string, any> }) => ({
   margin: 0,
   textIndent: 0,
   padding: 0,
@@ -28,7 +28,11 @@ const hueToBorderColor: Record<Hue, string> = {
   lightest: 'border-fill-three',
 }
 
-const ListItemInner = styled(LiBare)(({ theme, $last, $hue = 'default' }) => ({
+const ListItemInner = styled(LiBare)<{
+  $last?: boolean
+  $hue?: string
+  $first?: boolean
+}>(({ theme, $last = false, $hue = 'default' }) => ({
   padding: `${theme.spacing.xsmall}px ${theme.spacing.medium}px`,
   borderBottomStyle: $last ? 'none' : 'solid',
   borderColor: theme.colors[hueToBorderColor[$hue]] || 'transparent',

--- a/www/src/components/utils/ReturnToBeginning.js
+++ b/www/src/components/utils/ReturnToBeginning.js
@@ -10,7 +10,7 @@ export function ReturnToBeginning({ beginning }) {
     >
       <Button
         onClick={beginning}
-        endIcon={<CaretUpIcon size="small" />}
+        endIcon={<CaretUpIcon size={14} />}
         marginRight="100px"
         marginBottom="30px"
       >


### PR DESCRIPTION
Some icons didn't get their sizes set properly when I migrated them over to their design system equivalents. This fixes that. (also fixed some unrelated typescript errors that were blocking me in dev).

Problem:
<img width="1483" alt="Screen Shot 2022-09-16 at 1 31 04 PM" src="https://user-images.githubusercontent.com/85062/190703888-edfd4d48-8f6e-4759-99b2-9e04f1781093.png">

Solution:
<img width="1169" alt="Screen Shot 2022-09-16 at 11 03 55 AM" src="https://user-images.githubusercontent.com/85062/190703929-106eb899-d117-4e8d-8032-a533894e0034.png">
