### PR TITLE
[ENG-725] Detect detached message and trigger shell restart

### DIFF
--- a/www/src/components/shell/Shell.js
+++ b/www/src/components/shell/Shell.js
@@ -59,7 +59,7 @@ function Shell({ shell }) {
     chan.on('stdo', ({ message }) => {
       const decoded = decodeBase64(message)
 
-      term.write(decodeBase64(message))
+      term.write(decoded)
 
       if (!restart && decoded.includes(detachedMessage)) {
         setRestart(true)

--- a/www/src/components/shell/Shell.js
+++ b/www/src/components/shell/Shell.js
@@ -41,8 +41,12 @@ function Shell({ shell }) {
   const [restart, setRestart] = useState(false)
 
   useEffect(() => {
-    if (!xterm?.current?.terminal) return
-    if (restart) return
+    if (!xterm?.current?.terminal || restart) {
+      // eslint-disable-next-line no-unused-expressions
+      restart && setRestart(false)
+
+      return
+    }
 
     const term = xterm.current.terminal
     const chan = socket.channel('shells:me')
@@ -88,8 +92,6 @@ function Shell({ shell }) {
       chan.leave()
     }
   }, [shell, xterm, fitAddon, restart])
-
-  useEffect(() => (restart ? setRestart(false) : undefined), [restart, setRestart])
 
   const handleResetSize = useCallback(() => {
     if (!channel) return


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
It appears that the workspace detached message does not really close the WS connection and it is still considered alive. Heartbeat can be seen every 30s in the network panel. Since there is no real connection error, timeout changes would not impact anything here. They are actually quite short (10s/20s).

I have added simple logic to detect the detached message and trigger the shell restart.

@michaeljguarino @dherault WDYT?

[Nagranie ekranu z 04.10.2022 14:44:51.webm](https://user-images.githubusercontent.com/2285385/193822877-13ae3a38-ff84-4f30-84c4-ccef49244979.webm)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally with 2 tabs. Opening shell in a second tab actually results in the detached from workspace message.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.