### PR TITLE
Implement subscription delete api

### DIFF
--- a/apps/graphql/lib/graphql/resolvers/payments.ex
+++ b/apps/graphql/lib/graphql/resolvers/payments.ex
@@ -94,6 +94,9 @@ defmodule GraphQl.Resolvers.Payments do
   def create_platform_subscription(%{attributes: attrs, plan_id: id}, %{context: %{current_user: user}}),
     do: Payments.create_platform_subscription(attrs, id, user)
 
+  def delete_platform_subscription(_, %{context: %{current_user: user}}),
+    do: Payments.delete_platform_subscription(user)
+
   def update_platform_plan(%{plan_id: id}, %{context: %{current_user: user}}),
     do: Payments.update_platform_plan(id, user)
 

--- a/apps/graphql/lib/graphql/schema/payments.ex
+++ b/apps/graphql/lib/graphql/schema/payments.ex
@@ -317,6 +317,12 @@ defmodule GraphQl.Schema.Payments do
       safe_resolve &Payments.create_platform_subscription/2
     end
 
+    field :delete_platform_subscription, :account do
+      middleware Authenticated
+
+      safe_resolve &Payments.delete_platform_subscription/2
+    end
+
     field :cancel_platform_subscription, :platform_subscription do
       middleware Authenticated
 

--- a/apps/graphql/test/mutations/payments_mutation_test.exs
+++ b/apps/graphql/test/mutations/payments_mutation_test.exs
@@ -378,6 +378,23 @@ defmodule GraphQl.PaymentsMutationsTest do
     end
   end
 
+  describe "deletePlatformSubscription" do
+    test "it can delete your subscription" do
+      user = insert(:user, roles: %{admin: true})
+      sub = insert(:platform_subscription, account: user.account, external_id: "ext_id")
+      expect(Stripe.Subscription, :delete, fn "ext_id" -> {:ok, %{}} end)
+
+      {:ok, %{data: %{"deletePlatformSubscription" => %{"id" => id}}}} = run_query("""
+        mutation {
+          deletePlatformSubscription { id }
+        }
+      """, %{}, %{current_user: user})
+
+      assert id == user.account_id
+      refute refetch(sub)
+    end
+  end
+
   describe "updatePlatformPlan" do
     test "it can update a platform plan" do
       expect(Stripe.Subscription, :update, fn


### PR DESCRIPTION
## Summary
This will be used for people who want to leave a paid tier and return to free.


## Test Plan
added unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.