### PR TITLE
Cluster Schema Setup

### DIFF
--- a/apps/core/lib/core/backfill/clusters.ex
+++ b/apps/core/lib/core/backfill/clusters.ex
@@ -1,0 +1,11 @@
+defmodule Core.Backfill.Clusters do
+  alias Core.Schema.UpgradeQueue
+
+  def from_queues() do
+    UpgradeQueue
+    |> UpgradeQueue.ordered(asc: :id)
+    |> Core.Repo.stream(method: :keyset)
+    |> Core.throttle()
+    |> Enum.each(&Core.Services.Clusters.create_from_queue/1)
+  end
+end

--- a/apps/core/lib/core/policies/cluster.ex
+++ b/apps/core/lib/core/policies/cluster.ex
@@ -1,0 +1,11 @@
+defmodule Core.Policies.Cluster do
+  use Piazza.Policy
+  alias Core.Schema.{User, Cluster}
+
+  def can?(%User{id: uid}, %Cluster{owner_id: uid}, _), do: :pass
+
+  def can?(%User{} = user, %Cluster{owner: %User{} = owner}, :access),
+    do: Core.Policies.Account.can?(user, owner, :impersonate)
+
+  def can?(_, _, _), do: {:error, :forbidden}
+end

--- a/apps/core/lib/core/schema/cluster.ex
+++ b/apps/core/lib/core/schema/cluster.ex
@@ -1,0 +1,50 @@
+defmodule Core.Schema.Cluster do
+  use Piazza.Ecto.Schema
+  alias Core.Schema.{
+    User,
+    Account,
+    UpgradeQueue,
+    Recipe.Provider,
+    Installation.Source
+  }
+
+  schema "clusters" do
+    field :provider,    Provider
+    field :name,        :string
+    field :console_url, :string
+    field :source,      Source
+    field :git_url,     :string
+    field :domain,      :string
+    field :pinged_at,   :utc_datetime_usec
+
+    belongs_to :owner,   User
+    belongs_to :account, Account
+    has_one :queue,      UpgradeQueue
+
+    timestamps()
+  end
+
+  def for_user(query \\ __MODULE__, %User{id: user_id, account_id: account_id} = user) do
+    accessible = User.accessible(user)
+    from(c in query,
+      left_join: u in subquery(accessible),
+      where: c.account_id == ^account_id and (c.owner_id == ^user_id or c.owner_id == u.id),
+      distinct: true
+    )
+  end
+
+  def ordered(query \\ __MODULE__, order \\ [asc: :name]) do
+    from(c in query, order_by: ^order)
+  end
+
+  @valid ~w(owner_id account_id provider name domain console_url source git_url pinged_at)a
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, @valid)
+    |> foreign_key_constraint(:owner_id)
+    |> foreign_key_constraint(:account_id)
+    |> unique_constraint(:name, name: index_name(:clusters, [:account_id, :provider, :name]))
+    |> validate_required([:name, :provider, :owner_id, :account_id])
+  end
+end

--- a/apps/core/lib/core/schema/upgrade_queue.ex
+++ b/apps/core/lib/core/schema/upgrade_queue.ex
@@ -1,6 +1,6 @@
 defmodule Core.Schema.UpgradeQueue do
   use Piazza.Ecto.Schema
-  alias Core.Schema.User
+  alias Core.Schema.{User, Cluster}
 
   @expiry 1
 
@@ -13,6 +13,7 @@ defmodule Core.Schema.UpgradeQueue do
     field :pinged_at, :utc_datetime_usec
 
     belongs_to :user, User
+    belongs_to :cluster, Cluster
 
     timestamps()
   end
@@ -30,13 +31,14 @@ defmodule Core.Schema.UpgradeQueue do
     from(q in query, where: q.pinged_at < ^expiry)
   end
 
-  @valid ~w(acked user_id name domain git provider)a
+  @valid ~w(acked user_id name domain git provider cluster_id)a
 
   def changeset(model, attrs \\ %{}) do
     model
     |> cast(attrs, @valid)
     |> validate_required([:user_id])
     |> foreign_key_constraint(:user_id)
+    |> unique_constraint(:cluster_id)
     |> unique_constraint(:name, name: index_name(:upgrade_queues, [:user_id, :name]))
   end
 end

