### PR TITLE
Implement dedicated upgrade delivery

### DIFF
--- a/apps/core/lib/core/schema/dependencies.ex
+++ b/apps/core/lib/core/schema/dependencies.ex
@@ -67,6 +67,7 @@ defmodule Core.Schema.Dependencies do
     field :secrets,          {:array, :string}
     field :application,      :boolean, default: false
     field :breaking,         :boolean, default: false
+    field :dedicated,        :boolean, default: false
     field :wait,             :boolean, default: false
     field :provider_vsn,     :string
     field :cli_vsn,          :string

--- a/apps/core/lib/core/schema/upgrade.ex
+++ b/apps/core/lib/core/schema/upgrade.ex
@@ -3,7 +3,7 @@ defmodule Core.Schema.Upgrade do
   alias Core.Schema.{UpgradeQueue, Repository}
   alias Piazza.Ecto.UUID
 
-  defenum Type, deploy: 0, approval: 1, bounce: 2
+  defenum Type, deploy: 0, approval: 1, bounce: 2, dedicated: 3
 
   schema "upgrades" do
     field :type,    Type

--- a/apps/core/lib/core/services/rollouts.ex
+++ b/apps/core/lib/core/services/rollouts.ex
@@ -30,7 +30,7 @@ defmodule Core.Services.Rollouts do
     |> ok()
   end
 
-  def lock_installation(%Version{dependencies: %Dependencies{breaking: true}}, inst) do
+  def lock_installation(%Version{dependencies: %Dependencies{breaking: b, dedicated: d}}, inst) when b or d do
     Ecto.Changeset.change(inst, %{locked: true})
     |> Core.Repo.update()
     |> notify(:locked)


### PR DESCRIPTION
## Summary

Introduce a `dedicated` boolean on deps.yaml to signal the need for a dedicated upgrade which will:

* lock the repo to ensure nothing can proceed until its applied
* set the upgrade type to dedicated so the console applies it correctly


## Test Plan
added unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.