### PR TITLE
Allow creators to always create domain records

### DIFF
--- a/apps/core/lib/core/policies/dns.ex
+++ b/apps/core/lib/core/policies/dns.ex
@@ -24,8 +24,9 @@ defmodule Core.Policies.Dns do
     do: :pass
 
   def can?(%User{id: id}, %DnsRecord{creator_id: id}, :delete), do: :pass
-  def can?(%User{account_id: id} = user, %DnsRecord{} = record, action) when action != :delete do
+  def can?(%User{account_id: id, id: uid} = user, %DnsRecord{} = record, action) when action != :delete do
     case Core.Repo.preload(record, [domain: [access_policy: :bindings]]) do
+      %{domain: %DnsDomain{creator_id: ^uid}} -> :pass
       %{domain: %DnsDomain{account_id: ^id, access_policy: nil}} -> :pass
       %{domain: %DnsDomain{account_id: ^id, access_policy: policy}} ->
         Rbac.evaluate_policy(user, policy) |> error(@policy_msg)

--- a/apps/core/test/services/dns_test.exs
+++ b/apps/core/test/services/dns_test.exs
@@ -141,6 +141,24 @@ defmodule Core.Services.DnsTest do
       assert record.type == :a
     end
 
+    test "creators can create records w/o being on the access policy" do
+      user = insert(:user)
+      domain = insert(:dns_domain, account: user.account, creator: user)
+      insert(:dns_access_policy_binding,
+        policy: build(:dns_access_policy, domain: domain),
+        user: insert(:user, account: user.account)
+      )
+
+      external_id = "12345"
+      expect(DnsRecord, :create, fn _, _ -> dns_resp(external_id) end)
+
+      {:ok, _} = Dns.create_record(%{
+        type: :a,
+        name: "some.#{domain.name}",
+        records: ["1.2.3.4"],
+      }, "cluster", :aws, user)
+    end
+
     test "It will respect access policies" do
       user = insert(:user)
       domain = insert(:dns_domain, account: user.account)


### PR DESCRIPTION
## Summary
The previous setup technically allowed people to remove the creator from being able to edit the domain, but it's also unintuitive, so going w/ this.

## Test Plan
unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.