### PR TITLE
Automate onboarding status updates

### DIFF
--- a/apps/core/lib/core/pubsub/events.ex
+++ b/apps/core/lib/core/pubsub/events.ex
@@ -75,3 +75,5 @@ defmodule Core.PubSub.StepLogs, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.CacheUser, do: use Piazza.PubSub.Event
 
 defmodule Core.PubSub.InviteCreated, do: use Piazza.PubSub.Event
+
+defmodule Core.PubSub.PersistedTokenCreated, do: use Piazza.PubSub.Event

--- a/apps/core/lib/core/services/users.ex
+++ b/apps/core/lib/core/services/users.ex
@@ -217,6 +217,7 @@ defmodule Core.Services.Users do
     %PersistedToken{}
     |> PersistedToken.changeset(%{user_id: user.id})
     |> Core.Repo.insert()
+    |> notify(:create, user)
   end
 
   @doc "self explanatory"
@@ -608,6 +609,8 @@ defmodule Core.Services.Users do
     do: handle_notify(PubSub.UserDeleted, u, actor: actor)
   def notify({:ok, %User{} = u}, :update, actor),
     do: handle_notify(PubSub.UserUpdated, u, actor: actor)
+  def notify({:ok, %PersistedToken{} = p}, :create, actor),
+    do: handle_notify(PubSub.PersistedTokenCreated, p, actor: actor)
   def notify(pass, _, _), do: pass
 
   def notify({:ok, %ResetToken{} = t}, :create),

--- a/apps/core/test/pubsub/fanout/users_test.exs
+++ b/apps/core/test/pubsub/fanout/users_test.exs
@@ -50,4 +50,25 @@ defmodule Core.PubSub.Fanout.UsersTest do
       :ok = Core.PubSub.Fanout.fanout(event)
     end
   end
+
+  describe "PersistedTokenCreated" do
+    test "new users will be marked configured" do
+      user = insert(:user, onboarding_checklist: %{status: :new})
+      tok  = insert(:persisted_token, user: user)
+
+      event = %PubSub.PersistedTokenCreated{item: tok, actor: user}
+      {:ok, updated} = Core.PubSub.Fanout.fanout(event)
+
+      assert updated.id == user.id
+      assert updated.onboarding_checklist.status == :configured
+    end
+
+    test "onboarded users are ignored" do
+      user = insert(:user, onboarding_checklist: %{status: :console_installed})
+      tok  = insert(:persisted_token, user: user)
+
+      event = %PubSub.PersistedTokenCreated{item: tok, actor: user}
+      :ok = Core.PubSub.Fanout.fanout(event)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Use some event cues w/in the server code to automate this, in particular:

* persisted token creates as a proxy for cli installs (done during plural init)
* various installation creates to see if console/new apps are installed

## Test Plan
added unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.