### PR TITLE
Add hubspot tracking to Signup page

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -82,6 +82,7 @@
     "react-resize-detector": "7.1.2",
     "react-router-dom": "6.4.1",
     "react-sage": "0.3.16",
+    "react-script-hook": "1.7.2",
     "react-scripts": "5.0.1",
     "react-spinners": "0.13.4",
     "react-stripe-elements": "6.1.2",

--- a/www/src/components/users/MagicLogin.js
+++ b/www/src/components/users/MagicLogin.js
@@ -18,6 +18,7 @@ import {
   A, Article, Button, Div, Flex, H2, Icon, Img, Input, P,
 } from 'honorable'
 import { useResizeDetector } from 'react-resize-detector'
+import useScript from 'react-script-hook'
 
 import { WelcomeHeader } from 'components/utils/WelcomeHeader'
 
@@ -537,6 +538,7 @@ export function Signup() {
       history.navigate('/')
     }
   }, [history])
+  useScript({ src: 'https://js.hs-scripts.com/22363579.js' })
 
   const { disabled, reason } = disableState(password, confirm, email)
 
@@ -625,6 +627,20 @@ export function Signup() {
           onClick={() => navigate('/login')}
         >
           Login
+        </A>
+      </P>
+      <P
+        body2
+        textAlign="center"
+        marginTop="xxsmall"
+      >
+        <A
+          inline
+          onClick={() => {
+            window?._hsp?.push(['showBanner'])
+          }}
+        >
+          Cookie settings
         </A>
       </P>
     </LoginPortal>

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -18500,6 +18500,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-script-hook@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "react-script-hook@npm:1.7.2"
+  peerDependencies:
+    react: ^16.8.6 || 17 - 18
+    react-dom: ^16.8.6 || 17 - 18
+  checksum: 74fb5ec2e6ec7eccad64a7a3b7e0d16e01e487d0880e7f123ad7433975707cfed47be604ce5cfd0d5c43d89be3f1a4fad46eba7d0bacd41f810705f30d958fa5
+  languageName: node
+  linkType: hard
+
 "react-scripts@npm:5.0.1":
   version: 5.0.1
   resolution: "react-scripts@npm:5.0.1"
@@ -23171,6 +23181,7 @@ __metadata:
     react-resize-detector: 7.1.2
     react-router-dom: 6.4.1
     react-sage: 0.3.16
+    react-script-hook: ^1.7.2
     react-scripts: 5.0.1
     react-spinners: 0.13.4
     react-stripe-elements: 6.1.2


### PR DESCRIPTION
Part of https://linear.app/pluralsh/issue/ENG-680/install-hubspot-tracking-code-onto-every-page-of-our-marketing-website