### PR TITLE
move plural workers to their own node group

### DIFF
--- a/plural/helm/plural/Chart.yaml
+++ b/plural/helm/plural/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: plural
 description: A helm chart for installing plural
 appVersion: "0.8.7"
-version: 0.8.89
+version: 0.8.90
 dependencies:
 - name: hydra
   repository: https://k8s.ory.sh/helm/charts

--- a/plural/helm/plural/templates/deployment.yaml
+++ b/plural/helm/plural/templates/deployment.yaml
@@ -109,15 +109,15 @@ spec:
         {{ include "plural.env" . | nindent 8 }}
         resources:
           {{- toYaml .Values.worker.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+    {{- with .Values.worker.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with .Values.worker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/plural/helm/plural/values.yaml
+++ b/plural/helm/plural/values.yaml
@@ -387,6 +387,23 @@ worker:
         app.kubernetes.io/name: plural-worker
         app.kubernetes.io/instance: plural
 
+  nodeSelector: {}
+
+  tolerations:
+  - key: plural.sh/pluralReserved
+    operator: Exists
+    effect: "NoSchedule"
+
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: plural.sh/scalingGroup
+            operator: In
+            values:
+            - plural-worker-small
+
 www:
   repository: plural-www
   # if empty the chart version is used

--- a/plural/helm/plural/values.yaml
+++ b/plural/helm/plural/values.yaml
@@ -402,7 +402,7 @@ worker:
           - key: plural.sh/scalingGroup
             operator: In
             values:
-            - plural-worker-small
+            - plural-worker-medium
 
 www:
   repository: plural-www

--- a/plural/terraform/aws/deps.yaml
+++ b/plural/terraform/aws/deps.yaml
@@ -7,7 +7,7 @@ dependencies:
 providers:
 - aws
 description: plural aws setup
-version: 0.1.3
+version: 0.1.4
 
 wirings:
   terraform: {}

--- a/plural/terraform/aws/variables.tf
+++ b/plural/terraform/aws/variables.tf
@@ -86,7 +86,7 @@ variable "single_az_node_groups" {
     plural_small = {
       name = "plural-small"
       capacity_type = "ON_DEMAND"
-      min_capacity = 1
+      min_capacity = 3
       max_capacity = 9
       desired_capacity = 0
       instance_types = ["t3.large", "t3a.large"]
@@ -106,7 +106,7 @@ variable "single_az_node_groups" {
     plural_worker_small = {
       name = "plural-worker-small"
       capacity_type = "ON_DEMAND"
-      min_capacity = 1
+      min_capacity = 3
       max_capacity = 9
       desired_capacity = 0
       instance_types = ["t3.large", "t3a.large"]

--- a/plural/terraform/aws/variables.tf
+++ b/plural/terraform/aws/variables.tf
@@ -86,9 +86,9 @@ variable "single_az_node_groups" {
     plural_small = {
       name = "plural-small"
       capacity_type = "ON_DEMAND"
-      min_capacity = 3
+      min_capacity = 0
       max_capacity = 9
-      desired_capacity = 3
+      desired_capacity = 0
       instance_types = ["t3.large", "t3a.large"]
       k8s_labels = {
         "plural.sh/capacityType" = "ON_DEMAND"
@@ -103,17 +103,17 @@ variable "single_az_node_groups" {
         }
       ]
     }
-    plural_worker_small = {
-      name = "plural-worker-small"
+    plural_worker_medium = {
+      name = "plural-worker-medium"
       capacity_type = "ON_DEMAND"
-      min_capacity = 3
+      min_capacity = 0
       max_capacity = 9
-      desired_capacity = 3
-      instance_types = ["t3.large", "t3a.large"]
+      desired_capacity = 0
+      instance_types = ["t3.xlarge", "t3a.xlarge"]
       k8s_labels = {
         "plural.sh/capacityType" = "ON_DEMAND"
         "plural.sh/performanceType" = "SUSTAINED"
-        "plural.sh/scalingGroup" = "plural-worker-small"
+        "plural.sh/scalingGroup" = "plural-worker-medium"
       }
       k8s_taints = [
         {

--- a/plural/terraform/aws/variables.tf
+++ b/plural/terraform/aws/variables.tf
@@ -86,9 +86,9 @@ variable "single_az_node_groups" {
     plural_small = {
       name = "plural-small"
       capacity_type = "ON_DEMAND"
-      min_capacity = 0
+      min_capacity = 3
       max_capacity = 9
-      desired_capacity = 0
+      desired_capacity = 3
       instance_types = ["t3.large", "t3a.large"]
       k8s_labels = {
         "plural.sh/capacityType" = "ON_DEMAND"
@@ -106,9 +106,9 @@ variable "single_az_node_groups" {
     plural_worker_medium = {
       name = "plural-worker-medium"
       capacity_type = "ON_DEMAND"
-      min_capacity = 0
+      min_capacity = 3
       max_capacity = 9
-      desired_capacity = 0
+      desired_capacity = 3
       instance_types = ["t3.xlarge", "t3a.xlarge"]
       k8s_labels = {
         "plural.sh/capacityType" = "ON_DEMAND"

--- a/plural/terraform/aws/variables.tf
+++ b/plural/terraform/aws/variables.tf
@@ -86,7 +86,7 @@ variable "single_az_node_groups" {
     plural_small = {
       name = "plural-small"
       capacity_type = "ON_DEMAND"
-      min_capacity = 0
+      min_capacity = 1
       max_capacity = 9
       desired_capacity = 0
       instance_types = ["t3.large", "t3a.large"]
@@ -106,7 +106,7 @@ variable "single_az_node_groups" {
     plural_worker_small = {
       name = "plural-worker-small"
       capacity_type = "ON_DEMAND"
-      min_capacity = 0
+      min_capacity = 1
       max_capacity = 9
       desired_capacity = 0
       instance_types = ["t3.large", "t3a.large"]

--- a/plural/terraform/aws/variables.tf
+++ b/plural/terraform/aws/variables.tf
@@ -88,7 +88,7 @@ variable "single_az_node_groups" {
       capacity_type = "ON_DEMAND"
       min_capacity = 3
       max_capacity = 9
-      desired_capacity = 0
+      desired_capacity = 3
       instance_types = ["t3.large", "t3a.large"]
       k8s_labels = {
         "plural.sh/capacityType" = "ON_DEMAND"
@@ -108,7 +108,7 @@ variable "single_az_node_groups" {
       capacity_type = "ON_DEMAND"
       min_capacity = 3
       max_capacity = 9
-      desired_capacity = 0
+      desired_capacity = 3
       instance_types = ["t3.large", "t3a.large"]
       k8s_labels = {
         "plural.sh/capacityType" = "ON_DEMAND"

--- a/plural/terraform/aws/variables.tf
+++ b/plural/terraform/aws/variables.tf
@@ -103,6 +103,26 @@ variable "single_az_node_groups" {
         }
       ]
     }
+    plural_worker_small = {
+      name = "plural-worker-small"
+      capacity_type = "ON_DEMAND"
+      min_capacity = 0
+      max_capacity = 9
+      desired_capacity = 0
+      instance_types = ["t3.large", "t3a.large"]
+      k8s_labels = {
+        "plural.sh/capacityType" = "ON_DEMAND"
+        "plural.sh/performanceType" = "SUSTAINED"
+        "plural.sh/scalingGroup" = "plural-worker-small"
+      }
+      k8s_taints = [
+        {
+          key = "plural.sh/pluralReserved"
+          value = "true"
+          effect = "NO_SCHEDULE"
+        }
+      ]
+    }
   }
   description = "Node groups to add to your cluster. A single managed node group will be created in each availability zone."
 }


### PR DESCRIPTION
## Summary
Move Plural workers onto their own nodes so that they don't interfere with other parts of Plural.

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.