### PR TITLE
ENG-742 Fix ‘Complete demo’ button at end of CLI onboarding

### DIFF
--- a/www/src/components/shell/onboarding/cli/CliCompletion.js
+++ b/www/src/components/shell/onboarding/cli/CliCompletion.js
@@ -10,7 +10,7 @@ import OnboardingNavSection from '../OnboardingNavSection'
 import OnboardingCard from '../OnboardingCard'
 
 function CliCompletion() {
-  const { previous, next } = useContext(CreateShellContext)
+  const { previous } = useContext(CreateShellContext)
 
   return (
     <>

--- a/www/src/components/shell/onboarding/cli/CliCompletion.js
+++ b/www/src/components/shell/onboarding/cli/CliCompletion.js
@@ -1,6 +1,7 @@
 import { useContext } from 'react'
 import { P } from 'honorable'
 import { ArrowTopRightIcon, Button } from 'pluralsh-design-system'
+import { Link } from 'react-router-dom'
 
 import CreateShellContext from '../../../../contexts/CreateShellContext'
 
@@ -42,9 +43,10 @@ function CliCompletion() {
         </Button>
         <Button
           primary
-          onClick={() => next()}
+          as={Link}
+          to="/marketplace"
         >
-          Complete Setup
+          Continue to app
         </Button>
       </OnboardingNavSection>
     </>


### PR DESCRIPTION
[ENG-742](https://linear.app/pluralsh/issue/ENG-742/fix-complete-demo-button-from-within-the-cli-path-of-onboarding-flow)
Changed wording of button to “Continue to app” and is now a link to `/marketplace`

https://user-images.githubusercontent.com/85062/193653909-e2d71abe-ad13-4b7d-944f-43fc6684cc07.mov

