### PR TITLE
Add stack details view

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -57,7 +57,7 @@
     "moment": "2.29.4",
     "phoenix": "1.6.11",
     "pluralsh-absinthe-socket-apollo-link": "0.2.0",
-    "pluralsh-design-system": "1.210.0",
+    "pluralsh-design-system": "1.211.0",
     "prop-types": "15.8.1",
     "query-string": "7.1.1",
     "randomcolor": "0.6.2",

--- a/www/src/components/Plural.js
+++ b/www/src/components/Plural.js
@@ -61,6 +61,8 @@ import PackageDependencies from './repos/common/PackageDependencies'
 import ImagePullMetrics from './repos/common/ImagePullMetrics'
 import ImageVulnerabilities from './repos/common/ImageVulnerabilities'
 import Publisher from './publisher/Publisher'
+import StackApps from './stack/StackApps'
+import Stack from './stack/Stack'
 
 function EditBilling(props) {
   return (
@@ -244,6 +246,16 @@ export function PluralInner() {
               <Route
                 path="edit"
                 element={<RepositoryEdit />}
+              />
+            </Route>
+            {/* --- STACK --- */}
+            <Route
+              path="/stack/:name"
+              element={<Stack />}
+            >
+              <Route
+                index
+                element={<StackApps />}
               />
             </Route>
             {/* --- HELM CHARTS --- */}

--- a/www/src/components/incidents/Responses.js
+++ b/www/src/components/incidents/Responses.js
@@ -110,8 +110,6 @@ function StatusSelector({ statuses, setStatuses }) {
     }
   }, [hasStatus, statuses, setStatuses])
 
-  console.log(statuses)
-
   return (
     <>
       <Box

--- a/www/src/components/marketplace/MarketplaceRepositories.js
+++ b/www/src/components/marketplace/MarketplaceRepositories.js
@@ -155,8 +155,6 @@ function MarketplaceRepositories({ installed, publisher }) {
     return title
   }
 
-  console.log(resultRepositories)
-
   return (
     <Flex
       direction="column"

--- a/www/src/components/marketplace/MarketplaceRepositories.js
+++ b/www/src/components/marketplace/MarketplaceRepositories.js
@@ -10,7 +10,6 @@ import {
   FiltersIcon,
   Input,
   MagnifyingGlassIcon,
-  RepositoryCard,
   Tab,
   TabList,
   TabPanel,
@@ -37,7 +36,7 @@ import { MARKETPLACE_QUERY } from './queries'
 
 import MarketplaceSidebar from './MarketplaceSidebar'
 import MarketplaceStacks from './MarketplaceStacks'
-import { fillEmptyColumns, flexBasis } from './utils'
+import { RepoCardList } from './RepoCardList'
 
 const searchOptions = {
   keys: ['name', 'description', 'tags.tag'],
@@ -54,56 +53,6 @@ const chipProps = {
 }
 
 const sidebarWidth = 256 - 32
-
-function RepoCardList({
-  repositories, repoProps, maxWidth, stretchLastRow = false, size = 'small', ...props
-}) {
-  return (
-    <Flex
-      mx={-1}
-      align="stretch"
-      wrap="wrap"
-      {...props}
-    >
-      {
-        repositories.map(repository => (
-          <Flex
-            key={`${repository.id}flex`}
-            px={0.75}
-            marginBottom="large"
-            width="auto"
-            flexBasis={flexBasis}
-            flexGrow={1}
-            flexShrink={1}
-            minWidth="250px"
-            maxWidth={maxWidth || '800px'}
-          >
-            <RepositoryCard
-              key={repository.id}
-              as={Link}
-              to={`/repository/${repository.id}`}
-              color="text"
-              textDecoration="none"
-              width="100%"
-              title={repository.name}
-              imageUrl={repository.darkIcon || repository.icon}
-              publisher={repository.publisher?.name}
-              description={repository.description}
-              tags={repository.tags.map(({ tag }) => tag)}
-              priv={repository.private}
-              installed={!!repository.installation}
-              verified={repository.verified}
-              trending={repository.trending}
-              size={size}
-              {...repoProps}
-            />
-          </Flex>
-        ))
-      }
-      {!stretchLastRow && fillEmptyColumns(10)}
-    </Flex>
-  )
-}
 
 const StyledTabPanel = styled(TabPanel)(() => ({
   display: 'flex',
@@ -205,6 +154,8 @@ function MarketplaceRepositories({ installed, publisher }) {
 
     return title
   }
+
+  console.log(resultRepositories)
 
   return (
     <Flex

--- a/www/src/components/marketplace/MarketplaceStacks.tsx
+++ b/www/src/components/marketplace/MarketplaceStacks.tsx
@@ -2,6 +2,8 @@ import { useQuery } from '@apollo/client'
 import { Flex, H1 } from 'honorable'
 import { Divider, StackCard } from 'pluralsh-design-system'
 
+import { useNavigate } from 'react-router-dom'
+
 import { fillEmptyColumns, flexBasis } from './utils'
 
 import { STACKS_QUERY } from './queries'
@@ -9,6 +11,7 @@ import { STACKS_QUERY } from './queries'
 const hues = ['blue', 'green', 'yellow', 'red']
 
 export default function MarketplaceStacks() {
+  const navigate = useNavigate()
   const { data } = useQuery(STACKS_QUERY, { featured: true } as any)
 
   if (!data) return
@@ -44,6 +47,7 @@ export default function MarketplaceStacks() {
               description={stack.description}
               apps={apps(stack)}
               hue={hue(i)}
+              onClick={() => navigate(`/stack/${stack.name}`)}
             />
           </Flex>
         ))}

--- a/www/src/components/marketplace/MarketplaceStacks.tsx
+++ b/www/src/components/marketplace/MarketplaceStacks.tsx
@@ -18,7 +18,7 @@ export default function MarketplaceStacks() {
 
   const { stacks: { edges } } = data
   const apps = ({ collections: c }) => (c?.length > 0
-    ? c[0].bundles.map(({ recipe: { repository: { name, icon } } }) => ({ name, imageUrl: icon })) : [])
+    ? c[0].bundles?.map(({ recipe: { repository: { name, icon } } }) => ({ name, imageUrl: icon })) : [])
   const hue = i => hues[i % hues.length]
 
   return (

--- a/www/src/components/marketplace/RepoCardList.tsx
+++ b/www/src/components/marketplace/RepoCardList.tsx
@@ -1,0 +1,55 @@
+import { Flex } from 'honorable'
+import { RepositoryCard } from 'pluralsh-design-system'
+import { Link } from 'react-router-dom'
+
+import { fillEmptyColumns, flexBasis } from './utils'
+
+export function RepoCardList({
+  repositories, repoProps = {}, maxWidth = '800px', stretchLastRow = false, size = 'small', ...props
+}) {
+  return (
+    <Flex
+      mx={-1}
+      align="stretch"
+      wrap="wrap"
+      {...props}
+    >
+      {
+        repositories?.map(repository => (
+          <Flex
+            key={`${repository.id}flex`}
+            px={0.75}
+            marginBottom="large"
+            width="auto"
+            flexBasis={flexBasis}
+            flexGrow={1}
+            flexShrink={1}
+            minWidth="250px"
+            maxWidth={maxWidth}
+          >
+            <RepositoryCard
+              key={repository.id}
+              as={Link}
+              to={`/repository/${repository.id}`}
+              color="text"
+              textDecoration="none"
+              width="100%"
+              title={repository.name}
+              imageUrl={repository.darkIcon || repository.icon}
+              publisher={repository.publisher?.name}
+              description={repository.description}
+              tags={repository.tags.map(({ tag }) => tag)}
+              priv={repository.private}
+              installed={!!repository.installation}
+              verified={repository.verified}
+              trending={repository.trending}
+              size={size}
+              {...repoProps}
+            />
+          </Flex>
+        ))
+      }
+      {!stretchLastRow && fillEmptyColumns(10)}
+    </Flex>
+  )
+}

--- a/www/src/components/profile/Profile.js
+++ b/www/src/components/profile/Profile.js
@@ -63,8 +63,6 @@ export function Profile() {
     }
   }, [files])
 
-  console.log('avatar', avatar)
-
   return (
     <Box fill>
       <PageTitle heading="Profile" />

--- a/www/src/components/repos/EditInstallation.js
+++ b/www/src/components/repos/EditInstallation.js
@@ -94,9 +94,7 @@ export function EditInstallation({ installation, repository, onUpdate }) {
       {notif && (
         <Pill
           background="status-ok"
-          onClose={() => {
-            console.log('wtf'); setNotif(false)
-          }}
+          onClose={() => setNotif(false)}
         >
           <Box
             direction="row"

--- a/www/src/components/stack/Stack.tsx
+++ b/www/src/components/stack/Stack.tsx
@@ -9,7 +9,7 @@ import {
 } from 'components/layout/ResponsiveLayout'
 
 import {
-  RocketIcon, StackIcon, Tab, TabList, TabPanel,
+  StackIcon, Tab, TabList, TabPanel,
 } from 'pluralsh-design-system'
 
 import { useRef } from 'react'

--- a/www/src/components/stack/Stack.tsx
+++ b/www/src/components/stack/Stack.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@apollo/client'
-import { Outlet, useParams } from 'react-router-dom'
-import { Flex } from 'honorable'
+import { Outlet, useLocation, useParams } from 'react-router-dom'
+import { Div, Flex, P } from 'honorable'
 
 import { GoBack } from 'components/utils/GoBack'
 
@@ -8,9 +8,13 @@ import {
   ResponsiveLayoutContentContainer, ResponsiveLayoutSidecarContainer, ResponsiveLayoutSidenavContainer, ResponsiveLayoutSpacer,
 } from 'components/layout/ResponsiveLayout'
 
-import { TabPanel } from 'pluralsh-design-system'
+import {
+  RocketIcon, Tab, TabList, TabPanel,
+} from 'pluralsh-design-system'
 
 import { useRef } from 'react'
+
+import { LinkTabWrap } from 'components/utils/Tabs'
 
 import { LoopingLogo } from '../utils/AnimatedLogo'
 
@@ -18,6 +22,77 @@ import TopBar from '../layout/TopBar'
 
 import { STACK_QUERY } from './queries'
 import { StackContext } from './types'
+
+const DIRECTORY = [
+  { label: 'Stack applications', path: '' },
+]
+
+function Sidenav({ stack }: any) {
+  const { pathname } = useLocation()
+  const pathPrefix = `/stack/${stack.name}`
+  const currentTab = DIRECTORY
+    .sort((a, b) => b.path.length - a.path.length)
+    .find(tab => pathname?.startsWith(`${pathPrefix}${tab.path}`))
+  const tabStateRef = useRef<any>()
+
+  return (
+    <Flex
+      paddingVertical="medium"
+      paddingLeft="medium"
+      width={240}
+      flexShrink={0}
+      direction="column"
+    >
+      <Flex
+        align="center"
+        gap="medium"
+      >
+        <Flex
+          align="center"
+          justify="center"
+          padding="xsmall"
+          backgroundColor="fill-one"
+          border="1px solid border"
+          borderRadius="medium"
+          height={64}
+          width={64}
+        >
+          <RocketIcon size={32} />
+        </Flex>
+        <Div><P subtitle1>{stack.name}</P></Div>
+      </Flex>
+      <P
+        body2
+        color="text-xlight"
+        marginTop="medium"
+      >
+        Created by&nbsp;{stack.creator.name}
+      </P>
+      <Div
+        marginTop="medium"
+        marginLeft="minus-medium"
+      >
+        <TabList
+          stateRef={tabStateRef}
+          stateProps={{
+            orientation: 'vertical',
+            selectedKey: currentTab?.path,
+          }}
+        >
+          {DIRECTORY.map(({ label, path }) => (
+            <LinkTabWrap
+              key={path}
+              textValue={label}
+              to={`${pathPrefix}${path}`}
+            >
+              <Tab>{label}</Tab>
+            </LinkTabWrap>
+          ))}
+        </TabList>
+      </Div>
+    </Flex>
+  )
+}
 
 export default function Stack() {
   const { name } = useParams()
@@ -60,7 +135,10 @@ export default function Stack() {
         paddingRight="medium"
       >
         <ResponsiveLayoutSidenavContainer>
-          {/* <RepositorySideNav tabStateRef={tabStateRef} /> */}
+          <Sidenav
+            stack={stack}
+            tabStateRef={tabStateRef}
+          />
         </ResponsiveLayoutSidenavContainer>
         <ResponsiveLayoutSpacer />
         <TabPanel

--- a/www/src/components/stack/Stack.tsx
+++ b/www/src/components/stack/Stack.tsx
@@ -1,0 +1,75 @@
+import { useQuery } from '@apollo/client'
+import { Outlet, useParams } from 'react-router-dom'
+import { Flex } from 'honorable'
+
+import { GoBack } from 'components/utils/GoBack'
+
+import { ResponsiveLayoutSidecarContainer, ResponsiveLayoutSidenavContainer, ResponsiveLayoutSpacer } from 'components/layout/ResponsiveLayout'
+
+import { LoopingLogo } from '../utils/AnimatedLogo'
+
+import TopBar from '../layout/TopBar'
+
+import { STACK_QUERY } from './queries'
+
+export default function Stack() {
+  const { name } = useParams()
+  const { data } = useQuery(STACK_QUERY, { variables: { name, provider: 'AWS' } })
+  // const tabStateRef = useRef()
+
+  if (!data) {
+    return (
+      <Flex
+        paddingTop={388}
+        marginLeft={-80}
+        align="center"
+        justify="center"
+      >
+        <LoopingLogo />
+      </Flex>
+    )
+  }
+
+  const { stack } = data
+
+  return (
+    <Flex
+      height="100%"
+      maxHeight="100%"
+      direction="column"
+      overflowY="hidden"
+    >
+      <TopBar>
+        <GoBack
+          text="Back to marketplace"
+          link="/marketplace"
+        />
+      </TopBar>
+      <Flex
+        flexGrow={1}
+        height={0}
+        overflowX="hidden"
+        paddingLeft="medium"
+        paddingRight="medium"
+      >
+        <ResponsiveLayoutSidenavContainer>
+          {/* <RepositorySideNav tabStateRef={tabStateRef} /> */}
+        </ResponsiveLayoutSidenavContainer>
+        <ResponsiveLayoutSpacer />
+        <Outlet context={{ stack }} />
+        {/* <TabPanel
+          as={
+            <ResponsiveLayoutContentContainer />
+          }
+          stateRef={tabStateRef}
+        >
+          <Outlet />
+        </TabPanel> */}
+        <ResponsiveLayoutSidecarContainer>
+          {/* <RepositorySideCar /> */}
+        </ResponsiveLayoutSidecarContainer>
+        <ResponsiveLayoutSpacer />
+      </Flex>
+    </Flex>
+  )
+}

--- a/www/src/components/stack/Stack.tsx
+++ b/www/src/components/stack/Stack.tsx
@@ -9,7 +9,7 @@ import {
 } from 'components/layout/ResponsiveLayout'
 
 import {
-  RocketIcon, Tab, TabList, TabPanel,
+  RocketIcon, StackIcon, Tab, TabList, TabPanel,
 } from 'pluralsh-design-system'
 
 import { useRef } from 'react'
@@ -57,7 +57,10 @@ function Sidenav({ stack }: any) {
           height={64}
           width={64}
         >
-          <RocketIcon size={32} />
+          <StackIcon
+            color="text-primary-accent"
+            size={32}
+          />
         </Flex>
         <Div><P subtitle1>{stack.name}</P></Div>
       </Flex>

--- a/www/src/components/stack/Stack.tsx
+++ b/www/src/components/stack/Stack.tsx
@@ -148,7 +148,7 @@ export default function Stack() {
           <Outlet context={{ stack } as StackContext} />
         </TabPanel>
         <ResponsiveLayoutSidecarContainer>
-          {/* <RepositorySideCar /> */}
+          {/* TODO: <RepositorySideCar /> */}
         </ResponsiveLayoutSidecarContainer>
         <ResponsiveLayoutSpacer />
       </Flex>

--- a/www/src/components/stack/Stack.tsx
+++ b/www/src/components/stack/Stack.tsx
@@ -4,18 +4,25 @@ import { Flex } from 'honorable'
 
 import { GoBack } from 'components/utils/GoBack'
 
-import { ResponsiveLayoutSidecarContainer, ResponsiveLayoutSidenavContainer, ResponsiveLayoutSpacer } from 'components/layout/ResponsiveLayout'
+import {
+  ResponsiveLayoutContentContainer, ResponsiveLayoutSidecarContainer, ResponsiveLayoutSidenavContainer, ResponsiveLayoutSpacer,
+} from 'components/layout/ResponsiveLayout'
+
+import { TabPanel } from 'pluralsh-design-system'
+
+import { useRef } from 'react'
 
 import { LoopingLogo } from '../utils/AnimatedLogo'
 
 import TopBar from '../layout/TopBar'
 
 import { STACK_QUERY } from './queries'
+import { StackContext } from './types'
 
 export default function Stack() {
   const { name } = useParams()
   const { data } = useQuery(STACK_QUERY, { variables: { name, provider: 'AWS' } })
-  // const tabStateRef = useRef()
+  const tabStateRef = useRef()
 
   if (!data) {
     return (
@@ -56,15 +63,12 @@ export default function Stack() {
           {/* <RepositorySideNav tabStateRef={tabStateRef} /> */}
         </ResponsiveLayoutSidenavContainer>
         <ResponsiveLayoutSpacer />
-        <Outlet context={{ stack }} />
-        {/* <TabPanel
-          as={
-            <ResponsiveLayoutContentContainer />
-          }
+        <TabPanel
+          as={<ResponsiveLayoutContentContainer />}
           stateRef={tabStateRef}
         >
-          <Outlet />
-        </TabPanel> */}
+          <Outlet context={{ stack } as StackContext} />
+        </TabPanel>
         <ResponsiveLayoutSidecarContainer>
           {/* <RepositorySideCar /> */}
         </ResponsiveLayoutSidecarContainer>

--- a/www/src/components/stack/StackApps.tsx
+++ b/www/src/components/stack/StackApps.tsx
@@ -7,7 +7,8 @@ import { StackContext } from './types'
 
 export default function StackApps() {
   const { stack }: StackContext = useOutletContext()
-  const repositories = stack?.bundles?.map(({ repository }) => repository)
+  const { collections: c } = stack
+  const repositories = c?.length > 0 ? c[0].bundles?.map(({ recipe: { repository: r } }) => r) : []
 
   return (
     <Flex
@@ -21,7 +22,7 @@ export default function StackApps() {
         heading="Stack applications"
         paddingTop="medium"
       >
-        {/* <Flex display-desktop-up="none"><RepositoryActions /></Flex> */}
+        {/* TODO: <Flex display-desktop-up="none"><RepositoryActions /></Flex> */}
       </PageTitle>
       <Flex
         direction="column"
@@ -36,7 +37,7 @@ export default function StackApps() {
           body1
           marginBottom="medium"
         >
-          {stack.description}
+          {stack?.description}
         </P>
         <RepoCardList
           repositories={repositories}

--- a/www/src/components/stack/StackApps.tsx
+++ b/www/src/components/stack/StackApps.tsx
@@ -1,9 +1,13 @@
-import { Flex } from 'honorable'
+import { RepoCardList } from 'components/marketplace/RepoCardList'
+import { Flex, P } from 'honorable'
 import { PageTitle } from 'pluralsh-design-system'
 import { useOutletContext } from 'react-router-dom'
 
+import { StackContext } from './types'
+
 export default function StackApps() {
-  const { stack }: any = useOutletContext()
+  const { stack }: StackContext = useOutletContext()
+  const repositories = stack?.bundles?.map(({ repository }) => repository)
 
   return (
     <Flex
@@ -28,7 +32,13 @@ export default function StackApps() {
         marginBottom="medium"
         paddingRight="small"
       >
-        {stack.description}
+        <P
+          body1
+          marginBottom="medium"
+        >
+          {stack.description}
+        </P>
+        <RepoCardList repositories={repositories} />
       </Flex>
     </Flex>
   )

--- a/www/src/components/stack/StackApps.tsx
+++ b/www/src/components/stack/StackApps.tsx
@@ -38,7 +38,10 @@ export default function StackApps() {
         >
           {stack.description}
         </P>
-        <RepoCardList repositories={repositories} />
+        <RepoCardList
+          repositories={repositories}
+          mx={-0.75}
+        />
       </Flex>
     </Flex>
   )

--- a/www/src/components/stack/StackApps.tsx
+++ b/www/src/components/stack/StackApps.tsx
@@ -7,8 +7,6 @@ import { StackContext } from './types'
 
 export default function StackApps() {
   const { stack }: StackContext = useOutletContext()
-  const { collections: c } = stack
-  const repositories = c?.length > 0 ? c[0].bundles?.map(({ recipe: { repository: r } }) => r) : []
 
   return (
     <Flex
@@ -40,7 +38,7 @@ export default function StackApps() {
           {stack?.description}
         </P>
         <RepoCardList
-          repositories={repositories}
+          repositories={stack?.bundles?.map(({ repository }) => repository)}
           mx={-0.75}
         />
       </Flex>

--- a/www/src/components/stack/StackApps.tsx
+++ b/www/src/components/stack/StackApps.tsx
@@ -1,0 +1,35 @@
+import { Flex } from 'honorable'
+import { PageTitle } from 'pluralsh-design-system'
+import { useOutletContext } from 'react-router-dom'
+
+export default function StackApps() {
+  const { stack }: any = useOutletContext()
+
+  return (
+    <Flex
+      direction="column"
+      paddingRight="small"
+      borderRadius="large"
+      position="relative"
+      overflowY="hidden"
+    >
+      <PageTitle
+        heading="Stack applications"
+        paddingTop="medium"
+      >
+        {/* <Flex display-desktop-up="none"><RepositoryActions /></Flex> */}
+      </PageTitle>
+      <Flex
+        direction="column"
+        flexGrow={1}
+        overflowY="auto"
+        color="text-light"
+        paddingBottom="xlarge"
+        marginBottom="medium"
+        paddingRight="small"
+      >
+        {stack.description}
+      </Flex>
+    </Flex>
+  )
+}

--- a/www/src/components/stack/queries.ts
+++ b/www/src/components/stack/queries.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client'
+import { StackFragment } from 'models/repo'
+
+export const STACK_QUERY = gql`
+  query Stack($name: String!, $provider: Provider!) {
+    stack(name: $name, provider: $provider) {
+      ...StackFragment
+    }
+  }
+  ${StackFragment}
+`

--- a/www/src/components/stack/queries.ts
+++ b/www/src/components/stack/queries.ts
@@ -5,6 +5,15 @@ export const STACK_QUERY = gql`
   query Stack($name: String!, $provider: Provider!) {
     stack(name: $name, provider: $provider) {
       ...StackFragment
+      bundles {
+        id
+        repository {
+          ...RepoFragment
+          tags {
+            tag
+          }
+        }
+      }
     }
   }
   ${StackFragment}

--- a/www/src/components/stack/types.ts
+++ b/www/src/components/stack/types.ts
@@ -1,0 +1,3 @@
+export interface StackContext {
+  stack: any
+}

--- a/www/src/components/utils/SaveButton.tsx
+++ b/www/src/components/utils/SaveButton.tsx
@@ -32,7 +32,6 @@ export default function SaveButton({
       }, 2000)
 
       return () => {
-        console.log('clear timeout')
         setShowSaved(false)
         clearTimeout(timeout)
       }

--- a/www/src/models/repo.js
+++ b/www/src/models/repo.js
@@ -50,8 +50,10 @@ export const StackFragment = gql`
       bundles {
         recipe {
           repository {
-            name
-            icon
+            ...RepoFragment
+            tags {
+              tag
+            }
           }
         }
       }

--- a/www/src/models/repo.js
+++ b/www/src/models/repo.js
@@ -19,6 +19,7 @@ export const RepoFragment = gql`
     darkIcon
     private
     trending
+    verified
     category
     oauthSettings { uriFormat authMethod }
     publisher { ...PublisherFragment }

--- a/www/src/models/repo.js
+++ b/www/src/models/repo.js
@@ -32,6 +32,10 @@ export const StackFragment = gql`
     name
     description
     featured
+    creator { 
+      id
+      name
+    }
     bundles {
       repository {
         ...RepoFragment

--- a/www/src/models/repo.js
+++ b/www/src/models/repo.js
@@ -32,6 +32,14 @@ export const StackFragment = gql`
     name
     description
     featured
+    bundles {
+      repository {
+        ...RepoFragment
+        tags {
+          tag
+        }
+      }
+    }
     collections {
       provider
       bundles {
@@ -44,6 +52,7 @@ export const StackFragment = gql`
       }
     }
   }
+  ${RepoFragment}
 `
 
 export const InstallationFragment = gql`

--- a/www/src/models/repo.js
+++ b/www/src/models/repo.js
@@ -37,14 +37,6 @@ export const StackFragment = gql`
       id
       name
     }
-    bundles {
-      repository {
-        ...RepoFragment
-        tags {
-          tag
-        }
-      }
-    }
     collections {
       provider
       bundles {

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -16781,9 +16781,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pluralsh-design-system@npm:1.210.0":
-  version: 1.210.0
-  resolution: "pluralsh-design-system@npm:1.210.0"
+"pluralsh-design-system@npm:1.211.0":
+  version: 1.211.0
+  resolution: "pluralsh-design-system@npm:1.211.0"
   dependencies:
     "@floating-ui/react-dom-interactions": 0.8.1
     "@react-aria/button": 3.6.1
@@ -16818,7 +16818,7 @@ __metadata:
     react-dom: ">=16.0.0"
     react-transition-group: ">=4.4.2"
     styled-components: ">=5.3.5"
-  checksum: f26b3421afb4f80c3c138f619518f2ad56c2e9d68c6cc9476f9b3470d637ef3ec232dccc98c4cf93de175c356541ee758478d3131b49b882b66374b0ffceeabd
+  checksum: 92cb4aa3c3a2f49ec61aba60e00f4ba79947211079131c7d7690465de368585ddd2a441e449df4c429494554fd57d0b1afbde51f81e6c0ab248d76b7f97c5aa5
   languageName: node
   linkType: hard
 
@@ -23152,7 +23152,7 @@ __metadata:
     moment: 2.29.4
     phoenix: 1.6.11
     pluralsh-absinthe-socket-apollo-link: 0.2.0
-    pluralsh-design-system: 1.210.0
+    pluralsh-design-system: 1.211.0
     postcss-import: 8.2.0
     prop-types: 15.8.1
     query-string: 7.1.1


### PR DESCRIPTION
## Summary
<img width="1459" alt="Zrzut ekranu 2022-09-19 o 14 24 57" src="https://user-images.githubusercontent.com/2823399/191016570-858b9ce3-0772-4366-a67c-d223f14f4904.png">

Notes:
- Similar to marketplace page provider-specific bundle is used to display stack details. 
- `Published by ...` is replaced with `Created by ...` without any links because it wasn't working and in the API there is `creator` field not `publisher`.
- There is no `verified` field on the stack in the API so it is not added.

[Figma design](https://www.figma.com/file/HQRum7isI8qu0pcOLyCOMk/Plural-Stacks?node-id=159%3A32883).

Related to ENG-617.

## Test Plan

## Checklist
- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.