### PR TITLE
fix: expose template type in the API

### DIFF
--- a/apps/graphql/lib/graphql/schema/version.ex
+++ b/apps/graphql/lib/graphql/schema/version.ex
@@ -23,11 +23,13 @@ defmodule GraphQl.Schema.Version do
     field :tag, non_null(:string)
   end
 
+  @desc "The version of a package."
   object :version do
     field :id,              non_null(:id)
     field :version,         non_null(:string)
     field :readme,          :string
     field :values_template, :string
+    field :template_type,   :template_type, description: "The template engine used to render the valuesTemplate."
     field :helm,            :map
     field :tags,            list_of(:version_tag), resolve: dataloader(Version)
     field :dependencies,    :dependencies
@@ -43,6 +45,9 @@ defmodule GraphQl.Schema.Version do
 
     timestamps()
   end
+
+  @desc "Template engines that can be used at build time."
+  ecto_enum :template_type, Core.Schema.Version.TemplateType
 
   object :package_scan do
     field :id, non_null(:id)


### PR DESCRIPTION
## Summary
This PR exposes the templateType in the GraphQL API so this can be used downstream by our CLI. Also it adds some descriptions to start documenting our API.


## Test Plan
Build an image and deployed it to see if the field was added to the GraphQL schema.

![image](https://user-images.githubusercontent.com/28541758/205068478-b2d050ed-52d5-4354-a8b0-32d0fd38cc55.png)


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.