### PR TITLE
feat(frontend): Use repository name in the URL instead of id

### DIFF
--- a/www/src/components/Plural.tsx
+++ b/www/src/components/Plural.tsx
@@ -211,7 +211,7 @@ export function PluralInner() {
               </Route>
               {/* --- REPOSITORY --- */}
               <Route
-                path="/repository/:id"
+                path="/repository/:name"
                 element={<Repository />}
               >
                 <Route
@@ -277,7 +277,7 @@ export function PluralInner() {
               </Route>
               {/* --- HELM CHARTS --- */}
               <Route
-                path="/charts/:chartId"
+                path="/charts/:id"
                 element={<Chart />}
               >
                 <Route

--- a/www/src/components/audits/Audits.tsx
+++ b/www/src/components/audits/Audits.tsx
@@ -44,7 +44,7 @@ function resourceInfo({
     })
   }
 
-  if (repository) return { link: `/repository/${repository.id}`, text: `Repository{${repository.name}}` }
+  if (repository) return { link: `/repository/${repository.name}`, text: `Repository{${repository.name}}` }
 
   return { link: null, text: '' }
 }

--- a/www/src/components/marketplace/MarketplaceRepositories.tsx
+++ b/www/src/components/marketplace/MarketplaceRepositories.tsx
@@ -76,7 +76,6 @@ function MarketplaceRepositories({ installed, publisher }: any) {
   const categories = searchParams.getAll('category')
   const tags = searchParams.getAll('tag')
   const backRepositoryName = searchParams.get('backRepositoryName')
-  const backRepositoryId = searchParams.get('backRepositoryId')
   const [search, setSearch] = useState('')
   const [areFiltersOpen, setAreFiltersOpen] = useState(true)
   const tabStateRef = useRef<any>(null)
@@ -199,16 +198,16 @@ function MarketplaceRepositories({ installed, publisher }: any) {
             </LinkTabWrap>
           </TabList>
         )}
