### PR TITLE
Fix missing colors

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -60,7 +60,7 @@
     "moment": "2.29.4",
     "phoenix": "1.6.12",
     "pluralsh-absinthe-socket-apollo-link": "0.2.0",
-    "pluralsh-design-system": "1.236.0",
+    "pluralsh-design-system": "1.241.0",
     "prop-types": "15.8.1",
     "query-string": "7.1.1",
     "randomcolor": "0.6.2",

--- a/www/src/components/utils/IconButtons.tsx
+++ b/www/src/components/utils/IconButtons.tsx
@@ -8,7 +8,7 @@ export const DeleteIconButton = forwardRef<HTMLDivElement, Partial<IconFrameProp
     ref={ref}
     size={size || 'medium'}
     clickable={clickable === undefined ? true : clickable}
-    icon={<TrashCanIcon color="error" />}
+    icon={<TrashCanIcon color="icon-danger" />}
     textValue={textValue || 'Delete'}
     {...props}
   />

--- a/www/src/components/utils/List.tsx
+++ b/www/src/components/utils/List.tsx
@@ -21,7 +21,7 @@ const LiBare = styled.li(({ $extendStyle }: { $extendStyle?: Record<string, any>
   ...$extendStyle,
 }))
 
-const hueToBorderColor: Record<Hue, string> = {
+const hueToBorderColor: Record<Hue | 'none', string> = {
   none: 'border',
   default: 'border',
   lighter: 'border-fill-two',

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -16851,9 +16851,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pluralsh-design-system@npm:1.236.0":
-  version: 1.236.0
-  resolution: "pluralsh-design-system@npm:1.236.0"
+"pluralsh-design-system@npm:1.241.0":
+  version: 1.241.0
+  resolution: "pluralsh-design-system@npm:1.241.0"
   dependencies:
     "@floating-ui/react-dom-interactions": 0.8.1
     "@react-aria/button": 3.6.1
@@ -16892,7 +16892,7 @@ __metadata:
     react-dom: ">=16.0.0"
     react-transition-group: ">=4.4.2"
     styled-components: ">=5.3.5"
-  checksum: 2265fe9cb30387bb721d87be38062a56086c87f42988a82d7d004f9b6f3919767df9268bcb0b9619f47aea027568659909aa4bdd0f75afebee3c6f50169155b5
+  checksum: 71b68597859ce6bfe203c4a067c78763854c746f8141e066791304f32dffa0b5de6317ab48c50944b7280bfed879dc0cd98a6d00294fdf7b6c556808bc918c4f
   languageName: node
   linkType: hard
 
@@ -23243,7 +23243,7 @@ __metadata:
     moment: 2.29.4
     phoenix: 1.6.12
     pluralsh-absinthe-socket-apollo-link: 0.2.0
-    pluralsh-design-system: 1.236.0
+    pluralsh-design-system: 1.241.0
     postcss-import: 8.2.0
     prop-types: 15.8.1
     query-string: 7.1.1


### PR DESCRIPTION
Some colors were removed from the design system before being replaced in the app. This bring them back until we can replace them after the front-end refactor.

Also `<DeleteIconButton>` had it's icon set to a color that was never valid so this fixes that too. 