### PR TITLE
Don't toggle account delinquency on downgrade

### DIFF
--- a/apps/core/lib/core/services/payments.ex
+++ b/apps/core/lib/core/services/payments.ex
@@ -561,11 +561,7 @@ defmodule Core.Services.Payments do
       |> allow(user, :delete)
       |> when_ok(:delete)
     end)
-    |> add_operation(:account, fn %{fetch: account} ->
-      Account.payment_changeset(account, %{delinquent_at: nil})
-      |> Core.Repo.update()
-      |> when_ok(&Map.put(&1, :subscription, nil))
-    end)
+    |> add_operation(:account, fn %{fetch: account} -> {:ok, %{account | subscription: nil}} end)
     |> add_operation(:stripe, fn %{db: %{external_id: ext_id}} -> Stripe.Subscription.delete(ext_id, %{prorate: true}) end)
     |> execute(extract: :account)
     |> notify(:delete)


### PR DESCRIPTION
## Summary
I'm not positive why I implemented this logic, but delinquent accounts downgrading shouldn't be marked non-delinquent

## Test Plan
n/a

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.