### PR TITLE
fix(ci): require frontend build for release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -192,7 +192,7 @@ jobs:
   release:
     name: Create GitHub release
     runs-on: ubuntu-20.04
-    needs: publish
+    needs: [publish, publish-frontend]
     permissions:
       contents: write
       discussions: write


### PR DESCRIPTION
## Summary
Currently the release action will still create the github release even if the frontend container build has failed. This PR ensures the frontend container is also built before the github release is created.
