### PR TITLE
Auto-backup encryption keys in cloud shell

### DIFF
--- a/apps/core/lib/core/clients/openai.ex
+++ b/apps/core/lib/core/clients/openai.ex
@@ -1,6 +1,8 @@
 defmodule Core.Clients.OpenAI do
   require Logger
 
+  @options [recv_timeout: :infinity, timeout: :infinity]
+
   defmodule Choice, do: defstruct [:text, :index, :logprobs]
 
   defmodule CompletionResponse do
@@ -18,7 +20,7 @@ defmodule Core.Clients.OpenAI do
     })
 
     url("/completions")
-    |> HTTPoison.post(body, json_headers())
+    |> HTTPoison.post(body, json_headers(), @options)
     |> handle_response(CompletionResponse.spec())
   end
 

--- a/apps/core/lib/core/clients/vault.ex
+++ b/apps/core/lib/core/clients/vault.ex
@@ -5,6 +5,8 @@ defmodule Core.Clients.Vault do
 
   def write(path, value), do: call(:write, [vpath(path), value])
 
+  def delete(path), do: call(:delete, [vpath(path)])
+
   def client() do
     Vault.new(
       engine: Vault.Engine.KVV2,

--- a/apps/core/lib/core/schema/key_backup.ex
+++ b/apps/core/lib/core/schema/key_backup.ex
@@ -29,7 +29,18 @@ defmodule Core.Schema.KeyBackup do
     |> unique_constraint(:digest, name: index_name(:key_backups, [:user_id, :name]))
     |> unique_constraint(:vault_path)
     |> foreign_key_constraint(:user_id)
+    |> repositories()
     |> validate_required([:name, :vault_path])
+  end
+
+  defp repositories(cs) do
+    case get_change(cs, :repositories) do
+      [_ | _] = repos ->
+        # technically not atomic, but this won't have high write throughput at all so nbd
+        repos = Enum.uniq(repos ++ (cs.data.repositories || []))
+        put_change(cs, :repositories, repos)
+      _ -> cs
+    end
   end
 
   defp validate_digest(cs) do

--- a/apps/core/lib/core/services/shell.ex
+++ b/apps/core/lib/core/services/shell.ex
@@ -3,7 +3,7 @@ defmodule Core.Services.Shell do
   import Core.Policies.Shell
 
   alias Core.Schema.{CloudShell, User, Recipe, Installation, OIDCProvider}
-  alias Core.Services.{Shell.Pods, Dns, Recipes, Repositories}
+  alias Core.Services.{Shell.Pods, Dns, Recipes, Repositories, Encryption}
   alias Core.Shell.{Scm, Client}
 
   @type error :: {:error, term}
@@ -55,6 +55,9 @@ defmodule Core.Services.Shell do
           |> Core.Repo.update()
         end
       %{create: shell} -> {:ok, shell}
+    end)
+    |> add_operation(:backup, fn %{git: %{git_url: url, aes_key: key, workspace: %{cluster: cluster}}} ->
+      Encryption.create_backup(%{name: "shell:#{cluster}:#{Core.random_phrase(2)}", key: key, repositories: [url]}, user)
     end)
     |> add_operation(:init, fn %{create: %CloudShell{} = shell} -> reboot(shell) end)
     |> execute(extract: :git)

--- a/apps/core/test/test_helper.exs
+++ b/apps/core/test/test_helper.exs
@@ -29,5 +29,6 @@ Mimic.copy(Core.OAuth.Github)
 Mimic.copy(Core.Services.Shell.Pods)
 Mimic.copy(Vault)
 Mimic.copy(System)
+Mimic.copy(Core.Clients.Vault)
 
 {:ok, _} = Application.ensure_all_started(:ex_machina)

--- a/apps/graphql/lib/graphql/resolvers/user.ex
+++ b/apps/graphql/lib/graphql/resolvers/user.ex
@@ -290,6 +290,9 @@ defmodule GraphQl.Resolvers.User do
   def create_key_backup(%{attributes: attrs}, %{context: %{current_user: user}}),
     do: Encryption.create_backup(attrs, user)
 
+  def delete_key_backup(%{name: name}, %{context: %{current_user: user}}),
+    do: Encryption.delete_backup(name, user)
+
   @colors ~w(#6b5b95 #feb236 #d64161 #ff7b25 #103A50 #CDCCC2 #FDC401 #8E5B3C #020001 #2F415B)
 
   def background_color(%{id: id}) do

--- a/apps/graphql/lib/graphql/schema/user.ex
+++ b/apps/graphql/lib/graphql/schema/user.ex
@@ -577,5 +577,12 @@ defmodule GraphQl.Schema.User do
 
       safe_resolve &User.create_key_backup/2
     end
+
+    field :delete_key_backup, :key_backup do
+      middleware Authenticated
+      arg :name, non_null(:string)
+
+      safe_resolve &User.delete_key_backup/2
+    end
   end
 end

--- a/apps/graphql/test/mutations/shell_mutations_test.exs
+++ b/apps/graphql/test/mutations/shell_mutations_test.exs
@@ -15,6 +15,8 @@ defmodule GraphQl.ShellMutationsTest do
           {:ok, "git@github.com:pluralsh/demo.git", "pub-key", "priv-key", nil}
       end)
 
+      expect(Core.Clients.Vault, :write, fn _, _ -> {:ok, %{}} end)
+
       attrs = %{
         "provider" => "AWS",
         "scm" => %{"provider" => "GITHUB", "token" => "tok", "name" => "demo"},

--- a/apps/graphql/test/mutations/user_mutation_test.exs
+++ b/apps/graphql/test/mutations/user_mutation_test.exs
@@ -513,4 +513,24 @@ defmodule GraphQl.UserMutationTest do
       assert created["repositories"] == ["repo"]
     end
   end
+
+  describe "deleteKeyBackup" do
+    test "it will allow deletion of key backups" do
+      user = insert(:user)
+      backup = insert(:key_backup, user: user)
+
+      expect(Core.Clients.Vault, :delete, fn _ -> {:ok, %{}} end)
+
+      {:ok, %{data: %{"deleteKeyBackup" => del}}} = run_query("""
+        mutation Delete($name: String!) {
+          deleteKeyBackup(name: $name) {
+            id
+          }
+        }
+      """, %{"name" => backup.name}, %{current_user: user})
+
+      assert del["id"] == backup.id
+      refute refetch(backup)
+    end
+  end
 end

--- a/apps/graphql/test/queries/ai_queries_test.exs
+++ b/apps/graphql/test/queries/ai_queries_test.exs
@@ -6,7 +6,7 @@ defmodule GraphQl.AIQueriesTest do
   describe "helpQuestion" do
     test "it will query gpt-3 for an answer" do
       resp = Jason.encode!(%{choices: [%{text: "a long answer to a short question"}]})
-      expect(HTTPoison, :post, fn _, _, _ -> {:ok, %HTTPoison.Response{status_code: 200, body: resp}} end)
+      expect(HTTPoison, :post, fn _, _, _, _ -> {:ok, %HTTPoison.Response{status_code: 200, body: resp}} end)
 
       {:ok, %{data: %{"helpQuestion" => result}}} = run_query("""
         query Q($prompt: String!) {


### PR DESCRIPTION
## Summary
Also supports a delete endpoint for encryption key backups you want to purge

## Test Plan
unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.