### PR TITLE
Implement cluster promotions

### DIFF
--- a/apps/core/lib/core/schema/cluster.ex
+++ b/apps/core/lib/core/schema/cluster.ex
@@ -32,13 +32,20 @@ defmodule Core.Schema.Cluster do
     )
   end
 
-  def for_user(query \\ __MODULE__, %User{id: user_id, account_id: account_id} = user) do
+
+  def for_user(query \\ __MODULE__, user)
+
+  def for_user(query, %User{id: user_id, account_id: account_id} = user) do
     accessible = User.accessible(user)
     from(c in query,
       left_join: u in subquery(accessible),
       where: c.account_id == ^account_id and (c.owner_id == ^user_id or c.owner_id == u.id),
       distinct: true
     )
+  end
+
+  def for_user(query, user_id) when is_binary(user_id) do
+    from(c in query, where: c.owner_id == ^user_id)
   end
 
   def ordered(query \\ __MODULE__, order \\ [asc: :name]) do

--- a/apps/core/lib/core/schema/cluster_dependency.ex
+++ b/apps/core/lib/core/schema/cluster_dependency.ex
@@ -1,0 +1,44 @@
+defmodule Core.Schema.ClusterDependency do
+  use Piazza.Ecto.Schema
+  alias Core.Schema.Cluster
+
+  schema "cluster_dependencies" do
+    belongs_to :cluster,    Cluster
+    belongs_to :dependency, Cluster
+
+    timestamps()
+  end
+
+  def for_cluster(query \\ __MODULE__, id) do
+    from(d in query, where: d.cluster_id == ^id)
+  end
+
+  def waterline(query \\ __MODULE__, user_id) do
+    from(cd in query,
+      join: c in assoc(cd, :cluster),
+      join: d in assoc(cd, :dependency),
+      join: u in assoc(d, :owner),
+      where: c.owner_id == ^user_id and not is_nil(u.upgrade_to),
+      select: min(u.upgrade_to)
+    )
+  end
+
+  def for_user(query \\ __MODULE__, user_id) do
+    clusters = Cluster.for_user(user_id)
+    from(d in query,
+      join: c in subquery(clusters),
+        on: c.id == d.cluster_id
+    )
+  end
+
+  @valid ~w(cluster_id dependency_id)a
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, @valid)
+    |> unique_constraint(:cluster_id)
+    |> foreign_key_constraint(:cluster_id)
+    |> foreign_key_constraint(:dependency_id)
+    |> validate_required(@valid)
+  end
+end

--- a/apps/core/lib/core/schema/platform_plan.ex
+++ b/apps/core/lib/core/schema/platform_plan.ex
@@ -34,7 +34,7 @@ defmodule Core.Schema.PlatformPlan do
     field :external_id, :string
 
     embeds_one :features, Features, on_replace: :update do
-      boolean_fields [:vpn, :user_management, :audit]
+      boolean_fields [:vpn, :user_management, :audit, :multi_cluster]
     end
 
     embeds_many :line_items, LineItem, on_replace: :delete

--- a/apps/core/lib/core/schema/user.ex
+++ b/apps/core/lib/core/schema/user.ex
@@ -55,6 +55,7 @@ defmodule Core.Schema.User do
     field :phone,           :string
     field :external_id,     :string
     field :demo_count,      :integer, default: 0
+    field :upgrade_to,      :binary_id
     field :trusted_icon,    :boolean, default: false, virtual: true
     field :password_change, :boolean, default: false, virtual: true
 

--- a/apps/core/lib/core/services/dependencies.ex
+++ b/apps/core/lib/core/services/dependencies.ex
@@ -99,7 +99,7 @@ defmodule Core.Services.Dependencies do
   def closure(nil), do: []
   def closure(deps) when is_list(deps), do: closure(deps, MapSet.new(), [])
 
-  defp valid_version?([%{locked: true} | _], %{repo: repo}), do: {:locked, repo} # don't deliver updates when an installation is locked
+  # defp valid_version?([%{locked: true} | _], %{repo: repo}), do: {:locked, repo} # don't deliver updates when an installation is locked
   defp valid_version?([_ | _], %{version: nil}), do: true
   defp valid_version?(versions, %{any_of: [_ | _] = deps}) do
     by_name = Enum.into(deps, %{}, & {&1.name, &1})

--- a/apps/core/lib/core/services/upgrades.ex
+++ b/apps/core/lib/core/services/upgrades.ex
@@ -4,24 +4,39 @@ defmodule Core.Services.Upgrades do
   require Logger
   alias Core.Schema.{
     User,
-    UpgradeQueue,
+    Version,
     Upgrade,
+    UpgradeQueue,
     DeferredUpdate,
     ChartInstallation,
     TerraformInstallation
   }
-  alias Core.Services.{Dependencies, Locks, Clusters}
+  alias Core.Schema.Dependencies, as: Deps
+  alias Core.Services.{Dependencies, Locks, Clusters, Payments, Rollouts}
   alias Core.PubSub
 