--- a/apps/core/lib/core/schema/user.ex
+++ b/apps/core/lib/core/schema/user.ex
@@ -114,6 +114,17 @@ defmodule Core.Schema.User do
   end
   def for_service_account(query, _), do: for_bindings(query, [])
 
+  def accessible(query \\ __MODULE__, %__MODULE__{id: user_id, groups: groups}) do
+    group_ids = Enum.map(groups, & &1.id)
+
+    from(u in query,
+      join: p in assoc(u, :impersonation_policy),
+      join: b in assoc(p, :bindings),
+      where: b.group_id in ^group_ids or b.user_id == ^user_id,
+      distinct: true
+    )
+  end
+
   defp for_bindings(query, bindings) do
     user_ids  = Enum.filter(bindings, & &1.user_id) |> Enum.map(& &1.user_id)
     group_ids = Enum.filter(bindings, & &1.group_id) |> Enum.map(& &1.group_id)

--- a/apps/core/lib/core/services/clusters.ex
+++ b/apps/core/lib/core/services/clusters.ex
@@ -1,0 +1,101 @@
+defmodule Core.Services.Clusters do
+  use Core.Services.Base
+  import Core.Policies.Cluster
+  alias Core.Services.{Dns, Repositories}
+  alias Core.Schema.{Cluster, User, DnsRecord, UpgradeQueue}
+
+  @type error :: {:error, term}
+  @type cluster_resp :: {:ok, Cluster.t} | error
+
+  @spec get_cluster(binary, atom, binary) :: Cluster.t | nil
+  def get_cluster(account_id, provider, name) do
+    Core.Repo.get_by(Cluster, account_id: account_id, provider: provider, name: name)
+  end
+
+  @doc """
+  Determines if a user has access to the cluster referenced by `id`
+  """
+  @spec authorize(binary, User.t) :: cluster_resp
+  def authorize(id, %User{} = user) when is_binary(id) do
+    Core.Repo.get(Cluster, id)
+    |> Core.Repo.preload([owner: [impersonation_policy: :bindings]])
+    |> allow(user, :access)
+  end
+
+  @doc """
+  creates a cluster reference with this user as the marked owner
+  """
+  @spec create_cluster(map, User.t) :: cluster_resp
+  def create_cluster(attrs, %User{id: user_id, account_id: account_id} = user) do
+    %Cluster{owner_id: user_id, account_id: account_id}
+    |> Cluster.changeset(Map.put_new_lazy(attrs, :source, fn -> Repositories.installation_source(user) end))
+    |> Core.Repo.insert()
+  end
+
+  @doc """
+  creates a cluster record from an upgrade queue.  Also ties the cluster back onto that queue
+  """
+  @spec create_from_queue(UpgradeQueue.t) :: cluster_resp
+  def create_from_queue(%UpgradeQueue{name: n, provider: p, git: g, domain: d, pinged_at: pinged} = q) do
+    %{user: user} = Core.Repo.preload(q, [:user])
+
+    start_transaction()
+    |> add_operation(:cluster, fn _ ->
+      case get_cluster(user.account_id, p, n) do
+        %Cluster{} = c ->
+          Cluster.changeset(c, %{console_url: d})
+          |> Core.Repo.update()
+        _ ->
+          create_cluster(%{
+            name: n,
+            provider: p,
+            git_url: g,
+            console_url: d,
+            domain: infer_domain(d),
+            pinged_at: pinged
+          }, user)
+      end
+    end)
+    |> add_operation(:queue, fn %{cluster: %Cluster{id: id}} ->
+      UpgradeQueue.changeset(q, %{cluster_id: id})
+      |> Core.Repo.update()
+    end)
+    |> execute(extract: :cluster)
+  end
+
+  defp infer_domain(console_url) when is_binary(console_url) do
+    case String.split(console_url, ".") do
+      [_ | rest] when rest != [] -> Enum.join(rest, ".")
+      _ -> nil
+    end
+  end
+  defp infer_domain(_), do: nil
+
+  @doc """
+  deletes the cluster reference and flushes associated records
+  """
+  @spec delete_cluster(binary, binary, User.t) :: cluster_resp
+  def delete_cluster(name, provider, %User{id: user_id} = user) do
+    start_transaction()
+    |> add_operation(:cluster, fn _ ->
+      case get_cluster(user.account_id, provider, name) do
+        %Cluster{owner_id: ^user_id} = cluster -> Core.Repo.delete(cluster)
+        %Cluster{} -> {:error, "cannot delete a cluster you don't own"}
+        nil -> {:error, "not found"}
+      end
+    end)
+    |> add_operation(:rest, fn %{cluster: cluster} -> {:ok, flush_dns(cluster)} end)
+    |> execute(extract: :cluster)
+  end
+
+  defp flush_dns(%Cluster{name: name, provider: p, owner_id: user_id, domain: domain}) when is_binary(domain) do
+    Dns.get_domain(domain)
+    |> Dns.records()
+    |> Enum.filter(fn
+      %DnsRecord{cluster: ^name, provider: ^p, creator_id: ^user_id} -> true
+      _ -> false
+    end)
+    |> Enum.each(&Core.Conduit.Broker.publish(%Conduit.Message{body: &1}, :cluster))
+  end
+  defp flush_dns(_), do: :ok
+end

