### PR TITLE
feat(frontend): get node version from package.json in CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,10 +17,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.PLURAL_BOT_PAT }}
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        id: engines
       - name: 'Setup Node'
         uses: actions/setup-node@v3
         with:
-          node-version: 16.15.0
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
       - name: 'Update Schema'
         run: |
           yarn install --immutable

--- a/.github/workflows/www.yaml
+++ b/.github/workflows/www.yaml
@@ -34,10 +34,15 @@ jobs:
         shell: bash
         working-directory: www
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        id: engines
+      - name: 'Setup Node'
+        uses: actions/setup-node@v3
         with:
-          node-version: 16.15.0
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
       - run: yarn --immutable
       - run: yarn test
   lint:
@@ -48,10 +53,15 @@ jobs:
         shell: bash
         working-directory: www
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        id: engines
+      - name: 'Setup Node'
+        uses: actions/setup-node@v3
         with:
-          node-version: 16.15.0
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
       - run: yarn --immutable
       - run: yarn lint
   e2e:
@@ -65,10 +75,15 @@ jobs:
         shell: bash
         working-directory: www
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        id: engines
+      - name: 'Setup Node'
+        uses: actions/setup-node@v3
         with:
-          node-version: 16.15.0
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
       - run: yarn # Should run the --immutable in the CI by default
       - run: cd e2e && yarn
       - run: yarn e2e

--- a/www/package.json
+++ b/www/package.json
@@ -24,7 +24,7 @@
     "graphql:codegen": "graphql-codegen --config codegen.yml"
   },
   "engines": {
-    "node": ">=16.15.0"
+    "node": "16.15.0"
   },
   "packageManager": "yarn@3.2.4",
   "dependencies": {


### PR DESCRIPTION
## Summary
The node version in the CI was being set separately from the node version in the `package.json`. Also, since it was being set in numerous places this increases the chance of the versions diverging. This PR updates our CI to use the node version set in the `package.json`, ensuring that updates to the node version there (like by Renovate) will also be reflected in our CI runs.


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.