### PR TITLE
Begin implementing OpenAI

### DIFF
--- a/apps/core/lib/core/clients/openai.ex
+++ b/apps/core/lib/core/clients/openai.ex
@@ -1,0 +1,39 @@
+defmodule Core.Clients.OpenAI do
+  require Logger
+
+  defmodule Choice, do: defstruct [:text, :index, :logprobs]
+
+  defmodule CompletionResponse do
+    alias Core.Clients.OpenAI
+    defstruct [:id, :object, :model, :choices]
+
+    def spec(), do: %__MODULE__{choices: [%OpenAI.Choice{}]}
+  end
+
+  def completion(model, prompt) do
+    body = Jason.encode!(%{
+      model: model,
+      prompt: prompt,
+      max_tokens: 1000,
+    })
+
+    url("/completions")
+    |> HTTPoison.post(body, json_headers())
+    |> handle_response(CompletionResponse.spec())
+  end
+
+  defp handle_response({:ok, %HTTPoison.Response{status_code: code, body: body}}, type) when code in 200..299,
+    do: {:ok, Poison.decode!(body, as: type)}
+  defp handle_response(error, _) do
+    Logger.error "Failed to call openai api: #{inspect(error)}"
+    {:error, :openai_error}
+  end
+
+  defp url(path), do: "https://api.openai.com/v1#{path}"
+
+  defp json_headers(), do: headers([{"Content-Type", "application/json"}])
+
+  defp headers(headers \\ []), do: [{"Authorization", "Bearer #{token()}"} | headers]
+
+  defp token(), do: Application.get_env(:openai, :token)
+end

--- a/apps/core/lib/core/services/ai.ex
+++ b/apps/core/lib/core/services/ai.ex
@@ -1,0 +1,20 @@
+defmodule Core.Services.AI do
+  alias Core.Clients.OpenAI
+
+  @type error :: {:error, term}
+
+  @doc """
+  Generates an answer to a given prompt/question using gpt-3
+
+  TODO: begin tuning our own models and have tools to select against those.
+  TODO: add context to the query
+  """
+  @spec answer(binary) :: {:ok, binary} | error
+  def answer(prompt) do
+    case OpenAI.completion("davinci", prompt) do
+      {:ok, %OpenAI.CompletionResponse{choices: [%OpenAI.Choice{text: text} | _]}} -> {:ok, text}
+      {:ok, _} -> {:error, "no response found"}
+      error -> error
+    end
+  end
+end

--- a/apps/graphql/lib/graphql.ex
+++ b/apps/graphql/lib/graphql.ex
@@ -24,6 +24,7 @@ defmodule GraphQl do
   import_types GraphQl.Schema.Shell
   import_types GraphQl.Schema.Scaffold
   import_types GraphQl.Schema.Test
+  import_types GraphQl.Schema.AI
 
   alias GraphQl.Resolvers.{
     User,
@@ -112,6 +113,7 @@ defmodule GraphQl do
     import_fields :metric_queries
     import_fields :provider_queries
     import_fields :test_queries
+    import_fields :ai_queries
   end
 
   mutation do

--- a/apps/graphql/lib/graphql/resolvers/ai.ex
+++ b/apps/graphql/lib/graphql/resolvers/ai.ex
@@ -1,0 +1,5 @@
+defmodule GraphQl.Resolvers.AI do
+  alias Core.Services.AI
+
+  def answer(%{prompt: prompt}, _), do: AI.answer(prompt)
+end

--- a/apps/graphql/lib/graphql/schema/ai.ex
+++ b/apps/graphql/lib/graphql/schema/ai.ex
@@ -1,0 +1,13 @@
+defmodule GraphQl.Schema.AI do
+  use GraphQl.Schema.Base
+  alias GraphQl.Resolvers.AI
+
+  object :ai_queries do
+    field :help_question, :string do
+      middleware Authenticated
+      arg :prompt, non_null(:string)
+
+      safe_resolve &AI.answer/2
+    end
+  end
+end

--- a/apps/graphql/test/queries/ai_queries_test.exs
+++ b/apps/graphql/test/queries/ai_queries_test.exs
@@ -1,0 +1,20 @@
+defmodule GraphQl.AIQueriesTest do
+  use Core.SchemaCase, async: true
+  import GraphQl.TestHelpers
+  use Mimic
+
+  describe "helpQuestion" do
+    test "it will query gpt-3 for an answer" do
+      resp = Jason.encode!(%{choices: [%{text: "a long answer to a short question"}]})
+      expect(HTTPoison, :post, fn _, _, _ -> {:ok, %HTTPoison.Response{status_code: 200, body: resp}} end)
+
+      {:ok, %{data: %{"helpQuestion" => result}}} = run_query("""
+        query Q($prompt: String!) {
+          helpQuestion(prompt: $prompt)
+        }
+      """, %{"prompt" => "huh"}, %{current_user: insert(:user)})
+
+      assert result == "a long answer to a short question"
+    end
+  end
+end

--- a/plural/helm/plural/Chart.yaml
+++ b/plural/helm/plural/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: plural
 description: A helm chart for installing plural
 appVersion: "0.8.3"
-version: 0.8.81
+version: 0.8.82
 dependencies:
 - name: hydra
   repository: https://k8s.ory.sh/helm/charts

--- a/plural/helm/plural/templates/secret.yaml
+++ b/plural/helm/plural/templates/secret.yaml
@@ -18,6 +18,7 @@ data:
   JWT_ISS: {{ .Values.secrets.jwt_iss | b64enc | quote }}
   JWT_AUD: {{ .Values.secrets.jwt_aud | b64enc | quote }}
   AES_KEY: {{ .Values.secrets.aes_key | b64enc | quote }}
+  OPENAI_BEARER_TOKEN: {{ .Values.secrets.openai_token | default "" | b64enc | quote }}
 {{ if .Values.secrets.stripe_secret }}
   STRIPE_SECRET: {{ .Values.secrets.stripe_secret | b64enc | quote }}
 {{ end }}

--- a/rel/config/config.exs
+++ b/rel/config/config.exs
@@ -111,3 +111,5 @@ end
 
 config :core,
   registry: get_env("DKR_DNS")
+
+config :openai, :token, get_env("OPENAI_BEARER_TOKEN")


### PR DESCRIPTION
## Summary

The idea behind this is to give us a lightweight "ask stackoverflow/google" like support experience within the product.  At the moment this will just query gpt-3 but we can also build some tools to tune the model against our own support conversations and other data sources (git readmes, help docs, etc).


## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.