### PR TITLE
fix(backend): migrate to new config module

### DIFF
--- a/apps/email/lib/email_web/router.ex
+++ b/apps/email/lib/email_web/router.ex
@@ -24,7 +24,7 @@ defmodule EmailWeb.Router do
   #   pipe_through :api
   # end
 
-  if Mix.env() in [:dev, :test] do
+  if Application.fetch_env!(:core, :env) in [:dev, :test] do
     forward "/sent_emails", Bamboo.SentEmailViewerPlug
   end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,8 +1,9 @@
-use Mix.Config
+import Config
 
 config :core,
   ecto_repos: [Core.Repo],
-  broker: Core.Conduit.Broker
+  broker: Core.Conduit.Broker,
+  env: config_env()
 
 config :piazza_core,
   repos: [Core.Repo]
@@ -156,4 +157,4 @@ config :worker,
   rollout_interval: 10,
   docker_interval: 60
 
-import_config "#{Mix.env()}.exs"
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :core, Core.Repo,
   username: "postgres",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :piazza_core,
   shutdown_delay: 14_000

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :core, Core.Repo,
   username: "postgres",

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -7,7 +7,7 @@ use Distillery.Releases.Config,
   # This sets the default release built by `mix distillery.release`
   default_release: :default,
   # This sets the default environment used by `mix distillery.release`
-  default_environment: config_env()
+  default_environment: Mix.env()
 
 environment :dev do
   set dev_mode: true

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -7,7 +7,7 @@ use Distillery.Releases.Config,
   # This sets the default release built by `mix distillery.release`
   default_release: :default,
   # This sets the default environment used by `mix distillery.release`
-  default_environment: Mix.env()
+  default_environment: config_env()
 
 environment :dev do
   set dev_mode: true


### PR DESCRIPTION
## Summary
Use of `Mix.Config` is deprecated and replaced with the [Config](https://hexdocs.pm/elixir/master/Config) module. This PR follows the instructions from the [documentation](https://hexdocs.pm/elixir/master/Config.html#module-migrating-from-use-mix-config) to migrate `Mix.Config` to the `Config` module.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.