### PR TITLE
Bring-your-own-git for cloud shell

### DIFF
--- a/apps/core/lib/core/schema/cloud_shell.ex
+++ b/apps/core/lib/core/schema/cloud_shell.ex
@@ -129,6 +129,7 @@ defmodule Core.Schema.CloudShell do
     field :ssh_public_key,  EncryptedString
     field :ssh_private_key, EncryptedString
     field :bucket_prefix,   :string
+    field :missing,         {:array, :string}, virtual: true
 
     embeds_one :git_info,    GitInfo, on_replace: :update
     embeds_one :workspace,   Workspace, on_replace: :update

--- a/apps/core/lib/core/services/shell/scm.ex
+++ b/apps/core/lib/core/services/shell/scm.ex
@@ -3,7 +3,7 @@ defmodule Core.Shell.Scm do
 
   @providers ~w(github gitlab)a
 
-  @type provider :: :github | :gitlab
+  @type provider :: :github | :gitlab | :manual
   @type error :: {:error, term}
 
   @doc """

--- a/apps/core/test/services/shell/client_test.exs
+++ b/apps/core/test/services/shell/client_test.exs
@@ -10,11 +10,11 @@ defmodule Core.Shell.ClientTest do
       pod = Pods.pod("plrl-shell-1", "mjg@plural.sh")
       expect(Kazan, :run, fn _ -> {:ok, %{pod | status: %CoreV1.PodStatus{pod_ip: "10.0.1.0"}}} end)
       expect(HTTPoison, :post, fn "http://10.0.1.0:8080/v1/setup", _, _, _ ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: "OK"}}
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{missing: []})}}
       end)
 
       shell = insert(:cloud_shell, pod_name: "plrl-shell-1")
-      {:ok, true} = Client.setup(shell)
+      {:ok, %Client.Setup{missing: []}} = Client.setup(shell)
     end
   end
 

--- a/apps/core/test/services/shell_test.exs
+++ b/apps/core/test/services/shell_test.exs
@@ -232,11 +232,12 @@ defmodule Core.Services.ShellTest do
 
       pod = Pods.pod("plrl-shell-1", "mjg@plural.sh")
       expect(Kazan, :run, fn _ -> {:ok, %{pod | status: %CoreV1.PodStatus{pod_ip: "10.0.1.0"}}} end)
-      expect(HTTPoison, :post, fn _, _, _, _ -> {:ok, %HTTPoison.Response{status_code: 200}} end)
+      expect(HTTPoison, :post, fn _, _, _, _ -> {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{missing: ["permission"]})}} end)
 
       {:ok, setup} = Shell.setup_shell(user)
 
       assert setup.id == shell.id
+      assert setup.missing == ["permission"]
     end
   end
 

--- a/apps/graphql/lib/graphql/schema/shell.ex
+++ b/apps/graphql/lib/graphql/schema/shell.ex
@@ -15,13 +15,17 @@ defmodule GraphQl.Schema.Shell do
   enum :scm_provider do
     value :github
     value :gitlab
+    value :manual
   end
 
   input_object :scm_attributes do
-    field :provider, :scm_provider
-    field :token,    non_null(:string)
-    field :name,     non_null(:string)
-    field :org,      :string
+    field :provider,    :scm_provider
+    field :token,       :string
+    field :name,        :string
+    field :org,         :string
+    field :git_url,     :string
+    field :public_key,  :string
+    field :private_key, :string
   end
 
   input_object :workspace_attributes do
@@ -66,6 +70,7 @@ defmodule GraphQl.Schema.Shell do
     field :provider,    non_null(:provider)
     field :git_url,     non_null(:string)
     field :aes_key,     non_null(:string)
+    field :missing,     list_of(:string)
 
     field :cluster,     non_null(:string), resolve: fn
       %{workspace: %{cluster: cluster}}, _, _ -> {:ok, cluster}


### PR DESCRIPTION
## Summary
This adds support to provde a bring-your-own-git experience for the cloud shell.  Requires manually supplying the ssh keypair but otherwise should work as everything else



## Test Plan
unit test

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.