### PR TITLE
Add scan retries

### DIFF
--- a/apps/core/lib/core/schema/docker_image.ex
+++ b/apps/core/lib/core/schema/docker_image.ex
@@ -10,6 +10,7 @@ defmodule Core.Schema.DockerImage do
     field :grade,             Grade
     field :scanned_at,        :utc_datetime_usec
     field :scan_completed_at, :utc_datetime_usec
+    field :scan_retries,      :integer, default: 0
 
     has_many   :vulnerabilities,   Vulnerability, foreign_key: :image_id, on_replace: :delete
     belongs_to :docker_repository, DockerRepository
@@ -56,7 +57,7 @@ defmodule Core.Schema.DockerImage do
 
   def vulnerability_changeset(model, attrs \\ %{}) do
     model
-    |> cast(attrs, [:scan_completed_at, :grade])
+    |> cast(attrs, [:scan_completed_at, :grade, :scan_retries])
     |> cast_assoc(:vulnerabilities)
     |> validate_required([:scan_completed_at, :grade])
   end

--- a/apps/core/lib/core/services/scan.ex
+++ b/apps/core/lib/core/services/scan.ex
@@ -29,7 +29,7 @@ defmodule Core.Services.Scan do
         end
       {output, _} ->
         Logger.info "Trivy failed with: #{output}"
-        handle_trivy_error(img)
+        Repositories.retry_scan(img)
     end
   end
 
@@ -44,11 +44,6 @@ defmodule Core.Services.Scan do
       "--use-colors", "f"
     ])
     Versions.record_scan(output, version)
-  end
-
-  defp handle_trivy_error(%DockerImage{} = img) do
-    Ecto.Changeset.change(img, %{scan_completed_at: Timex.now()})
-    |> Core.Repo.update()
   end
 
   defp terrascan_details(%Version{

--- a/apps/core/priv/repo/migrations/20221114025225_add_scan_retries.exs
+++ b/apps/core/priv/repo/migrations/20221114025225_add_scan_retries.exs
@@ -1,0 +1,9 @@
+defmodule Core.Repo.Migrations.AddScanRetries do
+  use Ecto.Migration
+
+  def change do
+    alter table(:docker_images) do
+      add :scan_retries, :integer, default: 0
+    end
+  end
+end

--- a/apps/core/test/services/repositories_test.exs
+++ b/apps/core/test/services/repositories_test.exs
@@ -437,6 +437,27 @@ defmodule Core.Services.RepositoriesTest do
     end
   end
 
+  describe "#retry_scan/1" do
+    test "if a scan has < 2 retries it's retriable" do
+      image = insert(:docker_image, scan_retries: 1)
+
+      {:ok, img} = Repositories.retry_scan(image)
+
+      assert img.id == image.id
+      assert img.scan_retries == 2
+    end
+
+    test "images with >= 2 retries are completed" do
+      image = insert(:docker_image, scan_retries: 2)
+
+      {:ok, img} = Repositories.retry_scan(image)
+
+      assert img.id == image.id
+      assert img.scan_retries == 0
+      assert img.scan_completed_at
+    end
+  end
+
   describe "#create_artifact/3" do
     test "Publishers can create artifacts" do
       %{publisher: %{owner: user}} = repo = insert(:repository)


### PR DESCRIPTION
## Summary

Looking at some scan logs, some errors really are non-retriable persistent failures.  To avoid them jamming the system, we'll need a max retry policy and hope trivy eventually fixes its issues


## Test Plan
added/modified unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.