-        {publisher && !(backRepositoryName && backRepositoryId) && (
+        {publisher && !backRepositoryName && (
           <GoBack
             text="Back to marketplace"
             link="/marketplace"
           />
         )}
-        {publisher && backRepositoryName && backRepositoryId && (
+        {publisher && backRepositoryName && (
           <GoBack
             text={`Back to ${capitalize(backRepositoryName)}`}
-            link={`/repository/${backRepositoryId}`}
+            link={`/repository/${backRepositoryName}`}
           />
         )}
         {!publisher && (

--- a/www/src/components/marketplace/RepoCardList.tsx
+++ b/www/src/components/marketplace/RepoCardList.tsx
@@ -30,7 +30,7 @@ export function RepoCardList({
             <RepositoryCard
               key={repository.id}
               as={Link}
-              to={`/repository/${repository.id}${urlParams ? `?${urlParams}` : ''}`}
+              to={`/repository/${repository.name}${urlParams ? `?${urlParams}` : ''}`}
               color="text"
               textDecoration="none"
               width="100%"

--- a/www/src/components/publisher/PublisherSideNav.tsx
+++ b/www/src/components/publisher/PublisherSideNav.tsx
@@ -3,8 +3,6 @@ import { capitalize } from 'lodash'
 import { PageCard } from '@pluralsh/design-system'
 
 function PublisherSideNav({ publisher }: any) {
-  console.log(publisher)
-
   return (
     <Div
       marginLeft="medium"

--- a/www/src/components/publisher/PublisherSideNav.tsx
+++ b/www/src/components/publisher/PublisherSideNav.tsx
@@ -12,7 +12,7 @@ function PublisherSideNav({ publisher }: any) {
     >
       <PageCard
         icon={{
-          name: capitalize(publisher.name),
+          name: publisher.name,
           url: publisher.avatar,
         }}
         heading={capitalize(publisher.name)}

--- a/www/src/components/publisher/PublisherSideNav.tsx
+++ b/www/src/components/publisher/PublisherSideNav.tsx
@@ -3,6 +3,8 @@ import { capitalize } from 'lodash'
 import { PageCard } from '@pluralsh/design-system'
 
 function PublisherSideNav({ publisher }: any) {
+  console.log(publisher)
+
   return (
     <Div
       marginLeft="medium"
@@ -12,6 +14,7 @@ function PublisherSideNav({ publisher }: any) {
     >
       <PageCard
         icon={{
+          name: capitalize(publisher.name),
           url: publisher.avatar,
         }}
         heading={capitalize(publisher.name)}

--- a/www/src/components/repos/Chart.tsx
+++ b/www/src/components/repos/Chart.tsx
@@ -155,10 +155,10 @@ function ImageDependencies({ version: { imageDependencies } }: any) {
 }
 
 export default function Chart() {
-  const { chartId } = useParams()
+  const { id } = useParams()
   const { pathname } = useLocation()
   const [version, setVersion] = useState<any>(null)
-  const { data, fetchMore } = useQuery(CHART_Q, { variables: { chartId }, fetchPolicy: 'cache-and-network' })
+  const { data, fetchMore } = useQuery(CHART_Q, { variables: { id }, fetchPolicy: 'cache-and-network' })
   const tabStateRef = useRef<any>(null)
 
   if (!data) return null
@@ -212,7 +212,7 @@ export default function Chart() {
       <TopBar>
         <GoBack
           text="Back to packages"
-          link={`/repository/${chart.repository.id}/packages/helm`}
+          link={`/repository/${chart.repository.name}/packages/helm`}
         />
       </TopBar>
       <Box

--- a/www/src/components/repos/Docker.tsx
+++ b/www/src/components/repos/Docker.tsx
@@ -197,7 +197,7 @@ export function Docker() {
       <TopBar>
         <GoBack
           text="Back to packages"
-          link={`/repository/${image.dockerRepository.repository.id}/packages/docker`}
+          link={`/repository/${image.dockerRepository.repository.name}/packages/docker`}
         />
       </TopBar>
       <Box

--- a/www/src/components/repos/Terraform.tsx
+++ b/www/src/components/repos/Terraform.tsx
@@ -137,7 +137,7 @@ export default function Terraform() {
       <TopBar>
         <GoBack
           text="Back to packages"
-          link={`/repository/${terraformModule.repository.id}/packages/terraform`}
+          link={`/repository/${terraformModule.repository.name}/packages/terraform`}
         />
       </TopBar>
       <Box

--- a/www/src/components/repos/queries.ts
+++ b/www/src/components/repos/queries.ts
@@ -205,8 +205,8 @@ export const DELETE_TF = gql`
 `
 
 export const CHART_Q = gql`
-  query Charts($chartId: ID!, $cursor: String) {
-    chart(id: $chartId) {
+  query Charts($id: ID!, $cursor: String) {
+    chart(id: $id) {
       ...ChartFragment
       repository {
         ...RepoFragment
@@ -214,7 +214,7 @@ export const CHART_Q = gql`
       }
       installation { ...ChartInstallationFragment }
     }
-    versions(chartId: $chartId, first: 15, after: $cursor) {
+    versions(chartId: $id, first: 15, after: $cursor) {
       pageInfo { ...PageInfo }
       edges {
         node {

--- a/www/src/components/repository/OIDCProvider.tsx
+++ b/www/src/components/repository/OIDCProvider.tsx
@@ -330,11 +330,11 @@ export function UpdateProvider({
 export function OIDCProvider() {
   const navigate = useNavigate()
   const { installation } = useContext(RepositoryContext)
-  const { id } = useParams()
+  const { name } = useParams()
 
   useEffect(() => {
     if (!installation) navigate(-1)
-  }, [id, installation, navigate])
+  }, [name, installation, navigate])
 
   if (!installation) return null
   if (installation.oidcProvider) return <UpdateProvider installation={installation} />

--- a/www/src/components/repository/Repository.tsx
+++ b/www/src/components/repository/Repository.tsx
@@ -24,9 +24,9 @@ import { RepositorySideCar } from './RepositorySideCar'
 import { REPOSITORY_QUERY } from './queries'
 
 function Repository() {
-  const { id } = useParams()
+  const { name } = useParams()
   const [searchParams] = useSearchParams()
-  const { data } = useQuery(REPOSITORY_QUERY, { variables: { repositoryId: id } })
+  const { data } = useQuery(REPOSITORY_QUERY, { variables: { name } })
   const backStackName = searchParams.get('backStackName')
   const tabStateRef = useRef<any>(null)
 

--- a/www/src/components/repository/RepositoryPackages.tsx
+++ b/www/src/components/repository/RepositoryPackages.tsx
@@ -50,7 +50,7 @@ export default function RepositoryPackages() {
   const [q, setQ] = useState('')
   const { pathname } = useLocation()
   const tabStateRef = useRef<any>(null)
-  const pathPrefix = `/repository/${repository.id}/packages`
+  const pathPrefix = `/repository/${repository.name}/packages`
 
   const currentTab = DIRECTORY.find(tab => pathname?.startsWith(`${pathPrefix}${tab.path}`))
 

--- a/www/src/components/repository/RepositorySideNav.tsx
+++ b/www/src/components/repository/RepositorySideNav.tsx
@@ -40,7 +40,7 @@ function RepositorySideNav({
   const tabStateRef = useRef<any>()
 
   useImperativeHandle(outerTabStateRef, () => ({ ...(tabStateRef.current || {}) }))
-  const pathPrefix = `/repository/${repository.id}`
+  const pathPrefix = `/repository/${repository.name}`
   const filteredDirectory = DIRECTORY.filter(({ path }) => {
     switch (path) {
     case '/oidc':
@@ -101,7 +101,7 @@ function RepositorySideNav({
         <A
           inline
           as={Link}
-          to={`/publisher/${repository.publisher.id}?backRepositoryName=${repository.name}&backRepositoryId=${repository.id}`}
+          to={`/publisher/${repository.publisher.id}?backRepositoryName=${repository.name}`}
         >
           {capitalize(repository.publisher.name)}
         </A>

--- a/www/src/components/repository/misc.tsx
+++ b/www/src/components/repository/misc.tsx
@@ -34,7 +34,7 @@ function InstalledRepositoryActions({ installation, ...props }: any) {
         >
           <GearTrainIcon
             position="relative"
-            top={4}
+            height="24px"
           />
         </Button>
       </Flex>

--- a/www/src/components/repository/queries.ts
+++ b/www/src/components/repository/queries.ts
@@ -45,8 +45,8 @@ export const UPDATE_REPOSITORY_MUTATION = gql`
 `
 
 export const REPOSITORY_QUERY = gql`
-  query Repository($repositoryId: ID!) {
-    repository(id: $repositoryId) {
+  query Repository($repositoryId: ID, $name: String) {
+    repository(id: $repositoryId, name: $name) {
       ...RepoFragment
       editable
       publicKey


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Ref: [ENG-806](https://linear.app/pluralsh/issue/ENG-806/use-repository-name-instead-of-id-for-the-url-access)

- Used repository name instead of id where possible
- Updated publisher logo display to display initials when icon is not available
- Fixed gear icon misalignment on installed repository view

In order to update both publisher and chart views we would first need to update API to accept name, not only ID. @michaeljguarino do they also use unique names?

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.