### PR TITLE
fix: Notifications don’t close when clicking outside panel

### DIFF
--- a/www/src/components/layout/NotificationsPanelOverlay.tsx
+++ b/www/src/components/layout/NotificationsPanelOverlay.tsx
@@ -81,7 +81,10 @@ export function NotificationsPanelOverlay({
   return transitions(styles => (
 
     <Wrapper $leftOffset={leftOffset}>
-      <Animated style={styles}>
+      <Animated
+        style={styles}
+        ref={notificationsPanelRef}
+      >
         <Flex
           align="center"
           justify="space-between"

--- a/www/src/components/layout/Overlay.tsx
+++ b/www/src/components/layout/Overlay.tsx
@@ -12,8 +12,10 @@ import {
   useMemo,
   useReducer,
 } from 'react'
-import useUnmount from 'components/hooks/useUnmount'
+
 import { produce } from 'immer'
+
+import useUnmount from '../../hooks/useUnmount'
 
 const getTransitionProps = (isOpen: boolean) => ({
   from: { opacity: 0 /* , backdropFilter: 'blur(0px)' */ },

--- a/www/src/hooks/useUnmount.tsx
+++ b/www/src/hooks/useUnmount.tsx
@@ -1,0 +1,14 @@
+import { useEffect, useRef } from 'react'
+
+function useUnmount(effect: () => void) {
+  const effectRef = useRef(effect)
+
+  effectRef.current = effect
+
+  useEffect(() => () => {
+    effectRef.current()
+  },
+  [])
+}
+
+export default useUnmount


### PR DESCRIPTION
Notifications now close when clicking outside the panel.
Fix flickering if `useContentOverlay()` is used in more than one place.