### PR TITLE
chore(artifact): use updated busybox image for migration

### DIFF
--- a/plural/helm/plural/Chart.yaml
+++ b/plural/helm/plural/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: plural
 description: A helm chart for installing plural
 appVersion: 0.9.1
-version: 0.9.11
+version: 0.9.12
 dependencies:
 - name: hydra
   repository: https://k8s.ory.sh/helm/charts

--- a/plural/helm/plural/templates/_helpers.tpl
+++ b/plural/helm/plural/templates/_helpers.tpl
@@ -100,7 +100,7 @@ plural-migration-{{ .Release.Revision }}
 
 {{- define "plural.wait-for-migration" -}}
 - name: wait-for-pg
-  image: gcr.io/pluralsh/busybox:latest
+  image: gcr.io/pluralsh/library/busybox:1.35.0
   imagePullPolicy: IfNotPresent
   command: [ "/bin/sh", "-c", "until nc -zv plural-plural 5432 -w1; do echo 'waiting for db'; sleep 1; done" ]
 {{- end -}}


### PR DESCRIPTION
## Summary
With the updated image vendoring, the naming of the standard images has moved under `library/`. This PR updates the busybox image used to wait for Postgres migrations so it uses the latest image version.


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.