+  @type inst :: TerraformInstallation.t | ChartInstallation.t
+  @type error :: {:error, term}
+  @type queue_resp :: {:ok, UpgradeQueue.t} | error
+  @type upgrade_resp :: {:ok, Upgrade.t} | error
+  @type deferred_resp :: {:ok, DeferredUpdate.t} | error
+
+  @spec get_queue(binary) :: UpgradeQueue.t | nil
   def get_queue(id), do: Core.Repo.get(UpgradeQueue, id)
 
+  @spec get_queue(binary, binary) :: UpgradeQueue.t | nil
   def get_queue(user_id, name), do: Core.Repo.get_by(UpgradeQueue, user_id: user_id, name: name)
 
+  @spec queue_count(binary) :: integer
   def queue_count(user_id) do
     UpgradeQueue.for_user(user_id)
     |> Core.Repo.aggregate(:count, :id)
   end
 
+  @doc """
+  Determines whether your user can touch this q
+  """
+  @spec authorize(binary, User.t) :: queue_resp
   def authorize(id, %User{id: user_id}) do
     get_queue(id)
     |> Core.Repo.preload([:cluster])
@@ -31,80 +46,10 @@ defmodule Core.Services.Upgrades do
     end
   end
 
-  def poll_deferred_updates(type, limit) do
-    lock = lock_name(type)
-
-    start_transaction()
-    |> add_operation(:lock, fn _ -> Locks.acquire(lock, Ecto.UUID.generate()) end)
-    |> add_operation(:updates, fn _ ->
-      DeferredUpdate.dequeue(:"#{type}_installation_id", limit)
-      |> Core.Repo.all()
-      |> ok()
-    end)
-    |> add_operation(:release, fn _ -> Locks.release(lock) end)
-    |> execute(extract: :updates)
-  end
-
-  defp lock_name(type), do: "#{type}_deferred_updates"
-
-  def create_deferred_update(version_id, %ChartInstallation{id: id}, %User{id: user_id}) do
-    %DeferredUpdate{user_id: user_id}
-    |> DeferredUpdate.changeset(%{
-      chart_installation_id: id,
-      version_id: version_id,
-      dequeue_at: Timex.now()
-    })
-    |> Core.Repo.insert()
-  end
-
-  def create_deferred_update(version_id, %TerraformInstallation{id: id}, %User{id: user_id}) do
-    %DeferredUpdate{user_id: user_id}
-    |> DeferredUpdate.changeset(%{
-      terraform_installation_id: id,
-      version_id: version_id,
-      dequeue_at: Timex.now()
-    })
-    |> Core.Repo.insert()
-  end
-
-  def deferred_apply(%DeferredUpdate{} = update) do
-    %{user: user, version: version} = update =
-      Core.Repo.preload(update, [:user, :terraform_installation, :chart_installation, version: [:chart, :terraform]])
-
-    case Dependencies.valid?(version.dependencies, user) do
-      true ->
-        apply_deferred_update(update)
-      _ ->
-        dequeue = Timex.now() |> Timex.shift(hours: DeferredUpdate.wait_time(update))
-
-        update
-        |> Ecto.Changeset.change(%{dequeue_at: dequeue, attempts: update.attempts + 1})
-        |> Core.Repo.update()
-    end
-  end
-
-  defp apply_deferred_update(%DeferredUpdate{version_id: id, version: version} = update) do
-    start_transaction()
-    |> add_operation(:update, fn _ ->
-      update_inst(update)
-      |> Ecto.Changeset.change(%{version_id: id})
-      |> Core.Repo.update()
-    end)
-    |> add_operation(:upgrade, fn _ ->
-      Core.Rollable.Base.deliver_upgrades(update.user_id, fn queue ->
-        Core.Services.Upgrades.create_upgrade(%{
-          repository_id: repo_id(version),
-          message: "Upgraded #{type(version)} #{pkg_name(version)} to #{version.version}"
-        }, queue)
-      end)
-    end)
-    |> add_operation(:clean, fn _ -> Core.Repo.delete(update) end)
-    |> execute(extract: :clean)
-  end
-
-  defp update_inst(%{chart_installation: %ChartInstallation{} = inst}), do: inst
-  defp update_inst(%{terraform_installation: %TerraformInstallation{} = inst}), do: inst
-
+  @doc """
+  Create a new upgrade queue
+  """
+  @spec create_queue(map, User.t) :: queue_resp
   def create_queue(%{name: name} = attrs, %User{id: user_id, email: email} = user) do
     queue = get_queue(user_id, name)
 
@@ -130,6 +75,10 @@ defmodule Core.Services.Upgrades do
     |> notify(:upsert, queue)
   end
 
+  @doc """
+  Deletes this upgrade queue (done when the pinged time expires)
+  """
+  @spec delete_queue(UpgradeQueue.t) :: queue_resp
   def delete_queue(%UpgradeQueue{} = queue) do
     start_transaction()
     |> add_operation(:q, fn _ -> Core.Repo.delete(queue) end)
@@ -143,6 +92,10 @@ defmodule Core.Services.Upgrades do
     |> execute(extract: :q)
   end
 
+  @doc """
+  Create an upgrade queue
+  """
+  @spec create_upgrade(map, UpgradeQueue.t) :: upgrade_resp
   def create_upgrade(params, %UpgradeQueue{} = queue) do
     %Upgrade{queue_id: queue.id}
     |> Upgrade.changeset(params)
