### PR TITLE
ENG-723 - Remove "confirm email" toast during net-new users onboarding.

### DIFF
--- a/www/src/components/layout/Sidebar.js
+++ b/www/src/components/layout/Sidebar.js
@@ -25,7 +25,7 @@ import {
 
 import { getPreviousUserData, wipeToken } from '../../helpers/authentication'
 import { CurrentUserContext, handlePreviousUserClick } from '../login/CurrentUser'
-import useOnboarded from '../shell/onboarding/useOnboarded'
+import { useIsCurrentlyOnboarding } from '../shell/onboarding/useOnboarded'
 
 import CreatePublisherModal from '../publisher/CreatePublisherModal'
 
@@ -35,13 +35,9 @@ export const SIDEBAR_ICON_HEIGHT = '40px'
 export const SIDEBAR_WIDTH = '224px'
 export const SMALL_WIDTH = '60px'
 
-function isOnboarding(fresh, currentPath) {
-  return fresh && currentPath.endsWith('/shell')
-}
-
 function SidebarWrapper() {
   const me = useContext(CurrentUserContext)
-  const { fresh } = useOnboarded()
+  const isCurrentlyOnboarding = useIsCurrentlyOnboarding()
   const { pathname } = useLocation()
 
   const items = [
@@ -79,7 +75,7 @@ function SidebarWrapper() {
       {({ notificationsCount }) => (
         <Sidebar
           transition="width 300ms ease, opacity 200ms ease"
-          style={isOnboarding(fresh, pathname) ? {
+          style={isCurrentlyOnboarding ? {
             width: '0',
             opacity: '0',
           } : null}

--- a/www/src/components/shell/onboarding/useOnboarded.js
+++ b/www/src/components/shell/onboarding/useOnboarded.js
@@ -1,8 +1,8 @@
 import { useMutation } from '@apollo/client'
 import { useContext } from 'react'
+import { useLocation } from 'react-router-dom'
 
 import { CurrentUserContext } from '../../login/CurrentUser'
-
 import { OnboardingStatus } from '../../profile/types'
 import { UPDATE_USER } from '../../users/queries'
 
@@ -16,7 +16,9 @@ function useOnboarded() {
   })
 
   const onboarding = me.onboarding || OnboardingStatus.NEW
-  const fresh = onboarding === OnboardingStatus.NEW || !!localStorage.getItem(FORCE_ONBOARDING)
+  const fresh
+    = onboarding === OnboardingStatus.NEW
+    || !!localStorage.getItem(FORCE_ONBOARDING)
 
   return {
     mutation: fresh ? mutation : () => Promise.resolve(),
@@ -25,3 +27,10 @@ function useOnboarded() {
 }
 
 export default useOnboarded
+
+export function useIsCurrentlyOnboarding() {
+  const { fresh } = useOnboarded()
+  const { pathname } = useLocation()
+
+  return fresh && pathname.startsWith('/shell')
+}

--- a/www/src/components/users/EmailConfirmation.js
+++ b/www/src/components/users/EmailConfirmation.js
@@ -9,6 +9,7 @@ import { useParams } from 'react-router-dom'
 
 import { Icon } from 'components/utils/IconOld'
 
+import { useIsCurrentlyOnboarding } from '../shell/onboarding/useOnboarded'
 import { CurrentUserContext } from '../login/CurrentUser'
 import { Alert, AlertStatus, GqlError } from '../utils/Alert'
 import { LoopingLogo } from '../utils/AnimatedLogo'
@@ -64,10 +65,11 @@ export function VerifyEmailConfirmed() {
     variables: { attributes: { email: me.email, type: ResetTokenType.EMAIL } },
     onCompleted: () => setOpen(false),
   })
+  const isCurrentlyOnboarding = useIsCurrentlyOnboarding()
 
   const close = useCallback(() => setOpen(false), [setOpen])
 
-  if (me.emailConfirmed || me.serviceAccount || !open) return null
+  if (me.emailConfirmed || me.serviceAccount || !open || isCurrentlyOnboarding) return null
 
   return (
     <Layer


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->
Hides the email confirmation banner when user is in the initial onboarding process with the sidebar hidden. Shares the same logic as determining whether to hide the sidebar.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Tested manually with a new account

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.