### PR TITLE
Update card sizing

### DIFF
--- a/www/src/components/marketplace/utils.tsx
+++ b/www/src/components/marketplace/utils.tsx
@@ -1,6 +1,6 @@
 import { Flex } from 'honorable'
 
-export const flexBasis = '400px'
+export const flexBasis = '365px'
 
 // Workaround that will render empty columns to align the last row.
 // It is better to use bigger columns number to prevent issues on all kinds of viewports.


### PR DESCRIPTION
## Summary
Reduce card flex basis in order to display three rows down to 1440px viewport width.

Closes ENG-784.

<img width="1539" alt="Zrzut ekranu 2022-10-18 o 11 10 18" src="https://user-images.githubusercontent.com/2823399/196388727-6cf9ab9e-2443-4d1d-b01d-0ea8897e2cc4.png">
<img width="1552" alt="Zrzut ekranu 2022-10-18 o 11 09 40" src="https://user-images.githubusercontent.com/2823399/196388734-9c72a0fc-19ab-4c23-a537-0bf2a2d6b199.png">

## Test Plan
Tested manually.

## Checklist
- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.