@@ -151,6 +104,10 @@ defmodule Core.Services.Upgrades do
     |> notify(:create)
   end
 
+  @doc """
+  Fetch the next unacked upgrade in this queue
+  """
+  @spec next(UpgradeQueue.t) :: Upgrade.t | nil
   def next(%UpgradeQueue{id: id, acked: acked}) do
     Upgrade.after_seq(acked)
     |> Upgrade.for_queue(id)
@@ -160,6 +117,10 @@ defmodule Core.Services.Upgrades do
     |> Core.Repo.preload([:repository])
   end
 
+  @doc """
+  update the pinged date for this queue
+  """
+  @spec ping(UpgradeQueue.t) :: queue_resp
   def ping(%UpgradeQueue{} = q) do
     %{cluster: cluster} = Core.Repo.preload(q, [:cluster])
 
@@ -180,6 +141,10 @@ defmodule Core.Services.Upgrades do
     |> notify(:update)
   end
 
+  @doc """
+  Marks the current pointer for this queue at `id`
+  """
+  @spec ack(binary, UpgradeQueue.t) :: queue_resp
   def ack(id, %UpgradeQueue{acked: nil} = q) do
     Ecto.Changeset.change(q, %{acked: id})
     |> Core.Repo.update()
@@ -193,6 +158,133 @@ defmodule Core.Services.Upgrades do
     |> Core.Repo.update()
     |> notify(:update)
   end
+
+
+  @doc """
+  Get the next batch of deferred updates to potentially apply
+  """
+  @spec poll_deferred_updates(:chart | :terraform, integer) :: [DeferredUpdate.t]
+  def poll_deferred_updates(type, limit) do
+    lock = lock_name(type)
+
+    start_transaction()
+    |> add_operation(:lock, fn _ -> Locks.acquire(lock, Ecto.UUID.generate()) end)
+    |> add_operation(:updates, fn _ ->
+      DeferredUpdate.dequeue(:"#{type}_installation_id", limit)
+      |> Core.Repo.all()
+      |> ok()
+    end)
+    |> add_operation(:release, fn _ -> Locks.release(lock) end)
+    |> execute(extract: :updates)
+  end
+
+  defp lock_name(type), do: "#{type}_deferred_updates"
+
+
+  @doc """
+  Create a new deferred update with `attrs`
+  """
+  @spec create_deferred_update(map, binary, inst, User.t) :: deferred_resp
+  def create_deferred_update(attrs \\ %{}, version_id, inst, %User{id: user_id}) do
+    {type, id} = update_info(inst)
+    %DeferredUpdate{user_id: user_id}
+    |> DeferredUpdate.changeset(Map.merge(attrs, %{
+      "#{type}_installation_id": id,
+      version_id: version_id,
+      dequeue_at: Timex.now()
+    }))
+    |> Core.Repo.insert()
+  end
+
+  defp update_info(%ChartInstallation{id: id}), do: {:chart, id}
+  defp update_info(%TerraformInstallation{id: id}), do: {:terraform, id}
+
+  @doc """
+  will mark all pending deferred updates for a user as dequeueable immediately
+  """
+  @spec kick(User.t) :: {:ok, integer} | error
+  def kick(%User{id: user_id}) do
+    DeferredUpdate.for_user(user_id)
+    |> DeferredUpdate.pending()
+    |> Core.Repo.update_all(set: [dequeue_at: Timex.now()])
+    |> elem(0)
+    |> ok()
+  end
+
+  @doc """
+  Try to move this deferred update to a users upgrade queue.  Will fail if:
+  * the dependencies still aren't valid
+  * the user is current delinquent on payments
+  * the installation is locked
+  """
+  @spec deferred_apply(DeferredUpdate.t) :: {:ok, [Upgrade.t]} | deferred_resp
+  def deferred_apply(%DeferredUpdate{} = update) do
+    %{user: user, version: version} = update =
+      Core.Repo.preload(update, [:user, :terraform_installation, :chart_installation, version: [:chart, :terraform]])
+
+    case {Dependencies.valid?(version.dependencies, user), Payments.delinquent?(user), locked?(update)} do
+      {true, false, false} ->
+        apply_deferred_update(update)
+      _ ->
+        dequeue = Timex.now() |> Timex.shift(hours: DeferredUpdate.wait_time(update))
+
+        update
+        |> Ecto.Changeset.change(%{dequeue_at: dequeue, attempts: update.attempts + 1})
+        |> Core.Repo.update()
+    end
+  end
+
+  defp apply_deferred_update(%DeferredUpdate{version: version} = update) do
+    start_transaction()
+    |> add_operation(:upgrade, fn _ -> install_version(version, update_inst(update)) end)
+    |> add_operation(:clean, fn _ -> Core.Repo.delete(update) end)
+    |> execute(extract: :clean)
+  end
+
+  defp locked?(%{terraform_installation: %{locked: true}}), do: true
+  defp locked?(%{chart_installation: %{locked: true}}), do: true
+  defp locked?(_), do: false
+
+  @doc """
+  Installs a version and either:
+  * locks the installation if needed
+  * create an upgrade in the users queue if it's not a locking update
+  """
+  @spec install_version(Version.t, inst) :: {:ok, [Upgrade.t]} | error
+  def install_version(version, inst) do
+    start_transaction()
+    |> add_operation(:lock, fn _ -> Rollouts.lock_installation(version, inst) end)
+    |> add_operation(:inst, fn %{lock: inst} ->
+      inst
+      |> Ecto.Changeset.change(%{version_id: version.id})
+      |> Core.Repo.update()
+      |> when_ok(&Core.Repo.preload(&1, [:installation]))
+    end)
+    |> add_operation(:upgrades, fn
+      %{inst: %{locked: true}} -> locked_upgrades(version, inst)
+      %{inst: inst} -> Core.Rollable.Base.deliver_upgrades(inst.installation.user_id, fn queue ->
+        create_upgrade(%{
+          repository_id: repo_id(version),
+          message: "Upgraded #{type(version)} #{pkg_name(version)} to #{version.version}"
+        }, queue)
+      end)
+    end)
+    |> execute(extract: :upgrades)
+  end
+
+  defp locked_upgrades(%Version{dependencies: %Deps{dedicated: true}} = version, inst) do
+    Core.Rollable.Base.deliver_upgrades(inst.installation.user_id, fn queue ->
+      Core.Services.Upgrades.create_upgrade(%{
+        type: :dedicated,
+        repository_id: repo_id(version),
+        message: "Upgraded #{type(version)} #{pkg_name(version)} to #{version.version}"
+      }, queue)
+    end)
+  end
+  defp locked_upgrades(_, _), do: {:ok, []}
+
+  defp update_inst(%{chart_installation: %ChartInstallation{} = inst}), do: inst
+  defp update_inst(%{terraform_installation: %TerraformInstallation{} = inst}), do: inst
 
   defp notify({:ok, %Upgrade{} = upgrade}, :create),
     do: handle_notify(PubSub.UpgradeCreated, upgrade)

