### PR TITLE
Add validation for repository names

### DIFF
--- a/apps/api/test/api_web/controllers/auth_controller_test.exs
+++ b/apps/api/test/api_web/controllers/auth_controller_test.exs
@@ -83,7 +83,7 @@ defmodule ApiWeb.AuthControllerTest do
   describe "#refresh_license/2" do
     test "It can refresh the license for an installation", %{conn: conn} do
       publisher = insert(:publisher)
-      {:ok, repo} = Repositories.create_repository(%{name: "my repo", category: :data}, publisher.owner)
+      {:ok, repo} = Repositories.create_repository(%{name: "my-repo", category: :data}, publisher.owner)
 
       installation = insert(:installation, repository: repo)
       token = insert(:license_token, installation: installation)

--- a/apps/core/lib/core/schema/repository.ex
+++ b/apps/core/lib/core/schema/repository.ex
@@ -198,7 +198,7 @@ defmodule Core.Schema.Repository do
     |> cast_assoc(:shell)
     |> foreign_key_constraint(:publisher_id)
     |> cast_assoc(:integration_resource_definition)
-    |> validate_format(:name, ~r/^[a-z][-a-z0-9]*$/, message: "name must be formatted as a valid kubernetes namespace")
+    |> validate_format(:name, ~r/^[a-z0-9][-a-z0-9]*[a-z0-9]$/, message: "name must be formatted as a valid kubernetes namespace")
     |> unique_constraint(:name)
     |> validate_required([:name, :category])
     |> generate_uuid(:icon_id)

--- a/apps/core/lib/core/schema/repository.ex
+++ b/apps/core/lib/core/schema/repository.ex
@@ -198,6 +198,7 @@ defmodule Core.Schema.Repository do
     |> cast_assoc(:shell)
     |> foreign_key_constraint(:publisher_id)
     |> cast_assoc(:integration_resource_definition)
+    |> validate_format(:name, ~r/^[a-z][-a-z0-9]*$/, message: "name must be formatted as a valid kubernetes namespace")
     |> unique_constraint(:name)
     |> validate_required([:name, :category])
     |> generate_uuid(:icon_id)

--- a/apps/core/test/services/repositories_test.exs
+++ b/apps/core/test/services/repositories_test.exs
@@ -340,7 +340,7 @@ defmodule Core.Services.RepositoriesTest do
     test "It can generate an ecrypted license for an installation" do
       publisher = insert(:publisher)
       {:ok, repo} = Repositories.create_repository(%{
-        name: "my repo",
+        name: "my-repo",
         category: :data,
         secrets: %{"token" => "a"}
       }, publisher.owner)
@@ -361,7 +361,7 @@ defmodule Core.Services.RepositoriesTest do
 
     test "It can generate licenses for payed plans" do
       publisher = insert(:publisher)
-      {:ok, repo} = Repositories.create_repository(%{name: "my repo", category: :data}, publisher.owner)
+      {:ok, repo} = Repositories.create_repository(%{name: "my-repo", category: :data}, publisher.owner)
       installation = insert(:installation, repository: repo)
       plan = insert(:plan,
         repository: repo,
@@ -393,7 +393,7 @@ defmodule Core.Services.RepositoriesTest do
 
     test "It will not generate licenses if there is no subscription for a non-free repo" do
       publisher = insert(:publisher)
-      {:ok, repo} = Repositories.create_repository(%{name: "my repo", category: :data}, publisher.owner)
+      {:ok, repo} = Repositories.create_repository(%{name: "my-repo", category: :data}, publisher.owner)
       installation = insert(:installation, repository: repo)
       insert(:plan, repository: repo)
 

--- a/apps/graphql/test/mutations/repository_mutation_test.exs
+++ b/apps/graphql/test/mutations/repository_mutation_test.exs
@@ -16,7 +16,7 @@ defmodule GraphQl.RepositoryMutationsTest do
           }
         }
       """, %{"attrs" => %{
-        "name" => "my repo",
+        "name" => "my-repo",
         "category" => "DATA",
         "integration_resource_definition" => %{
           "name" => "definition",
@@ -30,7 +30,7 @@ defmodule GraphQl.RepositoryMutationsTest do
       }}, %{current_user: user})
 
       assert repo["id"]
-      assert repo["name"] == "my repo"
+      assert repo["name"] == "my-repo"
       assert repo["publisher"]["id"] == id
     end
 
@@ -51,7 +51,7 @@ defmodule GraphQl.RepositoryMutationsTest do
           }
         }
       """, %{"id" => pub.id, "attrs" => %{
-        "name" => "my repo",
+        "name" => "my-repo",
         "category" => "DATA",
         "integration_resource_definition" => %{
           "name" => "definition",
@@ -65,7 +65,7 @@ defmodule GraphQl.RepositoryMutationsTest do
       }}, %{current_user: user})
 
       assert repo["id"]
-      assert repo["name"] == "my repo"
+      assert repo["name"] == "my-repo"
       assert repo["publisher"]["id"] == pub.id
     end
   end
@@ -84,7 +84,7 @@ defmodule GraphQl.RepositoryMutationsTest do
         }
       """, %{
         "repositoryName" => repo.name,
-        "name" => "Updated Repo",
+        "name" => "updated-repo",
         "resource" => %{
           "name" => "definition",
           "spec" => [
@@ -97,7 +97,7 @@ defmodule GraphQl.RepositoryMutationsTest do
       }, %{current_user: user})
 
       assert updated["id"] == repo.id
-      assert updated["name"] == "Updated Repo"
+      assert updated["name"] == "updated-repo"
 
       %{integration_resource_definition: def} = Core.Repo.preload(refetch(repo), [:integration_resource_definition])
 

--- a/apps/graphql/test/queries/repository_queries_test.exs
+++ b/apps/graphql/test/queries/repository_queries_test.exs
@@ -294,7 +294,7 @@ defmodule GraphQl.RepositoryQueriesTest do
 
     test "publishers can see their public keys" do
       %{owner: user} = insert(:publisher)
-      {:ok, repo} = Core.Services.Repositories.create_repository(%{name: "my repo", category: :data}, user)
+      {:ok, repo} = Core.Services.Repositories.create_repository(%{name: "my-repo", category: :data}, user)
 
       {:ok, %{data: %{"repository" => found}}} = run_query("""
         query Repo($id: ID!) {
@@ -311,7 +311,7 @@ defmodule GraphQl.RepositoryQueriesTest do
 
     test "nonpublishers cannot see public keys" do
       %{owner: user} = insert(:publisher)
-      {:ok, repo} = Core.Services.Repositories.create_repository(%{name: "my repo", category: :data}, user)
+      {:ok, repo} = Core.Services.Repositories.create_repository(%{name: "my-repo", category: :data}, user)
 
       {:ok, %{data: %{"repository" => found}}} = run_query("""
         query Repo($id: ID!) {


### PR DESCRIPTION
## Summary
Repo names need to be valid k8s namespaces, but we need to enforce this in the api.  This regex should do a good enough job of that.


## Test Plan
fix unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.