### PR TITLE
Autoconfigure git for demo projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,11 @@ release-vsn: # tags and pushes a new release
 	git tag -a $$tag -m "new release"; \
 	git push origin $$tag
 
-update-schema:
+update-schema: ## updates gql schema
 	MIX_ENV=test mix absinthe.schema.sdl --schema GraphQl  schema/schema.graphql
 	cd www && yarn graphql:codegen
+
+delete-tag:  ## deletes a tag from git locally and upstream
+	@read -p "Version: " tag; \
+	git tag -d $$tag; \
+	git push origin :$$tag

--- a/apps/core/lib/core/pubsub/events.ex
+++ b/apps/core/lib/core/pubsub/events.ex
@@ -77,3 +77,6 @@ defmodule Core.PubSub.CacheUser, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.InviteCreated, do: use Piazza.PubSub.Event
 
 defmodule Core.PubSub.PersistedTokenCreated, do: use Piazza.PubSub.Event
+
+defmodule Core.PubSub.DemoProjectCreated, do: use Piazza.PubSub.Event
+defmodule Core.PubSub.DemoProjectDeleted, do: use Piazza.PubSub.Event

--- a/apps/core/lib/core/pubsub/protocols/hoggable.ex
+++ b/apps/core/lib/core/pubsub/protocols/hoggable.ex
@@ -23,3 +23,15 @@ end
 defimpl Core.PubSub.Hoggable, for: Core.PubSub.UserCreated do
   def hog(%{item: user}), do: {"user.created", user.id, %{}}
 end
+
+defimpl Core.PubSub.Hoggable, for: [Core.PubSub.DemoProjectCreated, Core.PubSub.DemoProjectDeleted] do
+  alias Core.PubSub
+  alias Core.Schema.DemoProject
+
+  def hog(%{item: %DemoProject{user_id: user_id}}) do
+    {event(@for), user_id, %{}}
+  end
+
+  defp event(PubSub.DemoProjectCreated), do: "demo.created"
+  defp event(PubSub.DemoProjectDeleted), do: "demo.deleted"
+end

--- a/apps/core/lib/core/schema/key_backup.ex
+++ b/apps/core/lib/core/schema/key_backup.ex
@@ -26,7 +26,6 @@ defmodule Core.Schema.KeyBackup do
     |> cast(attrs, @valid)
     |> validate_digest()
     |> unique_constraint(:name, name: index_name(:key_backups, [:user_id, :name]))
-    |> unique_constraint(:digest, name: index_name(:key_backups, [:user_id, :digest]))
     |> unique_constraint(:vault_path)
     |> foreign_key_constraint(:user_id)
     |> repositories()

--- a/apps/core/lib/core/services/shell.ex
+++ b/apps/core/lib/core/services/shell.ex
@@ -75,6 +75,8 @@ defmodule Core.Services.Shell do
     do: {:ok, url, pub, priv, %{name: user.name, email: user.email}}
   defp git_info(%{provider: p, token: t, name: n} = args, user) when is_binary(t) and is_binary(n),
     do: Scm.setup_repository(p, user.email, t, args[:org], n)
+  defp git_info(%{provider: :demo}, user),
+    do: Scm.setup_repository(:github, user.email, Core.conf(:github_demo_token), Core.conf(:github_demo_org), "demo-repo-#{user.id}")
   defp git_info(_, _), do: {:error, "you did not provide enough information to configure a git repository"}
 
   @doc """

--- a/apps/core/lib/core/services/shell/scm.ex
+++ b/apps/core/lib/core/services/shell/scm.ex
@@ -3,7 +3,7 @@ defmodule Core.Shell.Scm do
 
   @providers ~w(github gitlab)a
 
-  @type provider :: :github | :gitlab | :manual
+  @type provider :: :github | :gitlab | :manual | :demo
   @type error :: {:error, term}
 
   @doc """

--- a/apps/core/lib/core/services/users.ex
+++ b/apps/core/lib/core/services/users.ex
@@ -493,6 +493,15 @@ defmodule Core.Services.Users do
   end
 
   @doc """
+  Determines whether a user has an active demo project
+  """
+  @spec demoing?(User.t) :: boolean
+  def demoing?(%User{id: user_id}) do
+    Core.Schema.DemoProject.for_user(user_id)
+    |> Core.Repo.exists?()
+  end
+
+  @doc """
   Fetches or creates an eab key for the user mapped to that (cluster, provider)
   """
   @spec get_eab_key(binary, binary, User.t) :: {:ok, EabCredential.t} | error

--- a/apps/core/priv/repo/migrations/20230223134524_remove_backup_constraint.exs
+++ b/apps/core/priv/repo/migrations/20230223134524_remove_backup_constraint.exs
@@ -1,0 +1,7 @@
+defmodule Core.Repo.Migrations.RemoveBackupConstraint do
+  use Ecto.Migration
+
+  def change do
+    drop unique_index(:key_backups, [:user_id, :digest])
+  end
+end

--- a/apps/core/test/services/dns_test.exs
+++ b/apps/core/test/services/dns_test.exs
@@ -261,8 +261,4 @@ defmodule Core.Services.DnsTest do
       {:error, _} = Dns.delete_record(record.name, record.type, user)
     end
   end
-
-  defp dns_resp(external_id) do
-    {:ok, %Tesla.Env{body: %{"result" => %{"id" => external_id}}}}
-  end
 end

