### PR TITLE
Add Feature Differentiation

### DIFF
--- a/apps/core/lib/core/guardian.ex
+++ b/apps/core/lib/core/guardian.ex
@@ -19,7 +19,7 @@ defmodule Core.Guardian do
   end
   def resource_from_claims(_claims), do: {:error, :not_authorized}
 
-  @decorate cacheable(cache: Core.Cache, key: {:login, id}, opts: [ttl: @ttl], match: &allow/1)
+  @decorate cacheable(cache: Core.Cache, key: {:login_v2, id}, opts: [ttl: @ttl], match: &allow/1)
   def fetch_user(id) do
     Users.get_user(id)
     |> Core.Services.Rbac.preload()

--- a/apps/core/lib/core/schema/platform_plan.ex
+++ b/apps/core/lib/core/schema/platform_plan.ex
@@ -33,7 +33,7 @@ defmodule Core.Schema.PlatformPlan do
     field :external_id, :string
 
     embeds_one :features, Features, on_replace: :update do
-      boolean_fields [:vpn]
+      boolean_fields [:vpn, :user_management]
     end
 
     embeds_many :line_items, LineItem, on_replace: :delete

--- a/apps/core/lib/core/services/rbac.ex
+++ b/apps/core/lib/core/services/rbac.ex
@@ -2,7 +2,7 @@ defmodule Core.Services.Rbac do
   alias Core.Schema.{User, Role}
 
   def preload(user) do
-    Core.Repo.preload(user, [:account, role_bindings: :role, group_role_bindings: :role])
+    Core.Repo.preload(user, [account: [subscription: :plan], role_bindings: :role, group_role_bindings: :role])
   end
 
   def evaluate_policy(user, policy) do

--- a/apps/graphql/lib/graphql/middleware/differentiate.ex
+++ b/apps/graphql/lib/graphql/middleware/differentiate.ex
@@ -1,0 +1,13 @@
+defmodule GraphQl.Middleware.Differentiate do
+  @behaviour Absinthe.Middleware
+  alias Absinthe.Resolution
+  alias Core.{Schema.User, Services.Payments}
+
+  def call(%{context: %{current_user: %User{} = user}} = res, %{feature: feature}) do
+    case Payments.has_feature?(user, feature) do
+      true -> res
+      false -> Resolution.put_result(res, {:error, "your account does not have access to this functionality"})
+    end
+  end
+  def call(conn, opts) when is_list(opts), do: call(conn, Map.new(opts))
+end

--- a/apps/graphql/lib/graphql/schema/account.ex
+++ b/apps/graphql/lib/graphql/schema/account.ex
@@ -245,7 +245,7 @@ defmodule GraphQl.Schema.Account do
       middleware Authenticated
       arg :id, non_null(:id)
 
-      resolve safe_resolver(&Account.resolve_role/2)
+      safe_resolve &Account.resolve_role/2
     end
 
     connection field :roles, node_type: :role do
@@ -279,9 +279,10 @@ defmodule GraphQl.Schema.Account do
   object :account_mutations do
     field :create_service_account, :user do
       middleware Authenticated
+      middleware Differentiate, feature: :user_management
       arg :attributes, non_null(:service_account_attributes)
 
-      resolve safe_resolver(&Account.create_service_account/2)
+      safe_resolve &Account.create_service_account/2
     end
 
     field :update_service_account, :user do
@@ -289,7 +290,7 @@ defmodule GraphQl.Schema.Account do
       arg :id, non_null(:id)
       arg :attributes, non_null(:service_account_attributes)
 
-      resolve safe_resolver(&Account.update_service_account/2)
+      safe_resolve &Account.update_service_account/2
     end
 
     field :impersonate_service_account, :user do
@@ -298,27 +299,27 @@ defmodule GraphQl.Schema.Account do
       arg :id,    :id
       arg :email, :string
 
-      resolve safe_resolver(&Account.impersonate_service_account/2)
+      safe_resolve &Account.impersonate_service_account/2
     end
 
     field :update_account, :account do
       middleware Authenticated
       arg :attributes, non_null(:account_attributes)
 
-      resolve safe_resolver(&Account.update_account/2)
+      safe_resolve &Account.update_account/2
     end
 
     field :create_invite, :invite do
       arg :attributes, non_null(:invite_attributes)
 
-      resolve safe_resolver(&Account.create_invite/2)
+      safe_resolve &Account.create_invite/2
     end
 
     field :delete_invite, :invite do
       arg :id, :id
       arg :secure_id, :string
 
-      resolve safe_resolver(&Account.delete_invite/2)
+      safe_resolve &Account.delete_invite/2
     end
 
     field :realize_invite, :user do
@@ -329,16 +330,17 @@ defmodule GraphQl.Schema.Account do
 
     field :create_group, :group do
       middleware Authenticated
+      middleware Differentiate, feature: :user_management
       arg :attributes, non_null(:group_attributes)
 
-      resolve safe_resolver(&Account.create_group/2)
+      safe_resolve &Account.create_group/2
     end
 
     field :delete_group, :group do
       middleware Authenticated
       arg :group_id, non_null(:id)
 
