### PR TITLE
Implement delinquency enforcement

### DIFF
--- a/apps/core/lib/core/schema/account.ex
+++ b/apps/core/lib/core/schema/account.ex
@@ -10,6 +10,7 @@ defmodule Core.Schema.Account do
     field :icon,                 Core.Storage.Type
     field :billing_customer_id,  :string
     field :delinquent_at,        :utc_datetime_usec
+    field :grandfathered_until,  :utc_datetime_usec
     field :user_count,           :integer, default: 0
     field :cluster_count,        :integer, default: 0
     field :usage_updated,        :boolean

--- a/apps/core/priv/repo/migrations/20230105230510_add_grandfathered_until.exs
+++ b/apps/core/priv/repo/migrations/20230105230510_add_grandfathered_until.exs
@@ -1,0 +1,9 @@
+defmodule Core.Repo.Migrations.AddGrandfatheredUntil do
+  use Ecto.Migration
+
+  def change do
+    alter table(:accounts) do
+      add :grandfathered_until, :utc_datetime_usec
+    end
+  end
+end

--- a/apps/core/test/support/test_helpers.ex
+++ b/apps/core/test/support/test_helpers.ex
@@ -27,5 +27,10 @@ defmodule Core.TestHelpers do
 
   def refetch(%{__struct__: schema, id: id}), do: Core.Repo.get(schema, id)
 
+  def update_record(struct, attrs) do
+    Ecto.Changeset.change(struct, attrs)
+    |> Core.Repo.update()
+  end
+
   def priv_file(app, path), do: Path.join(:code.priv_dir(app), path)
 end

--- a/apps/graphql/lib/graphql/schema/account.ex
+++ b/apps/graphql/lib/graphql/schema/account.ex
@@ -82,6 +82,7 @@ defmodule GraphQl.Schema.Account do
     field :billing_customer_id,  :string
     field :workos_connection_id, :string
     field :delinquent_at,        :datetime
+    field :grandfathered_unitl,  :datetime
 
     field :icon, :string, resolve: fn
       account, _, _ -> {:ok, Core.Storage.url({account.icon, account}, :original)}


### PR DESCRIPTION
## Summary
The two actions we can easily do for delinquent accounts are:

* disable premium features
* disable upgrade delivery

we might need to figure out some more solutions here, but those seem fine for now.  Also this implements a simple grandfathering mechanism as well.

## Test Plan
added unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.