--- a/apps/core/priv/repo/migrations/20230226032204_cluster_promotions.exs
+++ b/apps/core/priv/repo/migrations/20230226032204_cluster_promotions.exs
@@ -1,0 +1,24 @@
+defmodule Core.Repo.Migrations.ClusterPromotions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :upgrade_to, :uuid
+    end
+
+    alter table(:deferred_updates) do
+      add :pending, :boolean
+    end
+
+    create table(:cluster_dependencies, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :cluster_id, references(:clusters, type: :uuid, on_delete: :delete_all)
+      add :dependency_id, references(:clusters, type: :uuid, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create unique_index(:cluster_dependencies, [:cluster_id])
+    create index(:cluster_dependencies, [:dependency_id])
+  end
+end

--- a/apps/core/test/services/dependencies_test.exs
+++ b/apps/core/test/services/dependencies_test.exs
@@ -24,28 +24,6 @@ defmodule Core.Services.DependenciesTest do
       assert Dependencies.valid?(terraform.dependencies, user)
     end
 
-    test "If a dependency is locked, it will return a locked tuple" do
-      chart     = insert(:chart)
-      terraform = insert(:terraform)
-      user      = insert(:user)
-      insert(:chart_installation,
-        chart: chart,
-        locked: true,
-        installation: insert(:installation, user: user, repository: chart.repository)
-      )
-      insert(:terraform_installation,
-        terraform: terraform,
-        installation: insert(:installation, user: user, repository: terraform.repository)
-      )
-
-      terraform = insert(:terraform, dependencies: %{dependencies: [
-        %{type: :helm, repo: chart.repository.name, name: chart.name, providers: [:gcp]},
-        %{type: :terraform, repo: terraform.repository.name, name: terraform.name}
-      ]})
-
-      {:locked, _} = Dependencies.valid?(terraform.dependencies, user)
-    end
-
     test "If a dependency is missing it returns false" do
       chart     = insert(:chart)
       terraform = insert(:terraform)

--- a/apps/core/test/services/rollable/versions_test.exs
+++ b/apps/core/test/services/rollable/versions_test.exs
@@ -148,6 +148,60 @@ defmodule Core.Rollable.VersionsTest do
       assert deferred.version_id == version.id
     end
 
+    test "it will defer updates if an installation is locked" do
+      user = insert(:user, account: build(:account))
+      %{chart: chart} = chart_version = insert(:version, version: "0.1.0")
+      inst = insert(:chart_installation,
+        locked: true,
+        installation: insert(:installation, auto_upgrade: true, user: user),
+        chart: chart,
+        version: chart_version
+      )
+
+      version = insert(:version, version: "0.1.1", chart: chart)
+      insert(:version_tag, version: version, chart: chart, tag: "latest")
+
+      event = %PubSub.VersionCreated{item: version}
+      {:ok, rollout} = Rollouts.create_rollout(chart.repository_id, event)
+
+      {:ok, rolled} = Rollouts.execute(rollout)
+
+      assert rolled.status == :finished
+      assert rolled.count == 1
+
+      [deferred] = Core.Repo.all(Core.Schema.DeferredUpdate)
+
+      assert deferred.chart_installation_id == inst.id
+      assert deferred.version_id == version.id
+    end
+
+    test "it will defer updates if a user has promotions enabled" do
+      user = insert(:user, account: build(:account), upgrade_to: uuid(0))
+      %{chart: chart} = chart_version = insert(:version, version: "0.1.0")
+      inst = insert(:chart_installation,
+        installation: insert(:installation, auto_upgrade: true, user: user),
+        chart: chart,
+        version: chart_version
+      )
+
+      version = insert(:version, version: "0.1.1", chart: chart)
+      insert(:version_tag, version: version, chart: chart, tag: "latest")
+
+      event = %PubSub.VersionCreated{item: version}
+      {:ok, rollout} = Rollouts.create_rollout(chart.repository_id, event)
+
+      {:ok, rolled} = Rollouts.execute(rollout)
+
+      assert rolled.status == :finished
+      assert rolled.count == 1
+
+      [deferred] = Core.Repo.all(Core.Schema.DeferredUpdate)
+
+      assert deferred.chart_installation_id == inst.id
+      assert deferred.version_id == version.id
+      assert deferred.pending
+    end
+
     test "it will defer updates if a version's dependencies aren't satisfied" do
       dep_chart = insert(:chart)
       %{chart: chart} = chart_version = insert(:version, version: "0.1.0")

--- a/apps/core/test/services/upgrades_test.exs
+++ b/apps/core/test/services/upgrades_test.exs
@@ -173,6 +173,38 @@ defmodule Core.Services.UpgradesTest do
       assert deferred.attempts == 1
       assert Timex.after?(deferred.dequeue_at, Timex.now())
     end
+
+    test "if an installation is locked, it will re-enqueue the upgrade" do
+      user  = insert(:user)
+      chart = insert(:chart)
+      insert(:upgrade_queue, user: user)
+      chart_inst = insert(:chart_installation, locked: true, installation: build(:installation, user: user))
+      version = insert(:version, chart: chart_inst.chart, dependencies: %{dependencies: [
+        %{type: :helm, repo: chart.repository.name, name: chart.name, providers: [:gcp]}
+      ]})
+      deferred = insert(:deferred_update, chart_installation: chart_inst, version: version, user: user)
+
+      {:ok, deferred} = Upgrades.deferred_apply(deferred)
+
+      assert deferred.attempts == 1
+      assert Timex.after?(deferred.dequeue_at, Timex.now())
+    end
+
+    test "if a user is delinquent, it will re-enqueue the upgrade" do
+      user  = insert(:user, account: build(:account, delinquent_at: Timex.now()))
+      chart = insert(:chart)
+      insert(:upgrade_queue, user: user)
+      chart_inst = insert(:chart_installation, installation: build(:installation, user: user))
+      version = insert(:version, chart: chart_inst.chart, dependencies: %{dependencies: [
+        %{type: :helm, repo: chart.repository.name, name: chart.name, providers: [:gcp]}
+      ]})
+      deferred = insert(:deferred_update, chart_installation: chart_inst, version: version, user: user)
+
+      {:ok, deferred} = Upgrades.deferred_apply(deferred)
+
+      assert deferred.attempts == 1
+      assert Timex.after?(deferred.dequeue_at, Timex.now())
+    end
   end
 
   describe "#poll_deferred_updates/2" do
@@ -186,6 +218,19 @@ defmodule Core.Services.UpgradesTest do
       {:ok, vals} = Upgrades.poll_deferred_updates(:chart, 10)
 
       assert ids_equal([deferred, deferred2], vals)
+    end
+
+    test "it will ignore updates pending promotion" do
+      user = insert(:user, upgrade_to: uuid(0))
+      inst1 = insert(:chart_installation, installation: build(:installation, user: user))
+      insert(:deferred_update, id: uuid(1), chart_installation: inst1, user: user)
+      insert(:deferred_update, id: uuid(2), chart_installation: inst1, user: user)
+      deferred2 = insert(:deferred_update, id: uuid(0), chart_installation: build(:chart_installation))
+      insert(:deferred_update, terraform_installation: build(:terraform_installation))
+
+      {:ok, vals} = Upgrades.poll_deferred_updates(:chart, 10)
+
+      assert ids_equal([deferred2], vals)
     end
   end
 end

--- a/apps/core/test/support/factory.ex
+++ b/apps/core/test/support/factory.ex
@@ -609,6 +609,13 @@ defmodule Core.Factory do
     }
   end
 
+  def cluster_dependency_factory do
+    %Schema.ClusterDependency{
+      cluster: build(:cluster),
+      dependency: build(:cluster)
+    }
+  end
+
   def with_password(%Schema.User{} = user, password) do
     Schema.User.changeset(user, %{password: password})
     |> Ecto.Changeset.apply_changes()

--- a/apps/graphql/lib/graphql.ex
+++ b/apps/graphql/lib/graphql.ex
@@ -62,7 +62,8 @@ defmodule GraphQl do
     Dns,
     Test,
     Cluster,
-    Upgrade
+    Upgrade,
+    GraphQl.InstallationLoader
   ]
 
   def context(ctx) do

