### PR TITLE
Fix stale struct error when deleting deferred updates

### DIFF
--- a/apps/core/lib/core/services/upgrades.ex
+++ b/apps/core/lib/core/services/upgrades.ex
@@ -237,7 +237,12 @@ defmodule Core.Services.Upgrades do
   defp apply_deferred_update(%DeferredUpdate{version: version} = update) do
     start_transaction()
     |> add_operation(:upgrade, fn _ -> install_version(version, update_inst(update)) end)
-    |> add_operation(:clean, fn _ -> Core.Repo.delete(update) end)
+    |> add_operation(:clean, fn _ ->
+      case Core.Repo.get(DeferredUpdate, update.id) do
+        nil -> {:ok, nil}
+        update -> Core.Repo.delete(update)
+      end
+    end)
     |> execute(extract: :clean)
   end
 


### PR DESCRIPTION
## Summary

I'm not sure the root cause here but it's probably due to the deferred update coming from a separate process in the genstage or something.  Refetching should solve the issue.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.