### PR TITLE
Posthog user.created event, and wipe root user id when moving accounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,5 +82,5 @@ release-vsn: # tags and pushes a new release
 	git push origin $$tag
 
 update-schema:
-	mix absinthe.schema.sdl --schema GraphQl  schema/schema.graphql
+	MIX_ENV=test mix absinthe.schema.sdl --schema GraphQl  schema/schema.graphql
 	cd www && yarn graphql:codegen

--- a/apps/core/lib/core/backfill/accounts.ex
+++ b/apps/core/lib/core/backfill/accounts.ex
@@ -15,4 +15,9 @@ defmodule Core.Backfill.Accounts do
     grandfathered = Timex.now() |> Timex.shift(days: 60)
     Core.Repo.update_all(Account, set: [grandfathered_until: grandfathered])
   end
+
+  def wipe_dangling() do
+    Account.dangling_root()
+    |> Core.Repo.update_all(set: [root_user_id: nil])
+  end
 end

--- a/apps/core/lib/core/pubsub/protocols/hoggable.ex
+++ b/apps/core/lib/core/pubsub/protocols/hoggable.ex
@@ -19,3 +19,7 @@ defimpl Core.PubSub.Hoggable, for: [Core.PubSub.InstallationCreated, Core.PubSub
   defp event(PubSub.InstallationCreated), do: "installation.created"
   defp event(PubSub.InstallationDeleted), do: "installation.deleted"
 end
+
+defimpl Core.PubSub.Hoggable, for: Core.PubSub.UserCreated do
+  def hog(%{item: user}), do: {"user.created", user.id, %{email: user.email}}
+end

--- a/apps/core/lib/core/pubsub/protocols/hoggable.ex
+++ b/apps/core/lib/core/pubsub/protocols/hoggable.ex
@@ -21,5 +21,5 @@ defimpl Core.PubSub.Hoggable, for: [Core.PubSub.InstallationCreated, Core.PubSub
 end
 
 defimpl Core.PubSub.Hoggable, for: Core.PubSub.UserCreated do
-  def hog(%{item: user}), do: {"user.created", user.id, %{email: user.email}}
+  def hog(%{item: user}), do: {"user.created", user.id, %{}}
 end

--- a/apps/core/lib/core/schema/account.ex
+++ b/apps/core/lib/core/schema/account.ex
@@ -30,6 +30,13 @@ defmodule Core.Schema.Account do
     from(a in query, where: a.usage_updated)
   end
 
+  def dangling_root(query \\ __MODULE__) do
+    from(a in query,
+      join: u in assoc(a, :root_user),
+      where: u.account_id != a.id
+    )
+  end
+
   def ordered(query \\ __MODULE__, order \\ [asc: :id]) do
     from(a in query, order_by: ^order)
   end

--- a/apps/core/test/backfill/accounts_test.exs
+++ b/apps/core/test/backfill/accounts_test.exs
@@ -35,4 +35,19 @@ defmodule Core.Backfill.AccountsTest do
         do: assert refetch(account).grandfathered_until
     end
   end
+
+  describe "wipe_dangling/0" do
+    setup [:setup_root_user] # at least one account has a correct root
+
+    test "it can remove root_user_id for dangling accounts", %{account: a, user: u} do
+      accounts = insert_list(3, :account, root_user: insert(:user))
+
+      {3, _} = Accounts.wipe_dangling()
+
+      for a <- accounts,
+        do: refute refetch(a).root_user_id
+
+      assert refetch(a).root_user_id == u.id
+    end
+  end
 end

--- a/apps/core/test/pubsub/posthog/users_test.exs
+++ b/apps/core/test/pubsub/posthog/users_test.exs
@@ -12,7 +12,6 @@ defmodule Core.PubSub.Posthog.UsersTest do
       event = %PubSub.UserCreated{item: user}
       {:ok, attrs} = Consumers.Posthog.handle_event(event)
 
-      assert attrs.email == user.email
       assert attrs.distinct_id == user.id
     end
   end

--- a/apps/core/test/pubsub/posthog/users_test.exs
+++ b/apps/core/test/pubsub/posthog/users_test.exs
@@ -1,0 +1,19 @@
+defmodule Core.PubSub.Posthog.UsersTest do
+  use Core.SchemaCase, async: true
+  use Mimic
+  alias Core.PubSub.Consumers
+  alias Core.PubSub
+
+  describe "UserCreated" do
+    test "it will log user.created" do
+      user = insert(:user)
+      expect(Posthog, :capture, fn "user.created", attrs -> {:ok, attrs} end)
+
+      event = %PubSub.UserCreated{item: user}
+      {:ok, attrs} = Consumers.Posthog.handle_event(event)
+
+      assert attrs.email == user.email
+      assert attrs.distinct_id == user.id
+    end
+  end
+end

--- a/apps/core/test/services/accounts_test.exs
+++ b/apps/core/test/services/accounts_test.exs
@@ -348,6 +348,22 @@ defmodule Core.Services.AccountsTest do
       assert_receive {:event, %PubSub.UserCreated{item: ^user}}
     end
 
+    test "Existing root users will have account de-rooted", %{user: user, account: account} do
+      %{user: root, account: a2} = setup_root_user([]) |> Map.new()
+      {:ok, invite} = Accounts.create_invite(%{email: root.email}, user)
+
+      {:ok, user} = Accounts.realize_invite(%{
+        password: "some long password",
+        name: "Some User"
+      }, invite.secure_id)
+
+      assert user.email == invite.email
+      assert user.account_id == account.id
+      assert user.name == "Some User"
+
+      refute refetch(a2).root_user_id
+    end
+
     test "it will ignore privileged fields", %{user: user, account: account} do
       {:ok, invite} = Accounts.create_invite(%{email: "some@example.com"}, user)
 

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1285,9 +1285,12 @@ type PlanLineItems {
 
 input ScmAttributes {
   provider: ScmProvider
-  token: String!
-  name: String!
+  token: String
+  name: String
   org: String
+  gitUrl: String
+  publicKey: String
+  privateKey: String
 }
 
 input WorkspaceAttributes {
@@ -1942,6 +1945,7 @@ type CloudShell {
   provider: Provider!
   gitUrl: String!
   aesKey: String!
+  missing: [String]
   cluster: String!
   subdomain: String!
   alive: Boolean!
@@ -3405,6 +3409,7 @@ enum Order {
 enum ScmProvider {
   GITHUB
   GITLAB
+  MANUAL
 }
 
 type TestDelta {

--- a/www/src/generated/graphql.ts
+++ b/www/src/generated/graphql.ts
@@ -333,6 +333,7 @@ export type CloudShell = {
   gitUrl: Scalars['String'];
   id: Scalars['ID'];
   insertedAt?: Maybe<Scalars['DateTime']>;
+  missing?: Maybe<Array<Maybe<Scalars['String']>>>;
   provider: Provider;
   region: Scalars['String'];
   status?: Maybe<ShellStatus>;
@@ -4024,15 +4025,19 @@ export type ScanViolation = {
 };
 
 export type ScmAttributes = {
-  name: Scalars['String'];
+  gitUrl?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
   org?: InputMaybe<Scalars['String']>;
+  privateKey?: InputMaybe<Scalars['String']>;
   provider?: InputMaybe<ScmProvider>;
-  token: Scalars['String'];
+  publicKey?: InputMaybe<Scalars['String']>;
+  token?: InputMaybe<Scalars['String']>;
 };
 
 export enum ScmProvider {
   Github = 'GITHUB',
-  Gitlab = 'GITLAB'
+  Gitlab = 'GITLAB',
+  Manual = 'MANUAL'
 }
 
 export type ServiceAccountAttributes = {


### PR DESCRIPTION
## Summary
We've seen a few users become undeletable because they organically signed up pre-invite and had an account record still point to them as root user.  This should fix that and backfill some of the stale data.

## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.