### PR TITLE
Expose Usage in gql, ignore service accounts

### DIFF
--- a/apps/core/lib/core/pubsub/protocols/usage.ex
+++ b/apps/core/lib/core/pubsub/protocols/usage.ex
@@ -12,10 +12,12 @@ defimpl Core.PubSub.Usage, for: Any do
 end
 
 defimpl Core.PubSub.Usage, for: Core.PubSub.UserCreated do
+  def update(%@for{item: %{service_account: true}}), do: :ok
   def update(%@for{item: %{account_id: aid}}), do: {aid, user: 1}
 end
 
 defimpl Core.PubSub.Usage, for: Core.PubSub.UserDeleted do
+  def update(%@for{item: %{service_account: true}}), do: :ok
   def update(%@for{item: %{account_id: aid}}), do: {aid, user: -1}
 end
 

--- a/apps/core/lib/core/schema/account.ex
+++ b/apps/core/lib/core/schema/account.ex
@@ -36,12 +36,12 @@ defmodule Core.Schema.Account do
       join: u in Core.Schema.User, on: u.account_id == a.id,
       left_join: q in Core.Schema.UpgradeQueue, on: q.user_id == u.id,
       group_by: a.id,
-      select: %{id: a.id, users: count(u.id, :distinct), clusters: count(q.id, :distinct)}
+      select: %{id: a.id, users: count(fragment("case when ? then null else ? end", u.service_account, u.id), :distinct), clusters: count(q.id, :distinct)}
     )
   end
 
   @valid ~w(name workos_connection_id sa_provisioned)a
-  @payment ~w(billing_customer_id)a
+  @payment ~w(billing_customer_id delinquent_at)a
 
   def changeset(model, attrs \\ %{}) do
     model
@@ -53,7 +53,6 @@ defmodule Core.Schema.Account do
     |> cast_attachments(attrs, [:icon], allow_urls: true)
   end
 
-  @payment ~w(billing_customer_id delinquent_at)a
 
   def payment_changeset(model, attrs \\ %{}) do
     model

--- a/apps/core/lib/core/services/shell.ex
+++ b/apps/core/lib/core/services/shell.ex
@@ -3,7 +3,7 @@ defmodule Core.Services.Shell do
   import Core.Policies.Shell
 
   alias Core.Schema.{CloudShell, User, Recipe, Installation, OIDCProvider, Stack}
-  alias Core.Services.{Shell.Pods, Dns, Recipes, Repositories, Encryption, Clusters}
+  alias Core.Services.{Shell.Pods, Dns, Recipes, Repositories, Encryption}
   alias Core.Shell.{Scm, Client}
 
   @type error :: {:error, term}

--- a/apps/core/test/backfill/accounts_test.exs
+++ b/apps/core/test/backfill/accounts_test.exs
@@ -6,6 +6,7 @@ defmodule Core.Backfill.AccountsTest do
     test "it will properly compute usage for all accounts" do
       ac1 = insert(:account)
       [u | _] = insert_list(3, :user, account: ac1)
+      insert(:user, account: ac1, service_account: true)
       insert(:upgrade_queue, user: u)
       insert(:upgrade_queue, user: u)
 

--- a/apps/core/test/pubsub/usage/users_test.exs
+++ b/apps/core/test/pubsub/usage/users_test.exs
@@ -14,6 +14,13 @@ defmodule Core.PubSub.Usage.UsersTest do
       assert account.user_count == 1
       assert account.usage_updated
     end
+
+    test "it ignores service accounts" do
+      user = insert(:user, service_account: true)
+
+      event = %PubSub.UserCreated{item: user}
+      :ok = Usage.handle_event(event)
+    end
   end
 
   describe "UserDeleted" do
@@ -26,6 +33,13 @@ defmodule Core.PubSub.Usage.UsersTest do
       account = refetch(user.account)
       assert account.user_count == 0
       assert account.usage_updated
+    end
+
+    test "it ignores service accounts" do
+      user = insert(:user, service_account: true)
+
+      event = %PubSub.UserDeleted{item: user}
+      :ok = Usage.handle_event(event)
     end
   end
 end

--- a/apps/core/test/services/shell_test.exs
+++ b/apps/core/test/services/shell_test.exs
@@ -1,6 +1,6 @@
 defmodule Core.Services.ShellTest do
   use Core.SchemaCase, async: true
-  alias Core.Services.{Shell, Dns, Encryption, Repositories, Clusters}
+  alias Core.Services.{Shell, Dns, Encryption, Repositories}
   alias Core.Services.Shell.Pods
   alias Kazan.Apis.Core.V1, as: CoreV1
   use Mimic

--- a/apps/graphql/lib/graphql/schema/account.ex
+++ b/apps/graphql/lib/graphql/schema/account.ex
@@ -81,6 +81,8 @@ defmodule GraphQl.Schema.Account do
     field :name,                 :string
     field :billing_customer_id,  :string
     field :workos_connection_id, :string
+    field :cluster_count,        :string
+    field :user_count,           :string
     field :delinquent_at,        :datetime
     field :grandfathered_unitl,  :datetime
 


### PR DESCRIPTION
## Summary
We need this to be present on the account object type, and also it looks like we're counting service accounts towards user usage which feels wrong.


## Test Plan
tweaked tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.