### PR TITLE
feat(backend): Add search support to dns domain list API

### DIFF
--- a/apps/core/lib/core/schema/dns_domain.ex
+++ b/apps/core/lib/core/schema/dns_domain.ex
@@ -47,4 +47,8 @@ defmodule Core.Schema.DnsDomain do
   def regex(base_domain) do
     ~r/^[a-z0-9-]+\.#{base_domain}$/
   end
+
+  def search(query \\ __MODULE__, name) do
+    from(d in query, where: ilike(d.name, ^"%#{name}%"))
+  end
 end

--- a/apps/graphql/lib/graphql/resolvers/dns.ex
+++ b/apps/graphql/lib/graphql/resolvers/dns.ex
@@ -14,6 +14,7 @@ defmodule GraphQl.Resolvers.Dns do
   def list_domains(args, %{context: %{current_user: user}}) do
     DnsDomain.for_account(user.account_id)
     |> DnsDomain.ordered()
+    |> maybe_search(DnsDomain, args)
     |> paginate(args)
   end
 

--- a/apps/graphql/lib/graphql/schema/dns.ex
+++ b/apps/graphql/lib/graphql/schema/dns.ex
@@ -76,6 +76,7 @@ defmodule GraphQl.Schema.Dns do
 
     connection field :dns_domains, node_type: :dns_domain do
       middleware Authenticated
+      arg :q, :string
 
       resolve &Dns.list_domains/2
     end

--- a/apps/graphql/test/queries/dns_queries_test.exs
+++ b/apps/graphql/test/queries/dns_queries_test.exs
@@ -19,6 +19,23 @@ defmodule Graphql.Queries.DnsTest do
       assert from_connection(found)
              |> ids_equal(domains)
     end
+
+    test "it can search domains for a user's account" do
+      user = insert(:user)
+      domain = insert(:dns_domain, account: user.account, name: "test domain")
+      insert_list(3, :dns_domain, account: user.account)
+
+      {:ok, %{data: %{"dnsDomains" => found}}} = run_query("""
+        query Domains($q: String) {
+          dnsDomains(first: 5, q: $q) {
+            edges { node { id } }
+          }
+        }
+      """, %{"q" => "test"}, %{current_user: user})
+
+      assert from_connection(found)
+             |> ids_equal([domain])
+    end
   end
 
   describe "dnsDomain" do


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Ref: [ENG-941](https://linear.app/pluralsh/issue/ENG-941/add-api-support-for-domain-search)

Added support for `q` argument to the `dnsDomains` query. It will allow moving search logic from the frontend to the backend.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Added unit test.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.