### PR TITLE
fix(frontend): have posthog work on login and signup page

### DIFF
--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -39,7 +39,7 @@ const honorableTheme = mergeTheme(theme, {
   ],
 })
 
-function PosthogIdentifier() {
+function PosthogOptInOut() {
   if (Cookiebot?.consent?.statistics) {
     posthog.opt_in_capturing()
   }
@@ -69,7 +69,7 @@ function App() {
 
   return (
     <Suspense>
-      <PosthogIdentifier />
+      <PosthogOptInOut />
       <ApolloProvider client={client}>
         <IntercomProvider appId={INTERCOM_APP_ID}>
           <ThemeProvider theme={honorableTheme}>

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -40,14 +40,13 @@ const honorableTheme = mergeTheme(theme, {
 })
 
 function PosthogOptInOut() {
-  if (Cookiebot?.consent?.statistics) {
-    posthog.opt_in_capturing()
-  }
-  else {
-    posthog.opt_out_capturing()
-  }
-
   useEffect(() => {
+    if (Cookiebot?.consent?.statistics) {
+      posthog.opt_in_capturing()
+    }
+    else {
+      posthog.opt_out_capturing()
+    }
     const onPrefChange = () => {
       if (Cookiebot?.consent?.statistics) {
         posthog.opt_in_capturing()

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -1,5 +1,5 @@
 import 'react-toggle/style.css'
-import { Suspense, lazy } from 'react'
+import { Suspense, lazy, useEffect } from 'react'
 import { Route, Routes } from 'react-router-dom'
 import { ApolloProvider } from '@apollo/client'
 import { IntercomProvider } from 'react-use-intercom'
@@ -10,12 +10,14 @@ import { ThemeProvider as StyledThemeProvider } from 'styled-components'
 import { mergeDeep } from '@apollo/client/utilities'
 import mpRecipe from 'honorable-recipe-mp'
 import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
+import posthog from 'posthog-js'
 
 import { client } from './helpers/client'
 import { INTERCOM_APP_ID } from './constants'
 import { DEFAULT_THEME } from './theme'
 import { HistoryRouter, browserHistory } from './router'
 import { growthbook } from './helpers/growthbook'
+import Cookiebot from './utils/cookiebot'
 
 const Plural = lazy(() => import('./components/Plural'))
 const Invite = lazy(() => import('./components/Invite'))
@@ -37,11 +39,37 @@ const honorableTheme = mergeTheme(theme, {
   ],
 })
 
+function PosthogIdentifier() {
+  if (Cookiebot?.consent?.statistics) {
+    posthog.opt_in_capturing()
+  }
+  else {
+    posthog.opt_out_capturing()
+  }
+
+  useEffect(() => {
+    const onPrefChange = () => {
+      if (Cookiebot?.consent?.statistics) {
+        posthog.opt_in_capturing()
+      }
+      else {
+        posthog.opt_out_capturing()
+      }
+    }
+
+    window.addEventListener('CookiebotOnAccept', onPrefChange)
+    window.addEventListener('CookiebotOnDecline', onPrefChange)
+  }, [])
+
+  return null
+}
+
 function App() {
   const mergedStyledTheme = mergeDeep(DEFAULT_THEME, styledTheme)
 
   return (
     <Suspense>
+      <PosthogIdentifier />
       <ApolloProvider client={client}>
         <IntercomProvider appId={INTERCOM_APP_ID}>
           <ThemeProvider theme={honorableTheme}>

--- a/www/src/components/users/LoginFooter.tsx
+++ b/www/src/components/users/LoginFooter.tsx
@@ -48,7 +48,7 @@ export function Footer(props) {
           href=""
           onClick={e => {
             e.preventDefault()
-            Cookiebot.show()
+            Cookiebot?.show()
           }}
         >
           Cookie settings

--- a/www/src/components/utils/HubSpot.tsx
+++ b/www/src/components/utils/HubSpot.tsx
@@ -10,17 +10,17 @@ function HubSpotScript() {
 }
 
 export function HubSpot() {
-  const [loadScript, setLoadScript] = useState(Cookiebot.consent.marketing)
+  const [loadScript, setLoadScript] = useState(Cookiebot?.consent?.marketing)
 
   useEffect(() => {
     const stop = () => {
-      const _hsq = ((window as any)._hsq = (window as any)._hsq || [])
+      const _hsq = window._hsq = window._hsq || []
 
       _hsq.push(['doNotTrack'])
     }
     const start = () => {
       setLoadScript(true)
-      const _hsq = ((window as any)._hsq = (window as any)._hsq || [])
+      const _hsq = window._hsq = window._hsq || []
 
       _hsq.push(['doNotTrack', { track: true }])
     }

--- a/www/src/types/window.d.ts
+++ b/www/src/types/window.d.ts
@@ -1,0 +1,8 @@
+import type { cookiebot } from '../utils/cookiebot'
+
+declare global {
+  interface Window {
+      Cookiebot?: cookiebot
+      _hsq?: any[]
+  }
+}

--- a/www/src/utils/cookiebot.ts
+++ b/www/src/utils/cookiebot.ts
@@ -1,4 +1,4 @@
-interface cookiebot {
+export type cookiebot = {
   consent: {
     necessary: boolean;
     preferences: boolean;
@@ -24,6 +24,6 @@ interface cookiebot {
   submitCustomConsent(optinPreferences: boolean, optinStatistics: boolean, optinMarketing: boolean): void;
 }
 
-declare const Cookiebot: cookiebot
+const { Cookiebot } = window
 
 export default Cookiebot

--- a/www/src/utils/posthog.ts
+++ b/www/src/utils/posthog.ts
@@ -10,7 +10,6 @@ import Cookiebot from './cookiebot'
 
 export default function PosthogIdentify(me: User) {
   if (Cookiebot?.consent?.statistics) {
-    posthog.opt_in_capturing()
     posthog.identify(me.id)
     posthog.people.set({
       // should email be under the GDPR check?
@@ -26,9 +25,6 @@ export default function PosthogIdentify(me: User) {
         name: me.name,
       })
     }
-  }
-  else {
-    posthog.opt_out_capturing()
   }
 }
 


### PR DESCRIPTION
## Summary
Currently we don't opt in to posthog tracking until after the login/signup page. This means we can't track people signing up properly. This PR adds the Posthog opt in/out to the mainpart of the app allowing us to track user interaction on the login and signup pages.


## Test Plan
Run locally and check it works in PostHog.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.