### PR TITLE
Preselect app based on url query param

### DIFF
--- a/www/src/components/shell/terminal/installer/helpers.tsx
+++ b/www/src/components/shell/terminal/installer/helpers.tsx
@@ -22,11 +22,7 @@ import { RECIPE_Q } from '../../../repository/packages/queries'
 import { Application } from './Application'
 import { APPLICATIONS_QUERY } from './queries'
 
-const FORCED_APPS = {
-  console: 'The Plural Console will allow you to monitor, upgrade, and deploy applications easily from one centralized place.',
-}
-
-const toPickerItems = (applications, provider: Provider): Array<WizardStepConfig> => applications?.map(app => ({
+const toPickerItems = (applications, provider: Provider, forcedApps): Array<WizardStepConfig> => applications?.map(app => ({
   key: app.id,
   label: app.name,
   imageUrl: app.icon,
@@ -34,15 +30,15 @@ const toPickerItems = (applications, provider: Provider): Array<WizardStepConfig
     key={app.id}
     provider={provider}
   />,
-  isRequired: Object.keys(FORCED_APPS).includes(app.name),
-  tooltip: FORCED_APPS[app.name],
+  isRequired: Object.keys(forcedApps).includes(app.name),
+  tooltip: forcedApps[app.name],
 })) || []
 
-const toDefaultSteps = (applications, provider: Provider): Array<WizardStepConfig> => [{
+const toDefaultSteps = (applications, provider: Provider, forcedApps): Array<WizardStepConfig> => [{
   key: 'apps',
   label: 'Apps',
   Icon: AppsIcon,
-  node: <WizardPicker items={toPickerItems(applications, provider)} />,
+  node: <WizardPicker items={toPickerItems(applications, provider, forcedApps)} />,
   isDefault: true,
 },
 {


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
`install=<appName>` query param can be used to preselect app in the installer.
`https://localhost:3001/shell?install=airflow`

![image](https://user-images.githubusercontent.com/2285385/223485579-73f519ad-0d8c-410c-ad67-7c32c4f1486b.png)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.