### PR TITLE
fix: trivy use skipdirs instead of scanref

### DIFF
--- a/.github/workflows/www.yaml
+++ b/.github/workflows/www.yaml
@@ -88,7 +88,7 @@ jobs:
         with:
           scan-type: 'fs'
           hide-progress: false
-          scan-ref: 'www'
+          skip-dirs: '.github,.stoat,apps,bin,config,plural,rel,testdata'
           format: 'sarif'
           output: 'trivy-results.sarif'
           security-checks: 'vuln,secret'


### PR DESCRIPTION
## Summary
Previously the `scan-ref` was being used to limit scanning to the `www` directory. However, this breaks file previews such as https://github.com/pluralsh/plural/security/code-scanning/887. This PR instead uses `skip-dirs` to filter out directories that aren’t frontend related from the trivy scan, allowing file previews to work properly.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.