--- a/apps/graphql/lib/graphql/resolvers/dataloaders.ex
+++ b/apps/graphql/lib/graphql/resolvers/dataloaders.ex
@@ -1,0 +1,19 @@
+defmodule GraphQl.InstallationLoader do
+  alias Core.Schema.Installation
+
+  def data(_) do
+    Dataloader.KV.new(&query/2, max_concurrency: 1)
+  end
+
+  def query(_, ids) do
+    insts = fetch_insts(ids)
+    Map.new(ids, & {&1, insts[&1]})
+  end
+
+  def fetch_insts(ids) do
+    MapSet.to_list(ids)
+    |> Installation.for_ids()
+    |> Core.Repo.all()
+    |> Map.new(& {&1.id, &1})
+  end
+end

--- a/apps/graphql/lib/graphql/schema/cluster.ex
+++ b/apps/graphql/lib/graphql/schema/cluster.ex
@@ -1,6 +1,8 @@
 defmodule GraphQl.Schema.Cluster do
   use GraphQl.Schema.Base
+  alias GraphQl.Middleware.Differentiate
   alias GraphQl.Resolvers.{User, Account, Upgrade, Cluster}
+  alias GraphQl.InstallationLoader
 
   @desc "Possible cluster sources."
   ecto_enum :source, Core.Schema.Installation.Source