--- a/apps/core/lib/core/services/repositories.ex
+++ b/apps/core/lib/core/services/repositories.ex
@@ -372,7 +372,7 @@ defmodule Core.Services.Repositories do
     do: Map.put(attrs, :track_tag, tag)
   defp add_track_tag(attrs, _), do: attrs
 
-  defp installation_source(%User{id: id}) do
+  def installation_source(%User{id: id}) do
     Core.local_cache({:inst_source, id}, fn ->
       case {Demo.has_demo?(id), Shell.has_shell?(id)} do
         {true, _} -> :demo

--- a/apps/core/lib/core/services/upgrades.ex
+++ b/apps/core/lib/core/services/upgrades.ex
@@ -9,7 +9,7 @@ defmodule Core.Services.Upgrades do
     ChartInstallation,
     TerraformInstallation
   }
-  alias Core.Services.{Dependencies, Locks}
+  alias Core.Services.{Dependencies, Locks, Clusters}
   alias Core.PubSub
 
   def get_queue(id), do: Core.Repo.get(UpgradeQueue, id)
@@ -22,7 +22,9 @@ defmodule Core.Services.Upgrades do
   end
 
   def authorize(id, %User{id: user_id}) do
-    case get_queue(id) do
+    get_queue(id)
+    |> Core.Repo.preload([:cluster])
+    |> case do
       %UpgradeQueue{user_id: ^user_id} = q -> {:ok, q}
       _ -> {:error, :unauthorized}
     end
@@ -114,7 +116,9 @@ defmodule Core.Services.Upgrades do
       |> UpgradeQueue.changeset(attrs)
       |> Core.Repo.insert_or_update()
     end)
-    |> execute(extract: :queue)
+    |> add_operation(:cluster, fn %{queue: q} -> Clusters.create_from_queue(q) end)
+    |> add_operation(:refetch, fn %{queue: q} -> {:ok, get_queue(q.id)} end)
+    |> execute(extract: :refetch)
     |> notify(:upsert, queue)
   end
 
@@ -149,8 +153,22 @@ defmodule Core.Services.Upgrades do
   end
 
   def ping(%UpgradeQueue{} = q) do
-    Ecto.Changeset.change(q, %{pinged_at: Timex.now()})
-    |> Core.Repo.update()
+    %{cluster: cluster} = Core.Repo.preload(q, [:cluster])
+
+    start_transaction()
+    |> add_operation(:queue, fn _ ->
+      Ecto.Changeset.change(q, %{pinged_at: Timex.now()})
+      |> Core.Repo.update()
+    end)
+    |> add_operation(:cluster, fn _ ->
+      case cluster do
+        nil -> {:ok, %{}}
+        _ ->
+          Ecto.Changeset.change(cluster, %{pinged_at: Timex.now()})
+          |> Core.Repo.update()
+      end
+    end)
+    |> execute(extract: :queue)
     |> notify(:update)
   end
 

