### PR TITLE
Show demo option only to the new users

### DIFF
--- a/www/src/components/shell/onboarding/OnboardingSidenav.tsx
+++ b/www/src/components/shell/onboarding/OnboardingSidenav.tsx
@@ -1,3 +1,5 @@
+import { CurrentUserContext } from 'components/login/CurrentUser'
+import { OnboardingStatus } from 'components/profile/types'
 import { A } from 'honorable'
 import {
   BrowserIcon,
@@ -9,6 +11,7 @@ import {
   Stepper,
   TerminalIcon,
 } from 'pluralsh-design-system'
+import { useContext } from 'react'
 import styled from 'styled-components'
 
 import {
@@ -27,10 +30,10 @@ type OnboardingSidenavProps = {
   onRestart: () => void
 }
 
-const steps = [
+const steps = (canUseDemo: boolean) => [
   { key: SECTION_APPLICATIONS, stepTitle: 'Choose applications', IconComponent: PackageIcon },
   { key: SECTION_GIT_PROVIDER, stepTitle: 'Create a git repo', IconComponent: NetworkInterfaceIcon },
-  { key: SECTION_CLOUD_SELECT, stepTitle: <>Choose a&nbsp;cloud</>, IconComponent: CloudIcon },
+  { key: SECTION_CLOUD_SELECT, stepTitle: `Choose a ${canUseDemo ? 'cloud' : 'shell'}`, IconComponent: CloudIcon },
   { key: SECTION_CLOUD_WORKSPACE, stepTitle: 'Configure workspace', IconComponent: GearTrainIcon },
   { key: SECTION_SYNOPSIS, stepTitle: <>Launch cloud&nbsp;shell</>, IconComponent: BrowserIcon },
 ]
@@ -72,11 +75,14 @@ const ResponsiveWidth = styled.div(({ theme }) => {
 
 // eslint-disable-next-line
 function OnboardingSidenav({ stepIndex, cliMode, onRestart }: OnboardingSidenavProps) {
+  const me: any = useContext(CurrentUserContext)
+  const canUseDemo = me?.onboarding === OnboardingStatus.NEW
+
   return (
     <ResponsiveWidth>
       <Stepper
         vertical
-        steps={cliMode ? stepsCli : steps}
+        steps={cliMode ? stepsCli : steps(canUseDemo)}
         stepIndex={stepIndex}
         collapseAtWidth={expandAtWidth - 1}
       />

--- a/www/src/components/shell/onboarding/cloud/CloudSelect.js
+++ b/www/src/components/shell/onboarding/cloud/CloudSelect.js
@@ -4,6 +4,10 @@ import { Button, CloudIcon } from 'pluralsh-design-system'
 
 import { persistProvider } from 'components/shell/persistance'
 
+import { CurrentUserContext } from 'components/login/CurrentUser'
+
+import { OnboardingStatus } from 'components/profile/types'
+
 import CreateShellContext from '../../../../contexts/CreateShellContext'
 
 import { SECTION_CLI_INSTALLATION, SECTION_CLOUD_BUILD, SECTION_CLOUD_CREDENTIALS } from '../../constants'
@@ -13,27 +17,93 @@ import OnboardingCard from '../OnboardingCard'
 
 import { ChooseAShell, CloudOption } from './provider'
 
-function CloudSelect() {
+function ChooseShell() {
+  const [shell, setShell] = useState()
+  const { previous, setSection } = useContext(CreateShellContext)
+
+  return (
+    <OnboardingCard title="Choose a shell">
+      <P marginBottom="medium">
+        Determine which shell you'll use to get started. The cloud shell
+        comes fully equipped with the Plural CLI and all required dependencies.
+      </P>
+      <Flex mx={-1}>
+        <CloudOption
+          selected={shell === 'cloud'}
+          icon={(
+            <CloudIcon
+              size={40}
+              color="text-light"
+            />
+          )}
+          header="Cloud shell"
+          description="Plug in your cloud credentials and boot into Plural's cloud shell."
+          onClick={() => setShell('cloud')}
+        />
+        <CloudOption
+          selected={shell === 'cli'}
+          icon={(
+            <CloudIcon
+              size={40}
+              color="text-light"
+            />
+          )}
+          header="Local terminal"
+          description="Install the Plural CLI in your local environment."
+          onClick={() => setShell('cli')}
+        />
+      </Flex>
+      <OnboardingNavSection>
+        <Button
+          secondary
+          onClick={() => {
+            previous()
+          }}
+        >
+          Back
+        </Button>
+        <Button
+          disabled={!shell}
+          onClick={() => {
+            if (shell === 'cli') {
+              setSection(SECTION_CLI_INSTALLATION)
+            }
+            else {
+              setSection(SECTION_CLOUD_CREDENTIALS)
+            }
+          }}
+        >
+          Continue
+        </Button>
+      </OnboardingNavSection>
+    </OnboardingCard>
+  )
+}
+
+export default function CloudSelect() {
+  const me = useContext(CurrentUserContext)
+  const canUseDemo = me?.onboarding === OnboardingStatus.NEW
   const { previous, setSection, setDemoId } = useContext(CreateShellContext)
   const [nextPath, setNextPath] = useState('')
   const [byocShell, setByocShell] = useState('cloud')
 
-  function handleDemoClick() {
+  if (!canUseDemo) return <ChooseShell />
+
+  const handleDemoClick = () => {
     setNextPath('demo')
     persistProvider('GCP')
   }
 
   return (
     <OnboardingCard title="Choose a cloud">
-      <P
-        marginBottom="medium"
-      >
-        Plural makes it easy to plug into your own cloud, but we also provide a free demo cloud to help you get started.
+      <P marginBottom="medium">
+        Plural makes it easy to plug into your own cloud,
+        but we also provide a free demo cloud to help you get started.
       </P>
       <Flex mx={-1}>
         <CloudOption
           selected={nextPath === 'demo'}
-          providerLogo={(
+          icon={(
             <Img
               src="/gcp.png"
               alt="Google Cloud logo"
@@ -46,7 +116,7 @@ function CloudSelect() {
         />
         <CloudOption
           selected={nextPath === 'byoc'}
-          providerLogo={(
+          icon={(
             <CloudIcon
               size={40}
               color="text-light"
@@ -103,5 +173,3 @@ function CloudSelect() {
     </OnboardingCard>
   )
 }
-
-export default CloudSelect

--- a/www/src/components/shell/onboarding/cloud/provider.tsx
+++ b/www/src/components/shell/onboarding/cloud/provider.tsx
@@ -24,7 +24,7 @@ export const CLOUD_CREDENTIALS_VALIDATIONS: Record<ProviderKey, any> = {
 }
 
 export function CloudOption({
-  providerLogo,
+  icon,
   header,
   description,
   selected,
@@ -42,7 +42,7 @@ export function CloudOption({
         maxHeight={40}
         overflow="visible"
       >
-        {providerLogo}
+        {icon}
       </Div>
       <Text
         body1


### PR DESCRIPTION
## Summary
Make GCP cloud demo option available only to the new users. For everyone else it will be not visible anymore.

Closes ENG-651.

New users:
<img width="1436" alt="Zrzut ekranu 2022-10-20 o 10 45 32" src="https://user-images.githubusercontent.com/2823399/196901664-8bea46cf-f441-468a-aaf0-375bd292fd5d.png">

Users with onboarding status different than `NEW`:
<img width="1418" alt="Zrzut ekranu 2022-10-20 o 10 45 12" src="https://user-images.githubusercontent.com/2823399/196901683-2fa6b4bc-145c-4327-a4ea-54452072ed52.png">

## Test Plan
Tested manually.

## Checklist
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.