### PR TITLE
Add ability to autoprovision service account rbac

### DIFF
--- a/apps/core/lib/core/schema/account.ex
+++ b/apps/core/lib/core/schema/account.ex
@@ -14,6 +14,7 @@ defmodule Core.Schema.Account do
     field :user_count,           :integer, default: 0
     field :cluster_count,        :integer, default: 0
     field :usage_updated,        :boolean
+    field :sa_provisioned,       :boolean
 
     belongs_to :root_user, User
     has_many :domain_mappings, DomainMapping, on_replace: :delete
@@ -39,7 +40,7 @@ defmodule Core.Schema.Account do
     )
   end
 
-  @valid ~w(name workos_connection_id)a
+  @valid ~w(name workos_connection_id sa_provisioned)a
   @payment ~w(billing_customer_id)a
 
   def changeset(model, attrs \\ %{}) do

--- a/apps/core/lib/core/schema/platform_plan.ex
+++ b/apps/core/lib/core/schema/platform_plan.ex
@@ -28,6 +28,7 @@ defmodule Core.Schema.PlatformPlan do
   schema "platform_plans" do
     field :name,        :string
     field :visible,     :boolean, default: true
+    field :enterprise,  :boolean
     field :cost,        :integer
     field :period,      Period
     field :external_id, :string

--- a/apps/core/lib/core/services/payments.ex
+++ b/apps/core/lib/core/services/payments.ex
@@ -139,6 +139,7 @@ defmodule Core.Services.Payments do
       {false, _, _, _} -> true
       {_, true, _, _} -> false
       {_, _, true, _} -> true
+      {_, _, _, %User{account: %Account{subscription: %PlatformSubscription{plan: %PlatformPlan{enterprise: true}}}}} -> true
       {_, _, _, %User{account: %Account{subscription: %PlatformSubscription{plan: %PlatformPlan{features: %{^feature => true}}}}}} -> true
       _ -> false
     end
@@ -333,6 +334,7 @@ defmodule Core.Services.Payments do
         name: "Enterprise",
         period: :monthly,
         visible: true,
+        enterprise: true,
         features: %{vpn: true, user_management: true},
         line_items: [
           %{name: "User", dimension: :user, period: :monthly, cost: 4900}, # these costs are arbitrary, as won't be billed through stripe

--- a/apps/core/priv/repo/migrations/20230109223232_add_role_provisioned_bool.exs
+++ b/apps/core/priv/repo/migrations/20230109223232_add_role_provisioned_bool.exs
@@ -1,0 +1,13 @@
+defmodule Core.Repo.Migrations.AddRoleProvisionedBool do
+  use Ecto.Migration
+
+  def change do
+    alter table(:accounts) do
+      add :sa_provisioned, :boolean
+    end
+
+    alter table(:platform_plans) do
+      add :enterprise, :boolean
+    end
+  end
+end

--- a/apps/core/priv/repo/seeds/012_enterprise_plan.exs
+++ b/apps/core/priv/repo/seeds/012_enterprise_plan.exs
@@ -1,0 +1,8 @@
+import Botanist
+
+seed do
+  enterprise = Core.Services.Payments.get_platform_plan_by_name!("Enterprise")
+
+  Ecto.Changeset.change(enterprise, %{enterprise: true})
+  |> Core.Repo.update!()
+end

--- a/apps/core/test/services/accounts_test.exs
+++ b/apps/core/test/services/accounts_test.exs
@@ -22,6 +22,15 @@ defmodule Core.Services.AccountsTest do
 
       assert binding.group_id == group.id
 
+      %{groups: [group], group_role_bindings: [%{role: role}]} = Core.Services.Rbac.preload(srv_acct)
+
+      assert group.name == "service-accounts"
+      assert group.account_id == srv_acct.account_id
+      assert role.name == "service-accounts"
+      assert role.permissions.install
+
+      assert refetch(user.account).sa_provisioned
+
       assert_receive {:event, %PubSub.UserCreated{item: ^srv_acct}}
     end
 

--- a/apps/core/test/services/payments_test.exs
+++ b/apps/core/test/services/payments_test.exs
@@ -546,6 +546,13 @@ defmodule Core.Services.PaymentsTest do
       assert Payments.has_feature?(user, :user_management)
     end
 
+    test "if a user's plan is enterprise, it get's any feature" do
+      account = insert(:account)
+      insert(:platform_subscription, account: account, plan: build(:platform_plan, enterprise: true, features: %{user_management: false}))
+      user = insert(:user, account: account)
+      assert Payments.has_feature?(user, :user_management)
+    end
+
     test "if a user's account is grandfathered, then it returns true" do
       account = insert(:account, grandfathered_until: Timex.now() |> Timex.shift(days: 1))
       insert(:platform_subscription, account: account, plan: build(:platform_plan, features: %{user_management: false}))

--- a/apps/graphql/lib/graphql/schema/payments.ex
+++ b/apps/graphql/lib/graphql/schema/payments.ex
@@ -99,6 +99,7 @@ defmodule GraphQl.Schema.Payments do
     field :visible,        non_null(:boolean)
     field :cost,           non_null(:integer)
     field :period,         non_null(:payment_period)
+    field :enterprise,     :boolean
     field :features,       :plan_features
     field :line_items,     list_of(:platform_plan_item)
 


### PR DESCRIPTION
## Summary

A lot of users get tripped up creating service accounts and not realizing they need to give them install perms. This will simplify this dramatically while also allowing users to remove perms in the future.

also added an enterprise bool for some plan logic

## Test Plan
added tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.