### PR TITLE
Fix Locked Installation emails

### DIFF
--- a/apps/email/lib/email/builder/locked_installation.ex
+++ b/apps/email/lib/email/builder/locked_installation.ex
@@ -1,5 +1,6 @@
 defmodule Email.Builder.LockedInstallation do
   use Email.Builder.Base
+  alias Core.Schema.{Dependencies, Version}
 
   def email(inst) do
     %{installation: %{user: user}} = inst = Core.Repo.preload(inst, [:version, installation: [:user, :repository]])
@@ -11,9 +12,14 @@ defmodule Email.Builder.LockedInstallation do
     |> assign(:user, user)
     |> assign(:installation, inst)
     |> assign(:deps, inst.version.dependencies)
+    |> assign(:instructions, instructions(inst.version))
     |> assign(:repo, repo)
     |> render(:locked_installation)
   end
+
+  defp instructions(%Version{dependencies: %Dependencies{instructions: %Dependencies.ChangeInstructions{} = instructions}}),
+    do: instructions
+  defp instructions(_), do: %{script: nil, instructions: nil}
 
   defp inst_type(%{chart: _}), do: :chart
   defp inst_type(%{terraform: _}), do: :terraform

--- a/apps/email/lib/email_web/templates/email/locked_installation.html.eex
+++ b/apps/email/lib/email_web/templates/email/locked_installation.html.eex
@@ -14,8 +14,8 @@
 <%= row do %>
 <div>
 <code>
-<%= if @deps.instructions.script do %>
-<%= @deps.instructions.script %>
+<%= if @instructions.script do %>
+<%= @instructions.script %>
 <% end %>
 plural build --only <%= @repo.name %>
 plural deploy --commit "applying breaking changes to <%= @repo.name %>"
@@ -24,13 +24,13 @@ plural repos unlock <%= @repo.name %>
 </div>
 <% end %>
 
-<%= if @deps.instructions.instructions do %>
+<%= if @instructions.instructions do %>
 <%= row do %>
 <%= text do %>
 The maintainers also have provided these instructions:
 <% end %>
 <pre>
-<%= @deps.instructions.instructions %>
+<%= @instructions.instructions %>
 </pre>
 <% end %>
 <% end %>

--- a/apps/email/lib/email_web/templates/email/locked_installation.text.eex
+++ b/apps/email/lib/email_web/templates/email/locked_installation.text.eex
@@ -2,16 +2,16 @@ Repository <%= @repo.name %> has unapplied breaking changes, to apply them,
 check out your repo locally and run the following commands:
 
 ```
-<%= if @deps.instructions.script do %>
-<%= @deps.instructions.script %>
+<%= if @instructions.script do %>
+<%= @instructions.script %>
 <% end %>
 plural build --only <%= @repo.name %>
 plural deploy --commit "applying breaking changes to <%= @repo.name %>"
 plural repos unlock <%= @repo.name %>
 ```
 
-<%= if @deps.instructions.instructions do %>
+<%= if @instructions.instructions do %>
 The maintainers also have provided these instructions:
 
-<%= @deps.instructions.instructions %>
+<%= @instructions.instructions %>
 <% end %>

--- a/apps/email/test/email/builder/locked_installation_test.exs
+++ b/apps/email/test/email/builder/locked_installation_test.exs
@@ -22,5 +22,25 @@ defmodule Email.Builder.LockedInstallationTest do
 
       assert to.id == user.id
     end
+
+    test "it can still deliver w/ no instructions provided" do
+      service_account = insert(:user, service_account: true)
+      user = insert(:user, account: service_account.account)
+      %{group: group} = insert(:impersonation_policy_binding,
+        policy: build(:impersonation_policy, user: service_account),
+        group: insert(:group, account: service_account.account)
+      )
+      insert(:group_member, group: group, user: user)
+
+      inst = insert(:installation, user: service_account)
+      ci = insert(:chart_installation,
+        installation: inst,
+        version: build(:version)
+      )
+
+      %{to: [to]} = Email.Builder.LockedInstallation.email(ci)
+
+      assert to.id == user.id
+    end
   end
 end


### PR DESCRIPTION
## Summary
Part of what made the last k8s upgrade rocky is I believe we didn't notify users properly.  This fixes a bug where the email send crashes w/o instructions in the deps.yaml so that should now be more robust.


## Test Plan
more unit tests for that case


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.