### PR TITLE
add dedicated node groups for Plural

### DIFF
--- a/plural/terraform/aws/deps.yaml
+++ b/plural/terraform/aws/deps.yaml
@@ -7,7 +7,7 @@ dependencies:
 providers:
 - aws
 description: plural aws setup
-version: 0.1.2
+version: 0.1.3
 
 wirings:
   terraform: {}

--- a/plural/terraform/aws/node-groups.tf
+++ b/plural/terraform/aws/node-groups.tf
@@ -1,0 +1,11 @@
+module "node_groups" {
+  source                 = "github.com/pluralsh/module-library//terraform/eks-node-groups/single-az-node-groups?ref=df068595c3e91590d11e1ace11e1d688630f03d6"
+  cluster_name           = var.cluster_name
+  default_iam_role_arn   = var.node_role_arn
+  tags                   = var.tags
+  node_groups_defaults   = var.node_groups_defaults
+
+  node_groups            = var.single_az_node_groups
+  set_desired_size       = false
+  private_subnets        = var.private_subnets
+}

--- a/plural/terraform/aws/terraform.tfvars
+++ b/plural/terraform/aws/terraform.tfvars
@@ -6,3 +6,8 @@ plural_images_bucket = {{ .Values.images_bucket | quote }}
 plural_namespace = {{ .Namespace | quote }}
 cluster_name = {{ .Cluster | quote }}
 shell_subnet_ids = {{ $bootstrap.cluster_worker_private_subnet_ids | toJson }}
+node_role_arn = {{ (index $bootstrap.node_groups 0).node_role_arn | quote }}
+private_subnets = yamldecode(<<EOT
+{{ $bootstrap.cluster_worker_private_subnets | toYaml }}
+EOT
+)

--- a/plural/terraform/aws/variables.tf
+++ b/plural/terraform/aws/variables.tf
@@ -51,3 +51,64 @@ EOF
 variable "shell_subnet_ids" {
   type = list(string)
 }
+
+variable "node_role_arn" {
+  type = string
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "node_groups_defaults" {
+  description = "map of maps of node groups to create. See \"`node_groups` and `node_groups_defaults` keys\" section in README.md for more details"
+  type        = any
+  default = {
+    desired_capacity = 0
+    min_capacity = 0
+    max_capacity = 3
+
+    instance_types = ["t3.large", "t3a.large"]
+    disk_size = 50
+    ami_release_version = "1.21.14-20220824"
+    force_update_version = true
+    ami_type = "AL2_x86_64"
+    k8s_labels = {}
+    k8s_taints = []
+  }
+}
+
+variable "single_az_node_groups" {
+  type = any
+  default = {
+    plural_small = {
+      name = "plural-small"
+      capacity_type = "ON_DEMAND"
+      min_capacity = 0
+      max_capacity = 9
+      desired_capacity = 0
+      instance_types = ["t3.large", "t3a.large"]
+      k8s_labels = {
+        "plural.sh/capacityType" = "ON_DEMAND"
+        "plural.sh/performanceType" = "SUSTAINED"
+        "plural.sh/scalingGroup" = "plural-small"
+      }
+      k8s_taints = [
+        {
+          key = "plural.sh/pluralReserved"
+          value = "true"
+          effect = "NO_SCHEDULE"
+        }
+      ]
+    }
+  }
+  description = "Node groups to add to your cluster. A single managed node group will be created in each availability zone."
+}
+
+variable "private_subnets" {
+  description = "A list of private subnets for the EKS worker groups."
+  type        = list(any)
+  default     = []
+}


### PR DESCRIPTION
## Summary
This PR adds a dedicated node group that we can later use to separate Plural pods away from other resources on the cluster.


## Test Plan
Local linking.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.