### PR TITLE
Backfill onboarding status and ensure set on user create

### DIFF
--- a/apps/core/lib/core/backfill/users.ex
+++ b/apps/core/lib/core/backfill/users.ex
@@ -1,0 +1,15 @@
+defmodule Core.Backfill.Users do
+  alias Core.{Schema.User}
+
+  def onboarding() do
+    User
+    |> User.ordered(asc: :id)
+    |> Core.Repo.stream(method: :keyset)
+    |> Core.throttle()
+    |> Enum.each(fn user ->
+      # don't show onboarding to existing users
+      {:ok, _} = User.changeset(user, %{onboarding_checklist: %{dismissed: true, status: :finished}})
+                 |> Core.Repo.update()
+    end)
+  end
+end

--- a/apps/core/lib/core/schema/user.ex
+++ b/apps/core/lib/core/schema/user.ex
@@ -263,7 +263,7 @@ defmodule Core.Schema.User do
 end
 
 defimpl Jason.Encoder, for: Core.Schema.User do
-  @ignore ~w(password password_hash jwt)a
+  @ignore ~w(password password_hash jwt onboarding_checklist)a
 
   def encode(struct, opts) do
     Piazza.Ecto.Schema.mapify(struct)

--- a/apps/core/lib/core/services/users.ex
+++ b/apps/core/lib/core/services/users.ex
@@ -255,6 +255,7 @@ defmodule Core.Services.Users do
       confirm_by = Timex.now() |> Timex.shift(days: 7)
       %User{email_confirm_by: confirm_by}
       |> User.changeset(attrs)
+      |> User.changeset(%{onboarding_checklist: %{status: :new}})
       |> Core.Repo.insert()
     end)
     |> add_operation(:user, fn %{pre: user} ->

--- a/apps/core/priv/repo/seeds/010_onboarding_backfill.exs
+++ b/apps/core/priv/repo/seeds/010_onboarding_backfill.exs
@@ -1,0 +1,5 @@
+import Botanist
+
+seed do
+  Core.Backfill.Users.onboarding()
+end

--- a/apps/core/test/backfill/users_test.exs
+++ b/apps/core/test/backfill/users_test.exs
@@ -1,0 +1,16 @@
+defmodule Core.Backfill.UsersTest do
+  use Core.SchemaCase, async: true
+  alias Core.Backfill.Users
+
+  describe "#onboarding/0" do
+    test "it will set onboarding_checklist structs" do
+      users = insert_list(3, :user)
+
+      Users.onboarding()
+
+      for user <- users do
+        assert refetch(user).onboarding_checklist.dismissed
+      end
+    end
+  end
+end

--- a/apps/core/test/services/users_test.exs
+++ b/apps/core/test/services/users_test.exs
@@ -15,6 +15,7 @@ defmodule Core.Services.UsersTest do
       assert user.name == "some user"
       assert user.email == "something@example.com"
       assert user.password_hash
+      assert user.onboarding_checklist.status == :new
       assert Timex.after?(user.email_confirm_by, Timex.now())
 
       %{account: account} = Core.Repo.preload(user, [:account])


### PR DESCRIPTION
## Summary

We currently default this to nil, when we should be setting the status to :new by default


## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.