--- a/apps/core/priv/repo/migrations/20230115004239_add_clusters.exs
+++ b/apps/core/priv/repo/migrations/20230115004239_add_clusters.exs
@@ -1,0 +1,31 @@
+defmodule Core.Repo.Migrations.AddClusters do
+  use Ecto.Migration
+
+  def change do
+    create table(:clusters, primary_key: false) do
+      add :id,          :uuid, primary_key: true
+      add :provider,    :integer
+      add :name,        :string
+      add :domain,      :string
+      add :console_url, :string
+      add :git_url,     :string
+      add :source,      :integer
+      add :pinged_at,   :utc_datetime_usec
+
+      add :owner_id,    references(:users, type: :uuid, on_delete: :delete_all)
+      add :account_id,  references(:accounts, type: :uuid, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create unique_index(:clusters, [:account_id, :provider, :name])
+    create unique_index(:clusters, [:owner_id])
+    create index(:clusters, [:account_id])
+
+    alter table(:upgrade_queues) do
+      add :cluster_id, references(:clusters, type: :uuid, on_delete: :delete_all)
+    end
+
+    create unique_index(:upgrade_queues, [:cluster_id])
+  end
+end

--- a/apps/core/priv/repo/seeds/013_clusters.exs
+++ b/apps/core/priv/repo/seeds/013_clusters.exs
@@ -1,0 +1,5 @@
+import Botanist
+
+seed do
+  Core.Backfill.Clusters.from_queues()
+end

--- a/apps/core/test/backfill/clusters_test.exs
+++ b/apps/core/test/backfill/clusters_test.exs
@@ -1,0 +1,17 @@
+defmodule Core.Backfill.ClustersTest do
+  use Core.SchemaCase, async: true
+  alias Core.Backfill.Clusters
+
+  describe "#from_queues/0" do
+    test "it will backfill cluster records from upgrade queues" do
+      queues = insert_list(2, :upgrade_queue, provider: :aws)
+
+      Clusters.from_queues()
+
+      for q <- queues do
+        cluster = Core.Services.Clusters.get_cluster(q.user.account_id, q.provider, q.name)
+        assert refetch(q).cluster_id == cluster.id
+      end
+    end
+  end
+end

--- a/apps/core/test/services/clusters_test.exs
+++ b/apps/core/test/services/clusters_test.exs
@@ -1,0 +1,94 @@
+defmodule Core.Services.ClustersTest do
+  use Core.SchemaCase, async: true
+  use Mimic
+  alias Core.Services.Clusters
+
+  describe "#create_cluster/2" do
+    test "a user can create a cluster" do
+      user = insert(:user)
+
+      {:ok, cluster} = Clusters.create_cluster(%{name: "cluster", provider: :aws}, user)
+
+      assert cluster.name == "cluster"
+      assert cluster.provider == :aws
+      assert cluster.account_id == user.account_id
+      assert cluster.owner_id == user.id
+      assert cluster.source == :default
+    end
+
+    test "it can populate installation source" do
+      user = insert(:user)
+      insert(:cloud_shell, user: user)
+
+      {:ok, cluster} = Clusters.create_cluster(%{name: "cluster", provider: :aws}, user)
+
+      assert cluster.name == "cluster"
+      assert cluster.provider == :aws
+      assert cluster.source == :shell
+    end
+  end
+
+  describe "#create_from_queue/1" do
+    test "it can create a new cluster from an upgrade queue" do
+      queue = insert(:upgrade_queue, domain: "console.plural.sh", git: "git@github.com/pluralsh/repo", provider: :aws)
+
+      {:ok, cluster} = Clusters.create_from_queue(queue)
+
+      assert cluster.name == queue.name
+      assert cluster.provider == queue.provider
+      assert cluster.owner_id == queue.user_id
+      assert cluster.account_id == queue.user.account_id
+      assert cluster.domain == "plural.sh"
+      assert cluster.console_url == "console.plural.sh"
+      assert cluster.git_url == "git@github.com/pluralsh/repo"
+
+      assert refetch(queue).cluster_id == cluster.id
+    end
+
+    test "if the cluster already exists, it will still tie in the queue" do
+      queue = insert(:upgrade_queue, domain: "console.plural.sh", git: "git@github.com/pluralsh/repo", provider: :aws)
+      cluster = insert(:cluster, name: queue.name, provider: queue.provider, account: queue.user.account, owner: queue.user)
+
+      {:ok, created} = Clusters.create_from_queue(queue)
+
+      assert created.id == cluster.id
+      assert created.console_url == "console.plural.sh"
+
+      assert refetch(queue).cluster_id == cluster.id
+    end
+  end
+
+  describe "#delete_cluster/2" do
+    test "a user can delete their own cluster" do
+      user = insert(:user)
+      domain = insert(:dns_domain, name: "example.com")
+      cluster = insert(:cluster, owner: user, account: user.account, domain: domain.name)
+
+      me = self()
+      insert(:dns_record, provider: :gcp, domain: domain, creator: user)
+      records = insert_list(3, :dns_record, provider: cluster.provider, cluster: cluster.name, creator: user, domain: domain)
+      expect(Core.Conduit.Broker, :publish, 3, fn %{body: r}, :cluster -> send(me, {:record, r}) end)
+
+      {:ok, deleted} = Clusters.delete_cluster(cluster.name, cluster.provider, user)
+
+      assert deleted.id == cluster.id
+      refute refetch(deleted)
+
+      for %{id: id} <- records,
+        do: assert_receive {:record, %{id: ^id}}
+    end
+
+    test "a user cannot delete other's clusters" do
+      user = insert(:user)
+      cluster = insert(:cluster, account: user.account)
+
+      {:error, _} = Clusters.delete_cluster(cluster.name, cluster.provider, user)
+    end
+
+    test "a user cannot delete a cluster that doesn't exist" do
+      user = insert(:user)
+
+      {:error, _} = Clusters.delete_cluster("bogus", :aws, user)
+    end
+  end
+end

--- a/apps/core/test/services/shell_test.exs
+++ b/apps/core/test/services/shell_test.exs
@@ -1,6 +1,6 @@
 defmodule Core.Services.ShellTest do
   use Core.SchemaCase, async: true
-  alias Core.Services.{Shell, Dns, Encryption, Repositories}
+  alias Core.Services.{Shell, Dns, Encryption, Repositories, Clusters}
   alias Core.Services.Shell.Pods
   alias Kazan.Apis.Core.V1, as: CoreV1
   use Mimic
@@ -66,6 +66,11 @@ defmodule Core.Services.ShellTest do
       [backup] = Encryption.get_backups(user)
       assert String.starts_with?(backup.name, "shell:#{shell.workspace.cluster}:")
       assert backup.repositories == ["git@github.com:pluralsh/installations.git"]
+
+      cluster = Clusters.get_cluster(user.account_id, :aws, "plural")
+      assert cluster.owner_id == user.id
+      assert cluster.domain == "sub.onplural.sh"
+      assert cluster.git_url == "git@github.com:pluralsh/installations.git"
     end
 
     test "a user can create a cloud shell with gitlab for scm" do

--- a/apps/core/test/support/factory.ex
+++ b/apps/core/test/support/factory.ex
@@ -600,6 +600,15 @@ defmodule Core.Factory do
     }
   end
 