--- a/apps/core/test/support/schema_case.ex
+++ b/apps/core/test/support/schema_case.ex
@@ -50,4 +50,8 @@ defmodule Core.SchemaCase do
     {:ok, %{user: user, account: account}} = Core.Services.Accounts.create_account(user)
     [user: %{user | account: account}, account: account]
   end
+
+  def dns_resp(external_id) do
+    {:ok, %Tesla.Env{body: %{"result" => %{"id" => external_id}}}}
+  end
 end

--- a/apps/graphql/lib/graphql/schema/shell.ex
+++ b/apps/graphql/lib/graphql/schema/shell.ex
@@ -16,6 +16,7 @@ defmodule GraphQl.Schema.Shell do
     value :github
     value :gitlab
     value :manual
+    value :demo
   end
 
   input_object :scm_attributes do

--- a/apps/graphql/lib/graphql/schema/user.ex
+++ b/apps/graphql/lib/graphql/schema/user.ex
@@ -120,6 +120,10 @@ defmodule GraphQl.Schema.User do
         {:ok, Core.Services.Users.has_installations?(user)}
     end
 
+    field :demoing, :boolean, resolve: fn
+      user, _, _ -> {:ok, Core.Services.Users.demoing?(user)}
+    end
+
     field :avatar, :string, resolve: fn
       user, _, _ -> {:ok, Core.Storage.url({user.avatar, user}, :original)}
     end

--- a/apps/graphql/test/mutations/dns_mutations_test.exs
+++ b/apps/graphql/test/mutations/dns_mutations_test.exs
@@ -135,8 +135,4 @@ defmodule GraphQl.DnsMutationsTest do
       refute refetch(record)
     end
   end
-
-  defp dns_resp(external_id) do
-    {:ok, %Tesla.Env{body: %{"result" => %{"id" => external_id}}}}
-  end
 end

--- a/apps/worker/test/conduit/subscribers/cluster_test.exs
+++ b/apps/worker/test/conduit/subscribers/cluster_test.exs
@@ -14,8 +14,4 @@ defmodule Worker.Conduit.Subscribers.ClusterTest do
       refute refetch(record)
     end
   end
-
-  defp dns_resp(external_id) do
-    {:ok, %Tesla.Env{body: %{"result" => %{"id" => external_id}}}}
-  end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -136,7 +136,9 @@ config :core,
   vault: "https://vault.plural.sh:443",
   docker_env: [],
   openai_token: "openai",
-  stripe_webhook_secret: "bogus"
+  stripe_webhook_secret: "bogus",
+  github_demo_token: "test-pat",
+  github_demo_org: "pluralsh-demos"
 
 config :briefly,
   directory: [{:system, "TMPDIR"}, {:system, "TMP"}, {:system, "TEMP"}, "/tmp"],

--- a/plural/helm/plural/Chart.yaml
+++ b/plural/helm/plural/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: plural
 description: A helm chart for installing plural
 appVersion: 0.9.39
-version: 0.9.67
+version: 0.9.68
 dependencies:
 - name: hydra
   repository: https://k8s.ory.sh/helm/charts

--- a/plural/helm/plural/templates/secret.yaml
+++ b/plural/helm/plural/templates/secret.yaml
@@ -75,6 +75,9 @@ data:
 {{ if .Values.secrets.cloud_shell_img }}
   CLOUD_SHELL_IMG: {{ .Values.secrets.cloud_shell_img | b64enc | quote }}
 {{ end }}
+{{ if .Values.secrets.github_demo_token }}
+  GITHUB_DEMO_TOKEN: {{ .Values.secrets.github_demo_token | b64enc | quote }}
+{{ end }}
 {{ range $key, $value := .Values.extraSecretEnv }}
   {{ $key }}: {{ $value | b64enc | quote }}
 {{ end }}

--- a/plural/helm/plural/values.yaml
+++ b/plural/helm/plural/values.yaml
@@ -107,6 +107,14 @@ configOverlays:
     documentation: client secret for github oauth
     updates:
     - path: ['plural', 'secrets', 'github', 'client_secret']
+- name: github-demo-token
+  spec:
+    folder: secrets
+    subfolder: github
+    name: Github Demo Token
+    documentation: token for provisioning demo repositories
+    updates:
+    - path: ['plural', 'secrets', 'github_demo_token']
 - name: gitlab-client-id
   spec:
     name: Gitlab Client Id

--- a/rel/config/config.exs
+++ b/rel/config/config.exs
@@ -80,7 +80,8 @@ config :core,
   gcp_identity: get_env("GCP_USER_EMAIL") || "mjg@plural.sh",
   openai_token: get_env("OPENAI_BEARER_TOKEN"),
   enforce_pricing: get_env("ENFORCE_PRICING"),
-  stripe_webhook_secret: get_env("STRIPE_WEBHOOK_SECRET")
+  stripe_webhook_secret: get_env("STRIPE_WEBHOOK_SECRET"),
+  github_demo_token: get_env("GITHUB_DEMO_TOKEN")
 
 
 if get_env("VAULT_HOST") do


### PR DESCRIPTION
## Summary
Use a hardcoded PAT to autoprovision a git repo based on user id for demo experience. Also sends some more PH events

## Test Plan
unit test changes


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.