### PR TITLE
Add option to get demo project for the current user

### DIFF
--- a/apps/core/lib/core/services/shell/demo.ex
+++ b/apps/core/lib/core/services/shell/demo.ex
@@ -174,12 +174,12 @@ defmodule Core.Services.Shell.Demo do
     end
   end
 
-  def poll_demo_project(id, _) when is_binary(id) do
+  def poll_demo_project(:id, id) do
     get_demo_project(id)
     |> poll_demo_project()
   end
 
-  def poll_demo_project(_, %User{id: user_id}) do
+  def poll_demo_project(:user, user_id) do
     get_by_user_id(user_id)
     |> poll_demo_project()
   end

--- a/apps/core/lib/core/services/shell/demo.ex
+++ b/apps/core/lib/core/services/shell/demo.ex
@@ -174,10 +174,17 @@ defmodule Core.Services.Shell.Demo do
     end
   end
 
-  def poll_demo_project(id) when is_binary(id) do
+  def poll_demo_project(id, user) when is_binary(id) do
     get_demo_project(id)
     |> poll_demo_project()
   end
+
+  def poll_demo_project(_, %User{id: user_id}) do
+    get_by_user_id(user_id)
+    |> poll_demo_project()
+  end
+
+  def poll_demo_project(nil), do: {:error, [message: "Demo project not found", code: 404]}
 
   defp enable(%DemoProject{} = proj) do
     DemoProject.changeset(proj, %{state: :enabled})

--- a/apps/core/lib/core/services/shell/demo.ex
+++ b/apps/core/lib/core/services/shell/demo.ex
@@ -174,7 +174,7 @@ defmodule Core.Services.Shell.Demo do
     end
   end
 
-  def poll_demo_project(id, user) when is_binary(id) do
+  def poll_demo_project(id, _) when is_binary(id) do
     get_demo_project(id)
     |> poll_demo_project()
   end

--- a/apps/graphql/lib/graphql/resolvers/shell.ex
+++ b/apps/graphql/lib/graphql/resolvers/shell.ex
@@ -12,7 +12,8 @@ defmodule GraphQl.Resolvers.Shell do
   def delete_shell(_, %{context: %{current_user: user}}),
     do: Shell.delete(user.id)
 
-  def get_demo_project(%{id: id}, %{context: %{current_user: user}}), do: Shell.Demo.poll_demo_project(id, user)
+  def get_demo_project(%{id: id}, _) when is_binary(id), do: Shell.Demo.poll_demo_project(:id, id)
+  def get_demo_project(_, %{context: %{current_user: %{id: user_id}}}), do: Shell.Demo.poll_demo_project(:user, user_id)
 
   def create_demo_project(_, %{context: %{current_user: user}}),
     do: Shell.Demo.create_demo_project(user)

--- a/apps/graphql/lib/graphql/resolvers/shell.ex
+++ b/apps/graphql/lib/graphql/resolvers/shell.ex
@@ -12,7 +12,7 @@ defmodule GraphQl.Resolvers.Shell do
   def delete_shell(_, %{context: %{current_user: user}}),
     do: Shell.delete(user.id)
 
-  def get_demo_project(%{id: id}, _), do: Shell.Demo.poll_demo_project(id)
+  def get_demo_project(%{id: id}, %{context: %{current_user: user}}), do: Shell.Demo.poll_demo_project(id, user)
 
   def create_demo_project(_, %{context: %{current_user: user}}),
     do: Shell.Demo.create_demo_project(user)

--- a/apps/graphql/lib/graphql/schema/shell.ex
+++ b/apps/graphql/lib/graphql/schema/shell.ex
@@ -114,7 +114,7 @@ defmodule GraphQl.Schema.Shell do
 
     field :demo_project, :demo_project do
       middleware Authenticated
-      arg :id, non_null(:id)
+      arg :id, :id
 
       safe_resolve &Shell.get_demo_project/2
     end


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Related to [ENG-643](https://linear.app/pluralsh/issue/ENG-643/implement-backend-logic-for-checklist) as the getting started checklist should be hidden for the GCP cloud demo users. This way we will be able to easily check if current user actually has any existing demo project.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Added tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.