+  def cluster_factory do
+    %Schema.Cluster{
+      name: sequence(:cluster, &"cluster-#{&1}"),
+      provider: :aws,
+      owner: build(:user),
+      account: build(:account)
+    }
+  end
+
   def with_password(%Schema.User{} = user, password) do
     Schema.User.changeset(user, %{password: password})
     |> Ecto.Changeset.apply_changes()

--- a/apps/graphql/lib/graphql.ex
+++ b/apps/graphql/lib/graphql.ex
@@ -25,6 +25,7 @@ defmodule GraphQl do
   import_types GraphQl.Schema.Scaffold
   import_types GraphQl.Schema.Test
   import_types GraphQl.Schema.AI
+  import_types GraphQl.Schema.Cluster
 
   alias GraphQl.Resolvers.{
     User,
@@ -40,7 +41,9 @@ defmodule GraphQl do
     Incidents,
     Rollout,
     Dns,
-    Test
+    Test,
+    Cluster,
+    Upgrade
   }
 
   @sources [
@@ -57,7 +60,9 @@ defmodule GraphQl do
     Incidents,
     Rollout,
     Dns,
-    Test
+    Test,
+    Cluster,
+    Upgrade
   ]
 
   def context(ctx) do
@@ -114,6 +119,7 @@ defmodule GraphQl do
     import_fields :provider_queries
     import_fields :test_queries
     import_fields :ai_queries
