### PR TITLE
Rightsize resource commitments for plural itself

### DIFF
--- a/plural/helm/plural/Chart.yaml
+++ b/plural/helm/plural/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: plural
 description: A helm chart for installing plural
 appVersion: 0.9.39
-version: 0.9.66
+version: 0.9.67
 dependencies:
 - name: hydra
   repository: https://k8s.ory.sh/helm/charts

--- a/plural/helm/plural/values.yaml
+++ b/plural/helm/plural/values.yaml
@@ -364,14 +364,7 @@ api:
   bucket: plural-assets
   resources: {}
 
-  topologySpreadConstraints:
-  - maxSkew: 1
-    topologyKey: topology.kubernetes.io/zone
-    whenUnsatisfiable: DoNotSchedule
-    labelSelector:
-      matchLabels:
-        app.kubernetes.io/name: plural-api
-        app.kubernetes.io/instance: plural
+  topologySpreadConstraints: []
 
 image:
   repository: plural
@@ -386,14 +379,7 @@ rtc:
   resources: {}
   replicaCount: 3
 
-  topologySpreadConstraints:
-  - maxSkew: 1
-    topologyKey: topology.kubernetes.io/zone
-    whenUnsatisfiable: DoNotSchedule
-    labelSelector:
-      matchLabels:
-        app.kubernetes.io/name: plural-rtc
-        app.kubernetes.io/instance: plural
+  topologySpreadConstraints: []
 
 worker:
   repository: worker

--- a/plural/terraform/aws/deps.yaml
+++ b/plural/terraform/aws/deps.yaml
@@ -7,7 +7,7 @@ dependencies:
 providers:
 - aws
 description: plural aws setup
-version: 0.1.8
+version: 0.1.9
 
 wirings:
   terraform: {}

--- a/plural/terraform/aws/variables.tf
+++ b/plural/terraform/aws/variables.tf
@@ -106,9 +106,9 @@ variable "single_az_node_groups" {
     plural_worker_medium = {
       name = "plural-worker-medium"
       capacity_type = "ON_DEMAND"
-      min_capacity = 3
+      min_capacity = 1
       max_capacity = 9
-      desired_capacity = 3
+      desired_capacity = 1
       instance_types = ["t3.xlarge", "t3a.xlarge"]
       k8s_labels = {
         "plural.sh/capacityType" = "ON_DEMAND"


### PR DESCRIPTION
## Summary

We're substantially overscaled for both the worker tier and probably webserver tier (although there its not as bad).  This should give us more room to shrink capacity

## Test Plan
link


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.