### PR TITLE
chore(deps): update AWS node group amis to k8s 1.22

### DIFF
--- a/plural/terraform/aws/deps.yaml
+++ b/plural/terraform/aws/deps.yaml
@@ -2,12 +2,12 @@ dependencies:
 - name: aws-bootstrap
   repo: bootstrap
   type: terraform
-  version: '>= 0.1.1'
+  version: '>= 0.1.46'
 
 providers:
 - aws
 description: plural aws setup
-version: 0.1.4
+version: 0.1.5
 
 wirings:
   terraform: {}

--- a/plural/terraform/aws/node-groups.tf
+++ b/plural/terraform/aws/node-groups.tf
@@ -1,5 +1,5 @@
 module "node_groups" {
-  source                 = "github.com/pluralsh/module-library//terraform/eks-node-groups/single-az-node-groups?ref=df068595c3e91590d11e1ace11e1d688630f03d6"
+  source                 = "github.com/pluralsh/module-library//terraform/eks-node-groups/single-az-node-groups?ref=20e64863ffc5e361045db8e6b81b9d244a55809e"
   cluster_name           = var.cluster_name
   default_iam_role_arn   = var.node_role_arn
   tags                   = var.tags

--- a/plural/terraform/aws/shell.tf
+++ b/plural/terraform/aws/shell.tf
@@ -1,25 +1,16 @@
 module "shell_node_group" {
-  source = "github.com/pluralsh/module-library//terraform/eks-node-groups/multi-az-node-group"
-  
-  node_group_name = "shell-nodes"
-  cluster_name    = var.cluster_name
-  instance_types  = ["t3.large"]
-  subnet_ids      = var.shell_subnet_ids
-  desired_size    = 1
-  min_capacity    = 1
-  max_capacity    = 10
-  
-  labels = {
-    "platform.plural.sh/instance-class" = "shell"
-  }
+  source = "github.com/pluralsh/module-library//terraform/eks-node-groups/multi-az-node-groups?ref=20e64863ffc5e361045db8e6b81b9d244a55809e"
+  cluster_name           = var.cluster_name
+  default_iam_role_arn   = var.node_role_arn
+  tags                   = var.tags
+  node_groups_defaults   = var.node_groups_defaults
 
-  tags = {}
+  node_groups            = var.shell_node_groups
+  set_desired_size       = false
+  private_subnet_ids        = var.private_subnet_ids
+}
 
-  taints = [
-    {
-      key = "platform.plural.sh/taint"
-      value = "SHELL"
-      effect = "NO_SCHEDULE"
-    }
-  ]
+moved {
+  from = module.shell_node_group.aws_eks_node_group.gpu_inf_small
+  to   = module.shell_node_group.aws_eks_node_group.workers["shell_nodes"]
 }

--- a/plural/terraform/aws/terraform.tfvars
+++ b/plural/terraform/aws/terraform.tfvars
@@ -5,7 +5,7 @@ plural_assets_bucket = {{ .Values.assets_bucket | quote }}
 plural_images_bucket = {{ .Values.images_bucket | quote }}
 plural_namespace = {{ .Namespace | quote }}
 cluster_name = {{ .Cluster | quote }}
-shell_subnet_ids = {{ $bootstrap.cluster_worker_private_subnet_ids | toJson }}
+private_subnet_ids = {{ $bootstrap.cluster_worker_private_subnet_ids | toJson }}
 node_role_arn = {{ (index $bootstrap.node_groups 0).node_role_arn | quote }}
 private_subnets = yamldecode(<<EOT
 {{ $bootstrap.cluster_worker_private_subnets | toYaml }}

--- a/plural/terraform/aws/variables.tf
+++ b/plural/terraform/aws/variables.tf
@@ -48,7 +48,7 @@ The k8s service account that will be used for plural deployments
 EOF
 }
 
-variable "shell_subnet_ids" {
+variable "private_subnet_ids" {
   type = list(string)
 }
 
@@ -72,7 +72,7 @@ variable "node_groups_defaults" {
 
     instance_types = ["t3.large", "t3a.large"]
     disk_size = 50
-    ami_release_version = "1.21.14-20220824"
+    ami_release_version = "1.22.15-20221222"
     force_update_version = true
     ami_type = "AL2_x86_64"
     k8s_labels = {}
@@ -125,6 +125,39 @@ variable "single_az_node_groups" {
     }
   }
   description = "Node groups to add to your cluster. A single managed node group will be created in each availability zone."
+}
+
+variable "shell_node_groups" {
+  type = any
+  default = {
+    shell_nodes = {
+      name = "shell-nodes"
+      capacity_type = "ON_DEMAND"
+      min_capacity = 1
+      max_capacity = 10
+      desired_capacity = 1
+      instance_types = ["t3.large"]
+      k8s_labels = {
+        "plural.sh/capacityType" = "ON_DEMAND"
+        "plural.sh/performanceType" = "SUSTAINED"
+        "plural.sh/scalingGroup" = "shell-nodes"
+        "platform.plural.sh/instance-class" = "shell"
+      }
+      k8s_taints = [
+        {
+          key = "platform.plural.sh/taint"
+          value = "SHELL"
+          effect = "NO_SCHEDULE"
+        }
+        # {
+        #   key = "plural.sh/pluralReserved"
+        #   value = "true"
+        #   effect = "NO_SCHEDULE"
+        # }
+      ]
+    }
+  }
+  description = "Node groups to add to your cluster. A single managed node group will be created across all availability zones."
 }
 
 variable "private_subnets" {


### PR DESCRIPTION
## Summary
This PR updates the AMIs of the Plural node groups to use the latest version for Kubernetes 1.22. It also migrates the shell node group to use the latest version of the upstream module from our module library, which ensure the cluster autoscaler will work correctly (it was broken before this change since the autoscaler wouldn't be aware of the labels and taints).


## Test Plan
Local linking.


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.