+    import_fields :cluster_queries
   end
 
   mutation do
@@ -133,6 +139,7 @@ defmodule GraphQl do
     import_fields :shell_mutations
     import_fields :rollout_mutations
     import_fields :test_mutations
+    import_fields :cluster_mutations
   end
 
   subscription do

--- a/apps/graphql/lib/graphql/resolvers/cluster.ex
+++ b/apps/graphql/lib/graphql/resolvers/cluster.ex
@@ -1,0 +1,21 @@
+defmodule GraphQl.Resolvers.Cluster do
+  use GraphQl.Resolvers.Base, model: Core.Schema.Cluster
+  alias Core.Services.Clusters
+
+  def query(_, _), do: Cluster
+
+  def resolve_cluster(%{id: id}, %{context: %{current_user: user}}),
+    do: Clusters.authorize(id, user)
+
+  def list_clusters(args, %{context: %{current_user: user}}) do
+    Cluster.for_user(user)
+    |> Cluster.ordered()
+    |> paginate(args)
+  end
+
+  def create_cluster(%{attributes: attrs}, %{context: %{current_user: user}}),
+    do: Clusters.create_cluster(attrs, user)
+
+  def delete_cluster(%{name: n, provider: p}, %{context: %{current_user: user}}),
+    do: Clusters.delete_cluster(n, p, user)
+end

--- a/apps/graphql/lib/graphql/schema/cluster.ex
+++ b/apps/graphql/lib/graphql/schema/cluster.ex
@@ -1,0 +1,60 @@
+defmodule GraphQl.Schema.Cluster do
+  use GraphQl.Schema.Base
+  alias GraphQl.Resolvers.{User, Account, Upgrade, Cluster}
+  ecto_enum :source, Core.Schema.Installation.Source
+
+  input_object :cluster_attributes do
+    field :name,        non_null(:string)
+    field :provider,    non_null(:provider)
+    field :source,      :source
+    field :git_url,     :string
+    field :console_url, :string
+    field :domain,      :string
+  end
+
+  object :cluster do
+    field :id,          non_null(:id)
+    field :name,        non_null(:string)
+    field :provider,    non_null(:provider)
+    field :source,      :source
+    field :git_url,     :string
+    field :console_url, :string
+    field :domain,      :string
+    field :pinged_at,   :datetime
+
+    field :owner,   :user, resolve: dataloader(User)
+    field :account, :account, resolve: dataloader(Account)
+    field :queue,   :upgrade_queue, resolve: dataloader(Upgrade)
+
+    timestamps()
+  end
+
+  connection node_type: :cluster
+
+  object :cluster_queries do
+    field :cluster, :cluster do
+      arg :id, non_null(:id)
+
+      resolve &Cluster.resolve_cluster/2
+    end
+
+    connection field :clusters, node_type: :cluster do
+      resolve &Cluster.list_clusters/2
+    end
+  end
+
+  object :cluster_mutations do
+    field :create_cluster, :cluster do
+      arg :attributes, non_null(:cluster_attributes)
+
+      safe_resolve &Cluster.create_cluster/2
+    end
+
+    field :delete_cluster, :cluster do
+      arg :name,     non_null(:string)
+      arg :provider, non_null(:provider)
+
+      safe_resolve &Cluster.delete_cluster/2
+    end
+  end
+end