@@ -17,18 +19,40 @@ defmodule GraphQl.Schema.Cluster do
 
   @desc "A Kubernetes cluster that can be used to deploy applications on with Plural."
   object :cluster do
-    field :id,          non_null(:id), description: "The ID of the cluster."
-    field :name,        non_null(:string), description: "The name of the cluster."
-    field :provider,    non_null(:provider), description: "The cluster's cloud provider."
-    field :source,      :source, description: "The source of the cluster."
-    field :git_url,     :string, description: "The git repository URL for the cluster."
-    field :console_url, :string, description: "The URL of the console running on the cluster."
-    field :domain,      :string, description: "The domain name used for applications deployed on the cluster."
-    field :pinged_at,   :datetime, description: "The last time the cluster was pinged."
+    field :id,           non_null(:id), description: "The ID of the cluster."
+    field :name,         non_null(:string), description: "The name of the cluster."
+    field :provider,     non_null(:provider), description: "The cluster's cloud provider."
+    field :source,       :source, description: "The source of the cluster."
+    field :git_url,      :string, description: "The git repository URL for the cluster."
+    field :console_url,  :string, description: "The URL of the console running on the cluster."
+    field :domain,       :string, description: "The domain name used for applications deployed on the cluster."
+    field :pinged_at,    :datetime, description: "The last time the cluster was pinged."
+    field :upgrade_info, list_of(:upgrade_info), description: "pending upgrades for each installed app", resolve: fn
+      cluster, _, _ -> Cluster.upgrade_info(cluster)
+    end
 
     field :owner,   :user, resolve: dataloader(User), description: "The user that owns the cluster."
     field :account, :account, resolve: dataloader(Account), description: "The account that the cluster belongs to."
     field :queue,   :upgrade_queue, resolve: dataloader(Upgrade), description: "The upgrade queue for applications running on the cluster."
+
+    timestamps()
+  end
+
+  @desc "The pending upgrades for a repository"
+  object :upgrade_info do
+    field :installation, :installation, resolve: fn
+      %{installation_id: id}, _, %{context: %{loader: loader}} ->
+        manual_dataloader(loader, InstallationLoader, :ids, id)
+    end
+    field :count, :integer
+  end
+
+  @desc "A dependncy reference between clusters"
+  object :cluster_dependency do
+    field :id, non_null(:id)
+
+    field :cluster,    :cluster, resolve: dataloader(Cluster), description: "the cluster holding this dependency"
+    field :dependency, :cluster, resolve: dataloader(Cluster), description: "the source cluster of this dependency"
 
     timestamps()
   end
@@ -55,6 +79,20 @@ defmodule GraphQl.Schema.Cluster do
       arg :attributes, non_null(:cluster_attributes), description: "The input attributes for the cluster that will be created."
 
       safe_resolve &Cluster.create_cluster/2
+    end
+
+    @desc "adds a dependency for this cluster to gate future upgrades"
+    field :create_cluster_dependency, :cluster_dependency do
+      # middleware Differentiate, feature: :multi_cluster
+      arg :source_id, non_null(:id)
+      arg :dest_id,   non_null(:id)
+
+      safe_resolve &Cluster.create_dependency/2
+    end
+
+    @desc "moves up the upgrade waterline for a user"
+    field :promote, :user do
+      safe_resolve &Cluster.promote/2
     end
 
     @desc "Delete a cluster."

--- a/apps/graphql/lib/graphql/schema/upgrade.ex
+++ b/apps/graphql/lib/graphql/schema/upgrade.ex
@@ -56,12 +56,20 @@ defmodule GraphQl.Schema.Upgrade do
     field :id,         non_null(:id)
     field :dequeue_at, :datetime
     field :attempts,   :integer
+    field :pending,    :boolean
+    field :messages,   list_of(:deferred_reason)
 
     field :chart_installation,     :chart_installation, resolve: dataloader(Chart)
     field :terraform_installation, :terraform_installation, resolve: dataloader(Terraform)
     field :version,                :version, resolve: dataloader(Version)
 
     timestamps()
