### PR TITLE
enable s3 encryption + set image bucket to private

### DIFF
--- a/plural/terraform/aws/deps.yaml
+++ b/plural/terraform/aws/deps.yaml
@@ -7,7 +7,7 @@ dependencies:
 providers:
 - aws
 description: plural aws setup
-version: 0.1.7
+version: 0.1.8
 
 wirings:
   terraform: {}

--- a/plural/terraform/aws/main.tf
+++ b/plural/terraform/aws/main.tf
@@ -70,14 +70,38 @@ resource "kubernetes_namespace" "plural" {
 resource "aws_s3_bucket" "chart_bucket" {
   bucket = var.chart_bucket
   acl    = "private"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket" "plural_assets_bucket" {
   bucket = var.plural_assets_bucket
   acl    = "private"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket" "plural_images_bucket" {
   bucket = var.plural_images_bucket
-  acl    = "public-read"
+  acl    = "private"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "AES256"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
For GDPR compliance we need to have S3 encryption enabled for all buckets and ensure they cannot be publicly accessed. This updates the AWS terraform to enable AES256 SSE-S3 encryption for the bucket. This does not use KMS, and as such doesn't require any additional policies for access to the objects. As of January 5th this is actually already enforced by default for new objects so this change shouldn't cause any issues.


## Test Plan
Tested multiple other S3 buckets with the same encryption setting and ensured the apps could still write data to S3.


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.