--- a/apps/graphql/test/mutations/cluster_mutations_test.exs
+++ b/apps/graphql/test/mutations/cluster_mutations_test.exs
@@ -1,0 +1,40 @@
+defmodule GraphQl.ClusterMutationsTest do
+  use Core.SchemaCase, async: true
+  import GraphQl.TestHelpers
+
+  describe "createCluster" do
+    test "a user can register a cluster" do
+      user = insert(:user)
+
+      {:ok, %{data: %{"createCluster" => cluster}}} = run_query("""
+        mutation Create($attrs: ClusterAttributes!) {
+          createCluster(attributes: $attrs) {
+            name
+            provider
+            source
+          }
+        }
+      """, %{"attrs" => %{"name" => "cluster", "provider" => "AWS"}}, %{current_user: user})
+
+      assert cluster["name"] == "cluster"
+      assert cluster["provider"] == "AWS"
+      assert cluster["source"] == "DEFAULT"
+    end
+  end
+
+  describe "deleteCluster" do
+    test "a user can deregister a cluster" do
+      user = insert(:user)
+      cluster = insert(:cluster, owner: user, account: user.account)
+
+      {:ok, %{data: %{"deleteCluster" => deleted}}} = run_query("""
+        mutation Delete($name: String!, $provider: Provider!) {
+          deleteCluster(name: $name, provider: $provider) { id }
+        }
+      """, %{"name" => cluster.name, "provider" => "AWS"}, %{current_user: user})
+
+      assert cluster.id == deleted["id"]
+      refute refetch(cluster)
+    end
+  end
+end

--- a/apps/graphql/test/queries/cluster_queries_test.exs
+++ b/apps/graphql/test/queries/cluster_queries_test.exs
@@ -1,0 +1,75 @@
+defmodule GraphQl.ClusterQueriesTest do
+  use Core.SchemaCase, async: true
+  import GraphQl.TestHelpers
+
+  describe "cluster" do
+    test "it can fetch a cluster by id" do
+      user = insert(:user)
+      cluster = insert(:cluster, owner: user)
+
+      {:ok, %{data: %{"cluster" => found}}} = run_query("""
+        query Cluster($id: ID!) {
+          cluster(id: $id) { id }
+        }
+      """, %{"id" => cluster.id}, %{current_user: user})
+
+      assert found["id"] == cluster.id
+    end
+
+    test "a user can access clusters via service account" do
+      user = insert(:user)
+      sa = insert(:user, service_account: true, account: user.account)
+      %{group: group} = insert(:impersonation_policy_binding,
+        policy: build(:impersonation_policy, user: sa),
+        group: insert(:group, account: user.account)
+      )
+      insert(:group_member, user: user, group: group)
+      cluster = insert(:cluster, account: sa.account, owner: sa)
+
+      {:ok, %{data: %{"cluster" => found}}} = run_query("""
+        query Cluster($id: ID!) {
+          cluster(id: $id) { id }
+        }
+      """, %{"id" => cluster.id}, %{current_user: Core.Services.Rbac.preload(user)})
+
+      assert found["id"] == cluster.id
+    end
+
+    test "it's forbidden if a user cannot access the cluster" do
+      user = insert(:user)
+      cluster = insert(:cluster)
+
+      {:ok, %{errors: [_ | _]}} = run_query("""
+        query Cluster($id: ID!) {
+          cluster(id: $id) { id }
+        }
+      """, %{"id" => cluster.id}, %{current_user: user})
+    end
+  end
+
+  describe "clusters" do
+    test "a user can list clusters they own or can access" do
+      user = insert(:user)
+      sa = insert(:user, service_account: true, account: user.account)
+      %{group: group} = insert(:impersonation_policy_binding,
+        policy: build(:impersonation_policy, user: sa),
+        group: insert(:group, account: user.account)
+      )
+      insert(:group_member, user: user, group: group)
+
+      c1 = insert(:cluster, account: user.account, owner: user)
+      c2 = insert(:cluster, account: sa.account, owner: sa)
+
+      {:ok, %{data: %{"clusters" => found}}} = run_query("""
+        query {
+          clusters(first: 5) {
+            edges { node { id } }
+          }
+        }
+      """, %{}, %{current_user: Core.Services.Rbac.preload(user)})
+
+      assert from_connection(found)
+             |> ids_equal([c1, c2])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Creates schema and backfills for a general cluster reference type we can use for multi-cluster management. This looks a lot like our upgrade queue but can be more general by not being tied to the console. PR has a few components:

* schema and CRUD for clusters
* backfill to create clusters from existing upgrade queues
* tie-in to ensure clusters are created w/ new upgrade queues and cloud shells
* ping logic on upgrade queues to serve as health indicator


## Test Plan
more unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.