### PR TITLE
fix hydra admin url due to upstream bug

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -145,7 +145,7 @@ config :worker, demo_projects_pipeline: []
 config :worker, docker_pipeline: []
 
 config :core, Core.Clients.Hydra,
-  hydra_admin: "http://plural-hydra-admin:4445",
+  hydra_admin: "http://plural-hydra-admin:4445/admin",
   hydra_public: "http://plural-hydra-public:4444"
 
 config :rtc, :flushable, false


### PR DESCRIPTION
## Summary
The hydra admin api url changed to being hosted at `/admin`, causing a redirect when our API tries to talk to the Hydra admin API. This PR configures the hydra admin api to include the `/admin` path.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.