-      resolve safe_resolver(&Account.delete_group/2)
+      safe_resolve &Account.delete_group/2
     end
 
     field :update_group, :group do
@@ -346,7 +348,7 @@ defmodule GraphQl.Schema.Account do
       arg :group_id, non_null(:id)
       arg :attributes, non_null(:group_attributes)
 
-      resolve safe_resolver(&Account.update_group/2)
+      safe_resolve &Account.update_group/2
     end
 
     field :create_group_member, :group_member do
@@ -354,7 +356,7 @@ defmodule GraphQl.Schema.Account do
       arg :group_id, non_null(:id)
       arg :user_id, non_null(:id)
 
-      resolve safe_resolver(&Account.create_group_member/2)
+      safe_resolve &Account.create_group_member/2
     end
 
     field :delete_group_member, :group_member do
@@ -362,14 +364,15 @@ defmodule GraphQl.Schema.Account do
       arg :group_id, non_null(:id)
       arg :user_id, non_null(:id)
 
-      resolve safe_resolver(&Account.delete_group_member/2)
+      safe_resolve &Account.delete_group_member/2
     end
 
     field :create_role, :role do
       middleware Authenticated
+      middleware Differentiate, feature: :user_management
       arg :attributes, non_null(:role_attributes)
 
-      resolve safe_resolver(&Account.create_role/2)
+      safe_resolve &Account.create_role/2
     end
 
     field :update_role, :role do
@@ -377,21 +380,21 @@ defmodule GraphQl.Schema.Account do
       arg :id, non_null(:id)
       arg :attributes, non_null(:role_attributes)
 
-      resolve safe_resolver(&Account.update_role/2)
+      safe_resolve &Account.update_role/2
     end
 
     field :delete_role, :role do
       middleware Authenticated
       arg :id, non_null(:id)
 
-      resolve safe_resolver(&Account.delete_role/2)
+      safe_resolve &Account.delete_role/2
     end
 
     field :create_integration_webhook, :integration_webhook do
       middleware Authenticated
       arg :attributes, non_null(:integration_webhook_attributes)
 
-      resolve safe_resolver(&Account.create_webhook/2)
+      safe_resolve &Account.create_webhook/2
     end
 
     field :update_integration_webhook, :integration_webhook do
@@ -399,28 +402,28 @@ defmodule GraphQl.Schema.Account do
       arg :id, non_null(:id)
       arg :attributes, non_null(:integration_webhook_attributes)
 
-      resolve safe_resolver(&Account.update_webhook/2)
+      safe_resolve &Account.update_webhook/2
     end
 
     field :delete_integration_webhook, :integration_webhook do
       middleware Authenticated
       arg :id, non_null(:id)
 
-      resolve safe_resolver(&Account.delete_webhook/2)
+      safe_resolve &Account.delete_webhook/2
     end
 
     field :create_oauth_integration, :oauth_integration do
       middleware Authenticated
       arg :attributes, non_null(:oauth_attributes)
 
-      resolve safe_resolver(&Account.create_integration/2)
+      safe_resolve &Account.create_integration/2
     end
 
     field :create_zoom, :zoom_meeting do
       middleware Authenticated, :external
       arg :attributes, non_null(:meeting_attributes)
 
-      resolve safe_resolver(&Account.create_zoom_meeting/2)
+      safe_resolve &Account.create_zoom_meeting/2
     end
   end
 end

--- a/apps/graphql/lib/graphql/schema/base/base.ex
+++ b/apps/graphql/lib/graphql/schema/base/base.ex
@@ -6,7 +6,7 @@ defmodule GraphQl.Schema.Base do
       import Absinthe.Resolution.Helpers
       import GraphQl.Schema.Helpers
       import GraphQl.Schema.Base
-      alias GraphQl.Middleware.Authenticated
+      alias GraphQl.Middleware.{Authenticated, Differentiate}
     end
   end
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -88,4 +88,5 @@ config :worker,
   docker_interval: 1
 
 config :core,
-  workos_webhook: "supersecret"
+  workos_webhook: "supersecret",
+  enforce_pricing: true

--- a/rel/config/config.exs
+++ b/rel/config/config.exs
@@ -78,7 +78,8 @@ config :core,
   docker_metrics_table: ~s("permanent"."downsampled_docker_pulls"),
   workos_webhook: get_env("WORKOS_WEBHOOK_SECRET"),
   gcp_identity: get_env("GCP_USER_EMAIL") || "mjg@plural.sh",
-  openai_token: get_env("OPENAI_BEARER_TOKEN")
+  openai_token: get_env("OPENAI_BEARER_TOKEN"),
+  enforce_pricing: get_env("ENFORCE_PRICING")
 
 
 if get_env("VAULT_HOST") do


### PR DESCRIPTION
## Summary

This enables feature differentiation for platform plans.  The implementation is actually very simple, just:

* add a boolean function to determine if enforcement is enabled and if so, if a user's plan is enforceable
* graphql middleware to apply it for specific mutations
  * we only do it on create mutations, so grandfathered/downgraded accounts can still use existing groups/roles/service accounts and not impair service
* rev caching so the standard user cache starts slurping in platform plans and this doesn't require a db round-trip

There is a killswitch to be able to quickly enable/disable as well


## Test Plan
unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.