### PR TITLE
Send emails to all service account bindings

### DIFF
--- a/apps/core/lib/core/services/accounts.ex
+++ b/apps/core/lib/core/services/accounts.ex
@@ -227,6 +227,16 @@ defmodule Core.Services.Accounts do
     do: allow(service_account, user, :impersonate)
 
   @doc """
+  Fetch all users that can impersonate this service account.  Return just the user if not a service account
+  """
+  @spec accessible_users(User.t) :: [User.t]
+  def accessible_users(%User{service_account: true} = user) do
+    User.for_service_account(user)
+    |> Core.Repo.all()
+  end
+  def accessible_users(user), do: [user]
+
+  @doc """
   Accepts the invite and creates a new user
   """
   @spec realize_invite(map, binary) :: user_resp

--- a/apps/email/lib/email/builder/base.ex
+++ b/apps/email/lib/email/builder/base.ex
@@ -1,10 +1,14 @@
 defmodule Email.Builder.Base do
   use Bamboo.Phoenix, view: EmailWeb.EmailView
+  alias Core.Schema.User
 
   defmacro __using__(_) do
     quote do
       use Bamboo.Phoenix, view: EmailWeb.EmailView
-      import Email.Builder.Base, only: [base_email: 0]
+      import Email.Builder.Base, only: [
+        base_email: 0,
+        expand_service_account: 1
+      ]
     end
   end
 
@@ -13,4 +17,8 @@ defmodule Email.Builder.Base do
     |> from("Plural.sh<notifications@plural.sh>")
     |> put_layout({EmailWeb.LayoutView, :email})
   end
+
+  def expand_service_account(%User{service_account: true} = user),
+    do: Core.Services.Accounts.accessible_users(user)
+  def expand_service_account(user), do: user
 end

--- a/apps/email/lib/email/builder/locked_installation.ex
+++ b/apps/email/lib/email/builder/locked_installation.ex
@@ -5,7 +5,7 @@ defmodule Email.Builder.LockedInstallation do
     %{installation: %{user: user}} = inst = Core.Repo.preload(inst, [:version, installation: [:user, :repository]])
     repo = inst.installation.repository
     base_email()
-    |> to(user)
+    |> to(expand_service_account(user))
     |> subject("Breaking Changes Need to be applied for #{repo.name}")
     |> assign(:type, inst_type(inst))
     |> assign(:user, user)

--- a/apps/email/test/email/builder/locked_installation_test.exs
+++ b/apps/email/test/email/builder/locked_installation_test.exs
@@ -1,0 +1,26 @@
+defmodule Email.Builder.LockedInstallationTest do
+  use Core.SchemaCase, async: true
+  use Bamboo.Test
+
+  describe "#email/1" do
+    test "if it's sent to a service account, the recipients will be expanded" do
+      service_account = insert(:user, service_account: true)
+      user = insert(:user, account: service_account.account)
+      %{group: group} = insert(:impersonation_policy_binding,
+        policy: build(:impersonation_policy, user: service_account),
+        group: insert(:group, account: service_account.account)
+      )
+      insert(:group_member, group: group, user: user)
+
+      inst = insert(:installation, user: service_account)
+      ci = insert(:chart_installation,
+        installation: inst,
+        version: build(:version, dependencies: %{instructions: %{script: "blach", instructions: nil}})
+      )
+
+      %{to: [to]} = Email.Builder.LockedInstallation.email(ci)
+
+      assert to.id == user.id
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When we lock an installation, if it's tied to a service account, then we should send the emails to the owners of the SA to ensure they know what's up


## Test Plan
unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.