### PR TITLE
fix(deps): Fix regex for autoupdate of plural cli by renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,7 +45,7 @@
     {
       "description": "Update Plural CLI version for the cloud shell",
       "fileMatch": ["^apps/core/lib/core/services/shell/pods.ex$"],
-      "matchStrings": ["@image \"(?<depName>.*?):(?<currentValue>.*?)\"\\n"],
+      "matchStrings": ["(^defp image.* ||$)\"(?<depName>.*?):(?<currentValue>.*?)\""],
       "datasourceTemplate": "docker"
     }
   ],


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
After the plural cli logic rewiring in elixir backend our renovate setup could not properly find and update it automatically.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
[regex101](https://regex101.com/)

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.