### PR TITLE
ENG-732 - Resolve "install plural console" issues with onboarding flow.

### DIFF
--- a/www/src/components/shell/CloudShell.tsx
+++ b/www/src/components/shell/CloudShell.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from 'react'
 import { useMutation, useQuery } from '@apollo/client'
 import { useLocation } from 'react-router-dom'
 
+import { LoopingLogo } from 'pluralsh-design-system'
+
+import { Flex } from 'honorable'
+
 import { AUTHENTICATION_URLS_QUERY, CLOUD_SHELL_QUERY, REBOOT_SHELL_MUTATION } from './queries'
 import { Terminal } from './Terminal'
 
@@ -27,6 +31,22 @@ function CloudShell() {
   if (shellData?.shell?.alive || created) {
     return (
       <Terminal />
+    )
+  }
+
+  // Don't show onboarding until we're sure we're not going to load the terminal
+  // Showing onboarding will mess with local storage vars needed for first load
+  // of the terminal
+  if (!shellData) {
+    return (
+      <Flex
+        flexGrow={1}
+        align="center"
+        justify="center"
+        padding="xlarge"
+      >
+        <LoopingLogo />
+      </Flex>
     )
   }
 

--- a/www/src/components/shell/onboarding/applications/ApplicationsSelection.tsx
+++ b/www/src/components/shell/onboarding/applications/ApplicationsSelection.tsx
@@ -62,10 +62,6 @@ type ApplicationsSelectionProps = {
   onNext: () => void
 }
 
-function countSelectedApps(applications:any[]) {
-  return applications.filter(a => (a.name !== CONSOLE_APP_NAME)).length
-}
-
 function ApplicationsSelection({ onNext }: ApplicationsSelectionProps) {
   const [searchParams] = useSearchParams()
   const stackName = searchParams.get('stackName')
@@ -107,6 +103,7 @@ function ApplicationsSelection({ onNext }: ApplicationsSelectionProps) {
       .filter(x => (isStack && stackData ? stackApplicationsIds.includes(x.id) : true))
   }, [applicationsData, isStack, stackData, stackProvider])
   const consoleApp = useMemo(() => applicationsData?.repositories?.edges?.find(({ node: a }) => a.name === CONSOLE_APP_NAME).node, [applicationsData])
+  const selectedAppsCount = useMemo(() => selectedApplications.filter(a => (a.name !== CONSOLE_APP_NAME)).length, [selectedApplications])
 
   useEffect(() => {
     if (isStack && stackData) {
@@ -162,7 +159,7 @@ function ApplicationsSelection({ onNext }: ApplicationsSelectionProps) {
         applications = applications.filter(a => a.id !== application.id)
       }
       // Don't count plural console against MAX_SELECTED_APPLICATIONS limit
-      else if (countSelectedApps(applications) < MAX_SELECTED_APPLICATIONS) {
+      else if (selectedAppsCount < MAX_SELECTED_APPLICATIONS) {
         applications = [...applications, application]
       }
 
@@ -325,8 +322,6 @@ function ApplicationsSelection({ onNext }: ApplicationsSelectionProps) {
   }
 
   function renderApplicationsFooter() {
-    const selectedAppsCount = countSelectedApps(selectedApplications)
-
     return (
       <P color="text-light">
         {selectedAppsCount
@@ -376,13 +371,13 @@ function ApplicationsSelection({ onNext }: ApplicationsSelectionProps) {
               cursor={
                 isStack
                   ? 'auto'
-                  : countSelectedApps(selectedApplications) >= MAX_SELECTED_APPLICATIONS
+                  : selectedAppsCount >= MAX_SELECTED_APPLICATIONS
                     && !selectedApplications.find(a => a.id === application.id)
                     ? 'not-allowed'
                     : 'pointer'
               }
               opacity={
-                countSelectedApps(selectedApplications) >= MAX_SELECTED_APPLICATIONS
+                selectedAppsCount >= MAX_SELECTED_APPLICATIONS
                 && !selectedApplications.find(a => a.id === application.id)
                   ? 0.5
                   : 1
@@ -433,7 +428,7 @@ function ApplicationsSelection({ onNext }: ApplicationsSelectionProps) {
         <Button
           primary
           onClick={onNext}
-          disabled={!countSelectedApps(selectedApplications)}
+          disabled={!selectedAppsCount}
           marginLeft="medium"
         >
           Continue

--- a/www/src/components/shell/persistance.ts
+++ b/www/src/components/shell/persistance.ts
@@ -47,7 +47,7 @@ export function persistConsole(shouldUseConsole: boolean) {
 }
 
 export function retrieveConsole() {
-  return localStorage.getItem(PROVIDER_LOCAL_STORAGE_KEY) === 'true'
+  return localStorage.getItem(CONSOLE_LOCAL_STORAGE_KEY) === 'true'
 }
 
 export function persistShouldUseOnboardingTerminalSidebar(shouldUseOnboardingTerminalSidebar: boolean) {


### PR DESCRIPTION
# Description
Fixes the following ([linear ticket](https://linear.app/pluralsh/issue/ENG-732/resolve-install-plural-console-issues-with-onboarding-flow)):
- The app selection screen should include a toggle switch for "Install Plural Console"
- During a quickstack install with Plural Console selected, the command is not installing the Plural Console.
- During a pre-made stack install, with Plural Console selected, there should be an additional step to install plural console (prior to stack install)

# Testing
Manually tested flow to terminal launch and install step for both quick-stack and pre-made stack once each.

### Showing 'console' is selected for install
<img width="1281" alt="Screen Shot 2022-09-29 at 12 56 32 PM" src="https://user-images.githubusercontent.com/85062/193130508-cab06ac6-9aee-4b44-9ad0-3f35bd64842b.png">


