### PR TITLE
fix(frontend): fix cypress with cookiebot banner

### DIFF
--- a/www/e2e/cypress/support/index.ts
+++ b/www/e2e/cypress/support/index.ts
@@ -17,6 +17,16 @@ import { GQLInterceptor } from '@intercept/graphql'
 
 Cypress.on('uncaught:exception', () => false)
 
+// The name of the cookie holding whether the user has accepted
+// the cookie policy
+const COOKIE_NAME = "CookieConsent";
+// The value meaning that user has accepted the cookie policy
+const COOKIE_VALUE = "{stamp:%27AChnN7ryDrPdHdS3SZUtqfIwORvkzlm6fuG079kDXtk4OOwDDiCXsQ==%27%2Cnecessary:true%2Cpreferences:false%2Cstatistics:false%2Cmarketing:false%2Cmethod:%27explicit%27%2Cver:1%2Cutc:1675377976778%2Cregion:%27us-06%27}";
+
+Cypress.on("window:before:load", window => {
+  window.document.cookie = `${COOKIE_NAME}=${COOKIE_VALUE}`;
+});
+
 before(() => {
   cy.clearCookies()
   cy.clearLocalStorage()


### PR DESCRIPTION
## Summary
After implementing cookiebot the E2E are failing. This PR should fix cypress by having it create the cookie that tracks a user’s consent preferences. 


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.