+  end
+
+  object :deferred_reason do
+    field :message,    :string
+    field :package,    :string
+    field :repository, :string
   end
 
   connection node_type: :upgrade

--- a/apps/graphql/test/mutations/cluster_mutations_test.exs
+++ b/apps/graphql/test/mutations/cluster_mutations_test.exs
@@ -37,4 +37,44 @@ defmodule GraphQl.ClusterMutationsTest do
       refute refetch(cluster)
     end
   end
+
+  describe "createClusterDependency" do
+    test "it will create a dependency reference" do
+      user = insert(:user)
+      sa = insert(:user, service_account: true, account: user.account)
+      insert(:impersonation_policy_binding,
+        policy: build(:impersonation_policy, user: sa),
+        user: user
+      )
+      dest   = insert(:cluster, owner: user)
+      source = insert(:cluster, owner: sa)
+
+      {:ok, %{data: %{"createClusterDependency" => dep}}} = run_query("""
+        mutation Create($source: ID!, $dest: ID!) {
+          createClusterDependency(sourceId: $source, destId: $dest) {
+            cluster { id }
+            dependency { id }
+          }
+        }
+      """, %{"source" => source.id, "dest" => dest.id}, %{current_user: user})
+
+      assert dep["cluster"]["id"] == dest.id
+      assert dep["dependency"]["id"] == source.id
+    end
+  end
+
+  describe "promote" do
+    test "it can do a promotion" do
+      user = insert(:user, upgrade_to: uuid(0))
+
+      {:ok, %{data: %{"promote" => promo}}} = run_query("""
+        mutation {
+          promote { id }
+        }
+      """, %{}, %{current_user: user})
+
+      assert promo["id"] == user.id
+      assert refetch(user).upgrade_to > user.upgrade_to
+    end
+  end
 end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -5,6 +5,12 @@ schema {
   subscription: RootSubscriptionType
 }
 
