### PR TITLE
ENG-741 - Fix inline link style on cloud shell side-panel

### DIFF
--- a/www/src/components/shell/TerminalSidebar.js
+++ b/www/src/components/shell/TerminalSidebar.js
@@ -385,8 +385,17 @@ function WizardDocs() {
         body1
         marginTop="medium"
       >
-        Our cli will lead you through a brief install wizard to make sure everything is configured properly. If you need more detailed guidance
-        for these steps, refer to <a href="https://docs.plural.sh/applications/repositories/console#setup-configuration">our documentation</a>.
+        Our cli will lead you through a brief install wizard to make sure
+        everything is configured properly. If you need more detailed guidance
+        for these steps, refer to{' '}
+        <A
+          inline
+          target="_blank"
+          href="https://docs.plural.sh/applications/repositories/console#setup-configuration"
+        >
+          our documentation
+        </A>
+        .
       </P>
       <P
         body1


### PR DESCRIPTION
[Linear](https://linear.app/pluralsh/issue/ENG-741/fix-inline-link-style-on-cloud-shell-side-panel)
After:
<img width="446" alt="Screen Shot 2022-10-03 at 11 56 36 AM" src="https://user-images.githubusercontent.com/85062/193658250-1d936561-915c-4da3-beff-bbd4702db71d.png">
