### PR TITLE
feat: Expose selected region via shell configuration workspace

### DIFF
--- a/apps/core/lib/core/services/shell/models.ex
+++ b/apps/core/lib/core/services/shell/models.ex
@@ -7,7 +7,7 @@ defmodule Core.Shell.Models.Network do
 end
 
 defmodule Core.Shell.Models.Workspace do
-  defstruct [:network, :bucket_prefix, :cluster]
+  defstruct [:network, :bucket_prefix, :cluster, :region]
 
   def as() do
     %__MODULE__{network: %Core.Shell.Models.Network{}}

--- a/apps/graphql/lib/graphql/schema/shell.ex
+++ b/apps/graphql/lib/graphql/schema/shell.ex
@@ -98,6 +98,7 @@ defmodule GraphQl.Schema.Shell do
     field :network,       :network_configuration
     field :bucket_prefix, :string
     field :cluster,       :string
+    field :region,        :string
   end
 
   object :network_configuration do

--- a/apps/graphql/test/queries/shell_queries_test.exs
+++ b/apps/graphql/test/queries/shell_queries_test.exs
@@ -67,18 +67,18 @@ defmodule GraphQl.ShellQueriesTest do
 
       expect(HTTPoison, :request, fn :get, "http://0.0.0.0:8080/v1/configuration", _, _, _ ->
         {:ok, %HTTPoison.Response{status_code: 200, body: Poison.encode!(%Models.Configuration{
-          workspace: %Models.Workspace{bucket_prefix: "pre", network: %Models.Network{plural_dns: true}},
+          workspace: %Models.Workspace{bucket_prefix: "pre", network: %Models.Network{plural_dns: true}, region: "us-east2"},
           git: %Models.Git{url: "git"},
           context_configuration: %{"some" => "config"},
           buckets: ["bucket"],
-          domains: ["some.example.com"]
+          domains: ["some.example.com"],
         })}}
       end)
 
       {:ok, %{data: %{"shellConfiguration" => found}}} = run_query("""
         query {
           shellConfiguration {
-            workspace { bucketPrefix network { pluralDns } }
+            workspace { bucketPrefix network { pluralDns } region }
             git { url }
             contextConfiguration
             buckets
@@ -88,6 +88,7 @@ defmodule GraphQl.ShellQueriesTest do
       """, %{}, %{current_user: shell.user})
 
       assert found["workspace"]["bucketPrefix"] == "pre"
+      assert found["workspace"]["region"] == "us-east2"
       assert found["workspace"]["network"]["pluralDns"]
       assert found["git"]["url"] == "git"
       assert found["contextConfiguration"] == %{"some" => "config"}


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Since `updateShell` mutation will only allow to update `credentials` struct, we will need to expose the region that can be shown in the UI. It will not be editable.

Ref: [figma](https://www.figma.com/file/985LCDEqp4ckoMLOHSWkDF/Onboarding-v3?node-id=209%3A51675&t=ZtoQFtURUFRGYXLM-4)
![image](https://user-images.githubusercontent.com/2285385/214565779-bcbcff48-72b5-4d5d-a080-3ea6083452ba.png)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Updated unit test

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.