+"The pending upgrades for a repository"
+type UpgradeInfo {
+  installation: Installation
+  count: Int
+}
+
 type PageInfo {
   "When paginating backwards, are there more items?"
   hasPreviousPage: Boolean!
@@ -17,6 +23,29 @@ type PageInfo {
 
   "When paginating forwards, the cursor to continue."
   endCursor: String
+}
+
+enum IncidentAction {
+  EDIT
+  CREATE
+  STATUS
+  SEVERITY
+  ACCEPT
+  COMPLETE
+}
+
+type ChartInstallation {
+  id: ID
+  chart: Chart
+  version: Version
+  installation: Installation
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type RepositorySubscriptionConnection {
+  pageInfo: PageInfo!
+  edges: [RepositorySubscriptionEdge]
 }
 
 type IncidentConnection {
@@ -39,27 +68,9 @@ type DeferredUpdateConnection {
   edges: [DeferredUpdateEdge]
 }
 
-enum IncidentAction {
-  EDIT
-  CREATE
-  STATUS
-  SEVERITY
-  ACCEPT
-  COMPLETE
-}
-
 type IncidentMessageConnection {
   pageInfo: PageInfo!
   edges: [IncidentMessageEdge]
-}
-
-type ChartInstallation {
-  id: ID
-  chart: Chart
-  version: Version
-  installation: Installation
-  insertedAt: DateTime
-  updatedAt: DateTime
 }
 
 type RecipeSection {
@@ -71,11 +82,6 @@ type RecipeSection {
   configuration: [RecipeConfiguration]
   insertedAt: DateTime
   updatedAt: DateTime
-}
-
-type RepositorySubscriptionConnection {
-  pageInfo: PageInfo!
-  edges: [RepositorySubscriptionEdge]
 }
 
 type UserConnection {
@@ -152,6 +158,14 @@ type ActionItem {
   link: String!
 }
 
+type LineItem {
+  name: String!
+  dimension: String!
+  cost: Int!
+  period: String
+  type: PlanType
+}
+
 type RecipeItem {
   id: ID
   chart: Chart
@@ -160,14 +174,6 @@ type RecipeItem {
   configuration: [RecipeConfiguration]
   insertedAt: DateTime
   updatedAt: DateTime
-}
-
-type LineItem {
-  name: String!
-  dimension: String!
-  cost: Int!
-  period: String
-  type: PlanType
 }
 
 type ClosureItem {
@@ -665,6 +671,12 @@ type RolloutConnection {
   edges: [RolloutEdge]
 }
 
+type DeferredReason {
+  message: String
+  package: String
+  repository: String
+}
+
 type GroupConnection {
   pageInfo: PageInfo!
   edges: [GroupEdge]
@@ -968,6 +980,21 @@ type Repository {
 
   "The documentation of the application."
   docs: [FileContent]
+
+  insertedAt: DateTime
+
+  updatedAt: DateTime
+}
+
+"A dependncy reference between clusters"
+type ClusterDependency {
+  id: ID!
+
+  "the cluster holding this dependency"
+  cluster: Cluster
+
+  "the source cluster of this dependency"
+  dependency: Cluster
 
   insertedAt: DateTime
 
@@ -1436,6 +1463,9 @@ type Cluster {
   "The last time the cluster was pinged."
   pingedAt: DateTime
 
+  "pending upgrades for each installed app"
+  upgradeInfo: [UpgradeInfo]
+
   "The user that owns the cluster."
   owner: User
 
@@ -1809,6 +1839,12 @@ type RootMutationType {
     "The input attributes for the cluster that will be created."
     attributes: ClusterAttributes!
   ): Cluster
+
+  "adds a dependency for this cluster to gate future upgrades"
+  createClusterDependency(sourceId: ID!, destId: ID!): ClusterDependency
+
+  "moves up the upgrade waterline for a user"
+  promote: User
 
   "Delete a cluster."
   deleteCluster(
@@ -2243,6 +2279,8 @@ type DeferredUpdate {
   id: ID!
   dequeueAt: DateTime
   attempts: Int
+  pending: Boolean
+  messages: [DeferredReason]
   chartInstallation: ChartInstallation
   terraformInstallation: TerraformInstallation
   version: Version

--- a/www/src/generated/graphql.ts
+++ b/www/src/generated/graphql.ts
@@ -376,6 +376,8 @@ export type Cluster = {
   /** The source of the cluster. */
   source?: Maybe<Source>;
   updatedAt?: Maybe<Scalars['DateTime']>;
+  /** pending upgrades for each installed app */
+  upgradeInfo?: Maybe<Array<Maybe<UpgradeInfo>>>;
 };
 
 /** Input for creating or updating a cluster. */
@@ -398,6 +400,18 @@ export type ClusterConnection = {
   __typename?: 'ClusterConnection';
   edges?: Maybe<Array<Maybe<ClusterEdge>>>;
   pageInfo: PageInfo;
+};
+
+/** A dependncy reference between clusters */
+export type ClusterDependency = {
+  __typename?: 'ClusterDependency';
+  /** the cluster holding this dependency */
+  cluster?: Maybe<Cluster>;
+  /** the source cluster of this dependency */
+  dependency?: Maybe<Cluster>;
+  id: Scalars['ID'];
+  insertedAt?: Maybe<Scalars['DateTime']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
 };
 
 export type ClusterEdge = {
@@ -496,6 +510,13 @@ export enum Datatype {
   String = 'STRING'
 }
 
+export type DeferredReason = {
+  __typename?: 'DeferredReason';
+  message?: Maybe<Scalars['String']>;
+  package?: Maybe<Scalars['String']>;
+  repository?: Maybe<Scalars['String']>;
+};
+
 export type DeferredUpdate = {
   __typename?: 'DeferredUpdate';
   attempts?: Maybe<Scalars['Int']>;
@@ -503,6 +524,8 @@ export type DeferredUpdate = {
   dequeueAt?: Maybe<Scalars['DateTime']>;
   id: Scalars['ID'];
   insertedAt?: Maybe<Scalars['DateTime']>;
+  messages?: Maybe<Array<Maybe<DeferredReason>>>;
+  pending?: Maybe<Scalars['Boolean']>;
   terraformInstallation?: Maybe<TerraformInstallation>;
   updatedAt?: Maybe<Scalars['DateTime']>;
   version?: Maybe<Version>;
@@ -2482,6 +2505,8 @@ export type RootMutationType = {
   createCard?: Maybe<Account>;
   /** Create a new cluster. */
   createCluster?: Maybe<Cluster>;
+  /** adds a dependency for this cluster to gate future upgrades */
+  createClusterDependency?: Maybe<ClusterDependency>;
   createCrd?: Maybe<Crd>;
   createDemoProject?: Maybe<DemoProject>;
   createDnsRecord?: Maybe<DnsRecord>;
@@ -2562,6 +2587,8 @@ export type RootMutationType = {
   oauthConsent?: Maybe<OauthResponse>;
   passwordlessLogin?: Maybe<User>;
   pingWebhook?: Maybe<WebhookResponse>;
+  /** moves up the upgrade waterline for a user */
+  promote?: Maybe<User>;
   provisionDomain?: Maybe<DnsDomain>;
   publishLogs?: Maybe<TestStep>;
   quickStack?: Maybe<Stack>;
@@ -2648,6 +2675,12 @@ export type RootMutationTypeCreateCardArgs = {
 
 export type RootMutationTypeCreateClusterArgs = {
   attributes: ClusterAttributes;
+};
+
+
+export type RootMutationTypeCreateClusterDependencyArgs = {
+  destId: Scalars['ID'];
+  sourceId: Scalars['ID'];
 };
 
 
@@ -4401,6 +4434,13 @@ export type UpgradeEdge = {
   __typename?: 'UpgradeEdge';
   cursor?: Maybe<Scalars['String']>;
   node?: Maybe<Upgrade>;
+};
+
+/** The pending upgrades for a repository */
+export type UpgradeInfo = {
+  __typename?: 'UpgradeInfo';
+  count?: Maybe<Scalars['Int']>;
+  installation?: Maybe<Installation>;
 };
 
 export type UpgradeQueue = {


### PR DESCRIPTION
## Summary
The way this is going to work is a user has a timestamp if promotions are enabled that forces upgrades to be deferred up to that timestamp, and each promotion will simply update that waterline.

Also cleaned up some of the upgrade code overall.  I've deferred gating it on the multi_cluster feature since we might want to let some users test it early-access

## Test Plan
unit tests throughout


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.