### PR TITLE
Fix code copy bug

### DIFF
--- a/www/src/components/shell/TerminalSidebar.js
+++ b/www/src/components/shell/TerminalSidebar.js
@@ -418,7 +418,7 @@ function Step1({ shell }) {
         To begin, run this one-line command:
       </P>
       <CodeLine marginTop="medium">
-        plural bundle install console console-{shell?.provider?.toLowerCase() || 'gcp'}
+        {`plural bundle install console console-${shell?.provider?.toLowerCase() || 'gcp'}`}
       </CodeLine>
       <P
         body1

--- a/www/src/components/utils/CodeLine.tsx
+++ b/www/src/components/utils/CodeLine.tsx
@@ -1,8 +1,12 @@
 import { useState } from 'react'
-import { Div, Flex } from 'honorable'
+import { Div, Flex, FlexProps } from 'honorable'
 import { CopyIcon } from 'pluralsh-design-system'
 
-function CodeLine({ children, ...props }) {
+type CodeLineProps = Omit<FlexProps, 'children'> & {
+ children:string
+}
+
+function CodeLine({ children, ...props }:CodeLineProps) {
   const [copied, setCopied] = useState(false)
 
   function handleCopy() {


### PR DESCRIPTION
`children` wasn’t a string, so the copied content got mangled. Also converted `CodeLine` to typescript and made the `children` prop a string so at least usage in ts files should throw an error when making this same mistake.