### PR TITLE
fix(frontend): add address element and fix add cards

### DIFF
--- a/www/src/components/Plural.tsx
+++ b/www/src/components/Plural.tsx
@@ -121,6 +121,16 @@ function WrapStripe({ children }: any) {
     appearance: {
       theme: 'night',
       labels: 'floating',
+      variables: {
+        // colorPrimary: '#747B8B',
+        // colorBackground: '#747B8B',
+        fontSizeBase: '10px',
+        colorText: '#747B8B',
+        // colorDanger: '#df1b41',
+        // fontFamily: 'Ideal Sans, system-ui, sans-serif',
+        // spacingUnit: '2px',
+        // borderRadius: '4px',
+      },
     },
   }
 

--- a/www/src/components/Plural.tsx
+++ b/www/src/components/Plural.tsx
@@ -117,10 +117,20 @@ function WrapStripe({ children }: any) {
 
   const stripePromise = useMemo(() => loadStripe(stripePublishableKey), [stripePublishableKey])
 
+  const options = {
+    appearance: {
+      theme: 'night',
+      labels: 'floating',
+    },
+  }
+
   if (!stripePublishableKey) return children
 
   return (
-    <Elements stripe={stripePromise}>
+    <Elements
+      stripe={stripePromise}
+      options={options}
+    >
       {children}
     </Elements>
   )

--- a/www/src/components/Plural.tsx
+++ b/www/src/components/Plural.tsx
@@ -3,7 +3,6 @@ import {
   lazy,
   useContext,
   useEffect,
-  useMemo,
   useState,
 } from 'react'
 import {
@@ -13,15 +12,14 @@ import {
   Routes,
   useMatch,
 } from 'react-router-dom'
-import { loadStripe } from '@stripe/stripe-js'
-import { Elements } from '@stripe/react-stripe-js'
 import { Toast } from '@pluralsh/design-system'
 
 import { growthbook } from '../helpers/growthbook'
 import { useHistory } from '../router'
-import PluralConfigurationContext from '../contexts/PluralConfigurationContext'
 import CurrentUserContext from '../contexts/CurrentUserContext'
 import PosthogIdentify from '../utils/posthog'
+
+import { WrapStripe } from './WrapStripe'
 
 const ApplicationLayout = lazy(() => import('./layout/ApplicationLayout'))
 const BreadcrumbProvider = lazy(() => import('./Breadcrumbs'))
@@ -111,40 +109,6 @@ const OIDCProvider = lazy(() => import('./repository/OIDCProvider').then(module 
 //     />
 //   )
 // }
-
-function WrapStripe({ children }: any) {
-  const { stripePublishableKey } = useContext(PluralConfigurationContext)
-
-  const stripePromise = useMemo(() => loadStripe(stripePublishableKey), [stripePublishableKey])
-
-  const options = {
-    appearance: {
-      theme: 'night' as 'none' | 'flat' | 'night' | 'stripe' | undefined,
-      labels: 'floating' as 'floating' | 'above' | undefined,
-      variables: {
-        // colorPrimary: '#747B8B',
-        // colorBackground: '#747B8B',
-        fontSizeBase: '10px',
-        colorText: '#747B8B',
-        // colorDanger: '#df1b41',
-        // fontFamily: 'Ideal Sans, system-ui, sans-serif',
-        // spacingUnit: '2px',
-        // borderRadius: '4px',
-      },
-    },
-  }
-
-  if (!stripePublishableKey) return children
-
-  return (
-    <Elements
-      stripe={stripePromise}
-      options={options}
-    >
-      {children}
-    </Elements>
-  )
-}
 
 // Weird judo to get around inability to match oauth callback
 // routes as subroutes passed from App.js.

--- a/www/src/components/Plural.tsx
+++ b/www/src/components/Plural.tsx
@@ -119,8 +119,8 @@ function WrapStripe({ children }: any) {
 
   const options = {
     appearance: {
-      theme: 'night',
-      labels: 'floating',
+      theme: 'night' as 'none' | 'flat' | 'night' | 'stripe' | undefined,
+      labels: 'floating' as 'floating' | 'above' | undefined,
       variables: {
         // colorPrimary: '#747B8B',
         // colorBackground: '#747B8B',

--- a/www/src/components/WrapStripe.tsx
+++ b/www/src/components/WrapStripe.tsx
@@ -13,8 +13,6 @@ export function WrapStripe({ children }: any) {
   const stripePromise = useMemo(() => loadStripe(stripePublishableKey),
     [stripePublishableKey])
 
-  console.log('theme', theme)
-
   const options = {
     appearance: {
       theme: 'night' as 'none' | 'flat' | 'night' | 'stripe' | undefined,

--- a/www/src/components/WrapStripe.tsx
+++ b/www/src/components/WrapStripe.tsx
@@ -1,0 +1,77 @@
+import { useContext, useMemo } from 'react'
+import { loadStripe } from '@stripe/stripe-js'
+import { Elements } from '@stripe/react-stripe-js'
+import { useTheme } from 'styled-components'
+import { styledTheme } from '@pluralsh/design-system'
+
+import PluralConfigurationContext from '../contexts/PluralConfigurationContext'
+
+export function WrapStripe({ children }: any) {
+  const theme = useTheme() as typeof styledTheme
+  const { stripePublishableKey } = useContext(PluralConfigurationContext)
+
+  const stripePromise = useMemo(() => loadStripe(stripePublishableKey),
+    [stripePublishableKey])
+
+  console.log('theme', theme)
+
+  const options = {
+    appearance: {
+      theme: 'night' as 'none' | 'flat' | 'night' | 'stripe' | undefined,
+      labels: 'above' as 'floating' | 'above' | undefined,
+      variables: {
+        fontFamily: theme.fontFamilies.sans,
+        fontSizeBase: `${theme.partials.text.body2.fontSize}px`,
+        spacingUnit: `${theme.spacing.xxsmall}px`,
+        borderRadius: `${theme.borderRadiuses.medium}px`,
+        colorPrimary: theme.colors['fill-primary'],
+        colorBackground: theme.colors['fill-one'],
+        colorText: theme.colors.text,
+        colorTextPlaceholder: theme.colors['text-xlight'],
+        colorDanger: theme.colors['text-danger'],
+        colorSuccess: theme.colors['text-success'],
+        colorWarning: theme.colors['text-warning'],
+        spacingGridRow: `${theme.spacing.medium}px`,
+        spacingGridColumn: `${theme.spacing.medium}px`,
+        spacingTab: `${theme.spacing.medium}px`,
+      },
+      rules: {
+        '.Label, .Input, .Dropdown': {
+          fontSize: `${theme.partials.text.body2Bold.fontSize}px`,
+          letterSpacing: `${theme.partials.text.body2Bold.letterSpacing}`,
+        },
+        '.Label': {
+          fontWeight: `${theme.partials.text.body2Bold.fontWeight}`,
+          marginBottom: `${theme.spacing.xsmall}px`,
+        },
+        '.Input, .Dropdown': {
+          boxShadow: 'none',
+          borderColor: theme.colors['border-input'],
+        },
+        '.Input:focus': {
+          outline: 'none',
+          boxShadow: 'none',
+          borderColor: theme.colors['border-outline-focused'],
+        },
+        '.Input--invalid': {
+          outline: 'none',
+          boxShadow: 'none',
+          borderColor: theme.colors['border-danger'],
+        },
+      },
+    },
+  }
+
+  if (!stripePublishableKey) {
+    return children
+  }
+
+  return (
+    <Elements
+      stripe={stripePromise}
+      options={options}
+    >
+      {children}
+    </Elements>
+  )
+}

--- a/www/src/components/account/billing/BillingBankCards.tsx
+++ b/www/src/components/account/billing/BillingBankCards.tsx
@@ -5,26 +5,13 @@ import { Div } from 'honorable'
 import BillingBankCardContext from '../../../contexts/BillingBankCardContext'
 
 import useBankCard from './useBankCard'
+import BillingError from './BillingError'
 
 function BillingBankCards() {
   const { card } = useContext(BillingBankCardContext)
   const [edit, setEdit] = useState(false)
 
-  const { error: cardError, renderDisplay, renderEdit } = useBankCard(setEdit, null)
-
-  if (cardError) {
-    return (
-      <Card
-        display="flex"
-        alignItems="center"
-        justifyContent="center"
-        padding="medium"
-        color="text-xlight"
-      >
-        An error occured, please reload the page or contact support (error message: {cardError})
-      </Card>
-    )
-  }
+  const { error: cardError, renderDisplay, renderEdit } = useBankCard({ setEdit })
 
   if (edit) {
     return (
@@ -32,8 +19,20 @@ function BillingBankCards() {
         display="flex"
         flexDirection="column"
         padding="medium"
+        gap="medium"
       >
         {renderEdit()}
+        {cardError && (
+          <Card
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            padding="medium"
+            color="text-xlight"
+          >
+            <BillingError>{cardError}</BillingError>
+          </Card>
+        )}
       </Card>
     )
   }

--- a/www/src/components/account/billing/BillingError.tsx
+++ b/www/src/components/account/billing/BillingError.tsx
@@ -1,13 +1,18 @@
 import { Flex } from 'honorable'
 
-function BillingError() {
+function BillingError({ children }: { children?: ReactNode }) {
   return (
     <Flex
       flexGrow={1}
       align="center"
       justify="center"
+      body2
     >
-      An error occured, please reload the page or contact support.
+      {children ? (
+        <>An error occured: {children}</>
+      ) : (
+        <>An error occured, please relead the page or contact support.</>
+      )}
     </Flex>
   )
 }

--- a/www/src/components/account/billing/BillingError.tsx
+++ b/www/src/components/account/billing/BillingError.tsx
@@ -12,7 +12,7 @@ function BillingError({ children }: { children?: ReactNode }) {
       {children ? (
         <>An error occured: {children}</>
       ) : (
-        <>An error occured, please relead the page or contact support.</>
+        <>An error occured, please reload the page or contact support.</>
       )}
     </Flex>
   )

--- a/www/src/components/account/billing/BillingError.tsx
+++ b/www/src/components/account/billing/BillingError.tsx
@@ -1,4 +1,5 @@
 import { Flex } from 'honorable'
+import { ReactNode } from 'react'
 
 function BillingError({ children }: { children?: ReactNode }) {
   return (

--- a/www/src/components/account/billing/BillingUpgradeToProfessionalModal.tsx
+++ b/www/src/components/account/billing/BillingUpgradeToProfessionalModal.tsx
@@ -26,7 +26,7 @@ type BillingUpgradeToProfessionalModalPropsType = {
 
 function BillingUpgradeToProfessionalModal({
   open,
-  onClose,
+  onClose: onCloseProp,
 }: BillingUpgradeToProfessionalModalPropsType) {
   const { proPlatformPlan, proYearlyPlatformPlan }
     = useContext(PlatformPlansContext)
@@ -53,6 +53,7 @@ function BillingUpgradeToProfessionalModal({
     renderEdit,
     renderDisplay,
     card,
+    resetForm,
   } = useBankCard({ setEdit, noCancel: true })
 
   const onSubmit = useCallback((event: FormEvent) => {
@@ -64,6 +65,10 @@ function BillingUpgradeToProfessionalModal({
     upgradeMutation()
   },
   [card, upgradeMutation])
+  const onClose = useCallback(() => {
+    resetForm()
+    onCloseProp()
+  }, [onCloseProp, resetForm])
 
   const renderContent = useCallback(() => (
     <>
@@ -98,7 +103,16 @@ function BillingUpgradeToProfessionalModal({
         <Flex
           justify="flex-end"
           marginTop="xxlarge"
+          gap="small"
         >
+          <Button
+            secondary
+            onClick={() => {
+              onClose()
+            }}
+          >
+            Cancel
+          </Button>
           <Button
             type="submit"
             loading={loading}
@@ -120,6 +134,7 @@ function BillingUpgradeToProfessionalModal({
     cardError,
     onSubmit,
     loading,
+    onClose,
   ])
 
   const renderSuccess = useCallback(() => (
@@ -148,6 +163,7 @@ function BillingUpgradeToProfessionalModal({
 
     setEdit(false)
   }, [card])
+  console.log('open', open)
 
   return (
     <Modal

--- a/www/src/components/account/billing/BillingUpgradeToProfessionalModal.tsx
+++ b/www/src/components/account/billing/BillingUpgradeToProfessionalModal.tsx
@@ -151,9 +151,6 @@ function BillingUpgradeToProfessionalModal({
         flexDirection="column"
         gap="xlarge"
       >
-        <FormField label="stuff">
-          <Input placeholder="stuff" />
-        </FormField>
         {!card ? renderBillingForm() : null}
         {edit || !card ? renderEdit() : renderDisplay()}
       </Flex>

--- a/www/src/components/account/billing/BillingUpgradeToProfessionalModal.tsx
+++ b/www/src/components/account/billing/BillingUpgradeToProfessionalModal.tsx
@@ -56,7 +56,7 @@ function BillingUpgradeToProfessionalModal({
     resetForm,
   } = useBankCard({ setEdit, noCancel: true })
 
-  const onSubmit = useCallback((event: FormEvent) => {
+  const onClickUpgrade = useCallback((event: FormEvent) => {
     event.preventDefault()
     if (!card) {
       return
@@ -99,29 +99,27 @@ function BillingUpgradeToProfessionalModal({
           <BillingError>{error || cardError}</BillingError>
         </Card>
       )}
-      <form onSubmit={onSubmit}>
-        <Flex
-          justify="flex-end"
-          marginTop="xxlarge"
-          gap="small"
+      <Flex
+        justify="flex-end"
+        marginTop="xxlarge"
+        gap="small"
+      >
+        <Button
+          secondary
+          onClick={() => {
+            onClose()
+          }}
         >
-          <Button
-            secondary
-            onClick={() => {
-              onClose()
-            }}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="submit"
-            loading={loading}
-            disabled={!card}
-          >
-            Upgrade
-          </Button>
-        </Flex>
-      </form>
+          Cancel
+        </Button>
+        <Button
+          loading={loading}
+          disabled={!card}
+          onClick={onClickUpgrade}
+        >
+          Upgrade
+        </Button>
+      </Flex>
     </>
   ),
   [
@@ -132,7 +130,7 @@ function BillingUpgradeToProfessionalModal({
     renderDisplay,
     error,
     cardError,
-    onSubmit,
+    onClickUpgrade,
     loading,
     onClose,
   ])
@@ -163,7 +161,6 @@ function BillingUpgradeToProfessionalModal({
 
     setEdit(false)
   }, [card])
-  console.log('open', open)
 
   return (
     <Modal

--- a/www/src/components/account/billing/useBankCard.tsx
+++ b/www/src/components/account/billing/useBankCard.tsx
@@ -99,18 +99,29 @@ function useBankCard({
 
     const { address } = addressVal.value
 
-    const { error, token } = await stripe.createToken(cardElt, {
-      name: addressVal.name,
-      address_line1: address.line1,
-      address_line2: address.line2,
-      address_city: address.city,
-      address_state: address.state,
-      address_zip: address.zip,
-      address_country: address.country,
-    })
+    let error: Awaited<ReturnType<typeof stripe.createToken>>['error'] | undefined
+    let token: Awaited<ReturnType<typeof stripe.createToken>>['token'] | undefined
 
-    if (error) {
-      setError(error.message!)
+    try {
+      ({ error, token } = await stripe.createToken(cardElt, {
+        name: addressVal.name ?? '',
+        address_line1: address.line1 ?? '',
+        address_line2: address.line2 ?? '',
+        address_city: address.city ?? '',
+        address_state: address.state ?? '',
+        address_zip: address.postal_code ?? '',
+        address_country: address.country ?? '',
+      }))
+    }
+    catch (error) {
+      setError((error as Error)?.message)
+      setLoading(false)
+
+      return
+    }
+
+    if (error || !token) {
+      setError(error?.message || 'Unknown issue with card.')
       setLoading(false)
 
       return

--- a/www/src/components/account/billing/useBankCard.tsx
+++ b/www/src/components/account/billing/useBankCard.tsx
@@ -9,7 +9,12 @@ import {
 import { useMutation } from '@apollo/client'
 import { Button, Card } from '@pluralsh/design-system'
 import { Div, Flex } from 'honorable'
-import { CardElement, useElements, useStripe } from '@stripe/react-stripe-js'
+import {
+  AddressElement,
+  CardElement,
+  useElements,
+  useStripe,
+} from '@stripe/react-stripe-js'
 import { capitalize } from 'lodash'
 
 import BillingBankCardContext from '../../../contexts/BillingBankCardContext'
@@ -99,6 +104,7 @@ function useBankCard(setEdit: Dispatch<SetStateAction<boolean>>, address, noCanc
           marginTop={-10}
           marginBottom={-10}
         >
+          <AddressElement options={{ mode: 'billing' }} />
           <CardElement options={{ style: { base: { color: '#747B8B' } } }} />
         </Flex>
         <Button

--- a/www/src/components/account/billing/useBankCard.tsx
+++ b/www/src/components/account/billing/useBankCard.tsx
@@ -97,14 +97,14 @@ function useBankCard({
       return
     }
 
-    const { address } = addressVal.value
+    const { address, name } = addressVal.value
 
     let error: Awaited<ReturnType<typeof stripe.createToken>>['error'] | undefined
     let token: Awaited<ReturnType<typeof stripe.createToken>>['token'] | undefined
 
     try {
       ({ error, token } = await stripe.createToken(cardElt, {
-        name: addressVal.name ?? '',
+        name: name ?? '',
         address_line1: address.line1 ?? '',
         address_line2: address.line2 ?? '',
         address_city: address.city ?? '',

--- a/www/src/components/account/billing/useBankCard.tsx
+++ b/www/src/components/account/billing/useBankCard.tsx
@@ -105,7 +105,7 @@ function useBankCard(setEdit: Dispatch<SetStateAction<boolean>>, address, noCanc
           marginBottom={-10}
         >
           <AddressElement options={{ mode: 'billing' }} />
-          <CardElement options={{ style: { base: { color: '#747B8B' } } }} />
+          <CardElement options={{ hidePostalCode: true, style: { base: { color: '#747B8B' } } }} />
         </Flex>
         <Button
           type="submit"

--- a/www/src/components/account/billing/useBankCard.tsx
+++ b/www/src/components/account/billing/useBankCard.tsx
@@ -38,9 +38,10 @@ function useBankCard({
   const [cardComplete, setCardComplete] = useState(false)
 
   const theme = useTheme() as typeof styledTheme
-  const { card, refetch } = useContext(BillingBankCardContext)
+  const { card, refetch: refetchBankCard } = useContext(BillingBankCardContext)
 
-  const { billingAddress } = useContext(SubscriptionContext)
+  const { billingAddress, refetch: refetchSubscription }
+    = useContext(SubscriptionContext)
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -99,8 +100,12 @@ function useBankCard({
 
     const { address, name } = addressVal.value
 
-    let error: Awaited<ReturnType<typeof stripe.createToken>>['error'] | undefined
-    let token: Awaited<ReturnType<typeof stripe.createToken>>['token'] | undefined
+    let error:
+        | Awaited<ReturnType<typeof stripe.createToken>>['error']
+        | undefined
+    let token:
+        | Awaited<ReturnType<typeof stripe.createToken>>['token']
+        | undefined
 
     try {
       ({ error, token } = await stripe.createToken(cardElt, {
@@ -142,8 +147,8 @@ function useBankCard({
           },
         },
       })
-
-      refetch()
+      refetchBankCard()
+      refetchSubscription()
       setEdit(false)
     }
     catch (error) {
@@ -152,7 +157,15 @@ function useBankCard({
 
     setLoading(false)
   },
-  [cardComplete, createCard, elements, refetch, setEdit, stripe])
+  [
+    cardComplete,
+    createCard,
+    elements,
+    refetchBankCard,
+    refetchSubscription,
+    setEdit,
+    stripe,
+  ])
 
   const handleDelete = useCallback(async () => {
     if (!card) return
@@ -165,9 +178,10 @@ function useBankCard({
       },
     })
 
-    refetch()
+    refetchBankCard()
+    refetchSubscription()
     setLoading(false)
-  }, [card, deleteCard, refetch])
+  }, [card, deleteCard, refetchBankCard, refetchSubscription])
 
   const defaultAddress = useMemo(() => ({
     name: billingAddress?.name ?? '',
@@ -303,7 +317,7 @@ function useBankCard({
             direction="column"
             body2
           >
-            {billingAddress?.name && <Div>{billingAddress.name}</Div>}
+            {card?.name && <Div>{card.name}</Div>}
             {billingAddress?.line1 && <Div>{billingAddress.line1}</Div>}
             {billingAddress?.line2 && <Div>{billingAddress.line2}</Div>}
             {billingAddress?.city && <Div>{billingAddress.city}</Div>}

--- a/www/src/components/account/billing/useBankCard.tsx
+++ b/www/src/components/account/billing/useBankCard.tsx
@@ -9,12 +9,7 @@ import {
 import { useMutation } from '@apollo/client'
 import { Button, Card } from '@pluralsh/design-system'
 import { Div, Flex } from 'honorable'
-import {
-  AddressElement,
-  CardElement,
-  useElements,
-  useStripe,
-} from '@stripe/react-stripe-js'
+import { CardElement, useElements, useStripe } from '@stripe/react-stripe-js'
 import { capitalize } from 'lodash'
 
 import BillingBankCardContext from '../../../contexts/BillingBankCardContext'
@@ -104,7 +99,6 @@ function useBankCard(setEdit: Dispatch<SetStateAction<boolean>>, address, noCanc
           marginTop={-10}
           marginBottom={-10}
         >
-          <AddressElement options={{ mode: 'billing' }} />
           <CardElement options={{ hidePostalCode: true, style: { base: { color: '#747B8B' } } }} />
         </Flex>
         <Button

--- a/www/src/generated/graphql.ts
+++ b/www/src/generated/graphql.ts
@@ -5043,6 +5043,50 @@ export type InvoiceFragment = { __typename?: 'Invoice', number: string, amountDu
 
 export type CardFragment = { __typename?: 'Card', id: string, last4: string, expMonth: number, expYear: number, name?: string | null, brand: string };
 
+export type SubscriptionQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type SubscriptionQuery = { __typename?: 'RootQueryType', account?: { __typename?: 'Account', billingCustomerId?: string | null, grandfatheredUntil?: Date | null, delinquentAt?: Date | null, userCount?: string | null, clusterCount?: string | null, availableFeatures?: { __typename?: 'PlanFeatures', userManagement?: boolean | null, audit?: boolean | null } | null, subscription?: { __typename?: 'PlatformSubscription', id: string, plan?: { __typename?: 'PlatformPlan', id: string, period: PaymentPeriod, lineItems?: Array<{ __typename?: 'PlatformPlanItem', dimension: LineItemDimension, cost: number } | null> | null } | null } | null, billingAddress?: { __typename?: 'Address', name?: string | null, line1?: string | null, line2?: string | null, zip?: string | null, state?: string | null, city?: string | null, country?: string | null } | null } | null };
+
+export type UpdateAccountBillingMutationVariables = Exact<{
+  attributes: AccountAttributes;
+}>;
+
+
+export type UpdateAccountBillingMutation = { __typename?: 'RootMutationType', updateAccount?: { __typename?: 'Account', id: string } | null };
+
+export type UpgradeToProfessionalPlanMutationVariables = Exact<{
+  planId: Scalars['ID'];
+}>;
+
+
+export type UpgradeToProfessionalPlanMutation = { __typename?: 'RootMutationType', createPlatformSubscription?: { __typename?: 'PlatformSubscription', id: string } | null };
+
+export type DowngradeToFreePlanMutationMutationVariables = Exact<{ [key: string]: never; }>;
+
+
+export type DowngradeToFreePlanMutationMutation = { __typename?: 'RootMutationType', deletePlatformSubscription?: { __typename?: 'Account', id: string } | null };
+
+export type CardsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type CardsQuery = { __typename?: 'RootQueryType', me?: { __typename?: 'User', id: string, cards?: { __typename?: 'CardConnection', edges?: Array<{ __typename?: 'CardEdge', node?: { __typename?: 'Card', id: string, last4: string, expMonth: number, expYear: number, name?: string | null, brand: string } | null } | null> | null } | null } | null };
+
+export type CreateCardMutationVariables = Exact<{
+  source: Scalars['String'];
+  address?: InputMaybe<AddressAttributes>;
+}>;
+
+
+export type CreateCardMutation = { __typename?: 'RootMutationType', createCard?: { __typename?: 'Account', id: string } | null };
+
+export type DeleteCardMutationVariables = Exact<{
+  id: Scalars['ID'];
+}>;
+
+
+export type DeleteCardMutation = { __typename?: 'RootMutationType', deleteCard?: { __typename?: 'Account', id: string } | null };
+
 export type RecipeFragment = { __typename?: 'Recipe', id: string, name: string, description?: string | null, restricted?: boolean | null, provider?: Provider | null, tests?: Array<{ __typename?: 'RecipeTest', type: TestType, name: string, message?: string | null, args?: Array<{ __typename?: 'TestArgument', name: string, repo: string, key: string } | null> | null } | null> | null, repository?: { __typename?: 'Repository', id: string, name: string } | null, oidcSettings?: { __typename?: 'OidcSettings', uriFormat?: string | null, uriFormats?: Array<string | null> | null, authMethod: OidcAuthMethod, domainKey?: string | null, subdomain?: boolean | null } | null, recipeSections?: Array<{ __typename?: 'RecipeSection', index?: number | null, repository?: { __typename?: 'Repository', id: string, name: string, notes?: string | null, description?: string | null, documentation?: string | null, icon?: string | null, darkIcon?: string | null, private?: boolean | null, trending?: boolean | null, verified?: boolean | null, category?: Category | null, installation?: { __typename?: 'Installation', id: string, context?: Map<string, unknown> | null, license?: string | null, licenseKey?: string | null, acmeKeyId?: string | null, acmeSecret?: string | null, autoUpgrade?: boolean | null, trackTag: string, repository?: { __typename?: 'Repository', id: string, name: string, notes?: string | null, description?: string | null, documentation?: string | null, icon?: string | null, darkIcon?: string | null, private?: boolean | null, trending?: boolean | null, verified?: boolean | null, category?: Category | null, oauthSettings?: { __typename?: 'OauthSettings', uriFormat: string, authMethod: OidcAuthMethod } | null, publisher?: { __typename?: 'Publisher', id?: string | null, name: string, phone?: string | null, avatar?: string | null, description?: string | null, backgroundColor?: string | null, owner?: { __typename?: 'User', id: string, name: string, email: string, avatar?: string | null, provider?: Provider | null, demoing?: boolean | null, demoed?: boolean | null, onboarding?: OnboardingState | null, emailConfirmed?: boolean | null, emailConfirmBy?: Date | null, backgroundColor?: string | null, serviceAccount?: boolean | null, onboardingChecklist?: { __typename?: 'OnboardingChecklist', dismissed?: boolean | null, status?: OnboardingChecklistState | null } | null, roles?: { __typename?: 'Roles', admin?: boolean | null } | null } | null, address?: { __typename?: 'Address', line1?: string | null, line2?: string | null, city?: string | null, country?: string | null, state?: string | null, zip?: string | null } | null } | null, recipes?: Array<{ __typename?: 'Recipe', name: string, provider?: Provider | null, description?: string | null } | null> | null } | null, user?: { __typename?: 'User', id: string, name: string, email: string, avatar?: string | null, provider?: Provider | null, demoing?: boolean | null, demoed?: boolean | null, onboarding?: OnboardingState | null, emailConfirmed?: boolean | null, emailConfirmBy?: Date | null, backgroundColor?: string | null, serviceAccount?: boolean | null, onboardingChecklist?: { __typename?: 'OnboardingChecklist', dismissed?: boolean | null, status?: OnboardingChecklistState | null } | null, roles?: { __typename?: 'Roles', admin?: boolean | null } | null } | null, oidcProvider?: { __typename?: 'OidcProvider', id: string, clientId: string, authMethod: OidcAuthMethod, clientSecret: string, redirectUris?: Array<string | null> | null, bindings?: Array<{ __typename?: 'OidcProviderBinding', id: string, user?: { __typename?: 'User', id: string, name: string, email: string, avatar?: string | null, provider?: Provider | null, demoing?: boolean | null, demoed?: boolean | null, onboarding?: OnboardingState | null, emailConfirmed?: boolean | null, emailConfirmBy?: Date | null, backgroundColor?: string | null, serviceAccount?: boolean | null, onboardingChecklist?: { __typename?: 'OnboardingChecklist', dismissed?: boolean | null, status?: OnboardingChecklistState | null } | null, roles?: { __typename?: 'Roles', admin?: boolean | null } | null } | null, group?: { __typename?: 'Group', id: string, name: string, global?: boolean | null, description?: string | null } | null } | null> | null, configuration?: { __typename?: 'OuathConfiguration', issuer?: string | null, authorizationEndpoint?: string | null, tokenEndpoint?: string | null, jwksUri?: string | null, userinfoEndpoint?: string | null } | null } | null } | null, oauthSettings?: { __typename?: 'OauthSettings', uriFormat: string, authMethod: OidcAuthMethod } | null, publisher?: { __typename?: 'Publisher', id?: string | null, name: string, phone?: string | null, avatar?: string | null, description?: string | null, backgroundColor?: string | null, owner?: { __typename?: 'User', id: string, name: string, email: string, avatar?: string | null, provider?: Provider | null, demoing?: boolean | null, demoed?: boolean | null, onboarding?: OnboardingState | null, emailConfirmed?: boolean | null, emailConfirmBy?: Date | null, backgroundColor?: string | null, serviceAccount?: boolean | null, onboardingChecklist?: { __typename?: 'OnboardingChecklist', dismissed?: boolean | null, status?: OnboardingChecklistState | null } | null, roles?: { __typename?: 'Roles', admin?: boolean | null } | null } | null, address?: { __typename?: 'Address', line1?: string | null, line2?: string | null, city?: string | null, country?: string | null, state?: string | null, zip?: string | null } | null } | null, recipes?: Array<{ __typename?: 'Recipe', name: string, provider?: Provider | null, description?: string | null } | null> | null } | null, recipeItems?: Array<{ __typename?: 'RecipeItem', id?: string | null, chart?: { __typename?: 'Chart', id?: string | null, name: string, description?: string | null, latestVersion?: string | null, insertedAt?: Date | null, dependencies?: { __typename?: 'Dependencies', wait?: boolean | null, application?: boolean | null, providers?: Array<Provider | null> | null, secrets?: Array<string | null> | null, providerWirings?: Map<string, unknown> | null, outputs?: Map<string, unknown> | null, dependencies?: Array<{ __typename?: 'Dependency', name?: string | null, repo?: string | null, type?: DependencyType | null, version?: string | null, optional?: boolean | null } | null> | null, wirings?: { __typename?: 'Wirings', terraform?: Map<string, unknown> | null, helm?: Map<string, unknown> | null } | null } | null } | null, terraform?: { __typename?: 'Terraform', id?: string | null, name?: string | null, readme?: string | null, package?: string | null, description?: string | null, latestVersion?: string | null, valuesTemplate?: string | null, insertedAt?: Date | null, dependencies?: { __typename?: 'Dependencies', wait?: boolean | null, application?: boolean | null, providers?: Array<Provider | null> | null, secrets?: Array<string | null> | null, providerWirings?: Map<string, unknown> | null, outputs?: Map<string, unknown> | null, dependencies?: Array<{ __typename?: 'Dependency', name?: string | null, repo?: string | null, type?: DependencyType | null, version?: string | null, optional?: boolean | null } | null> | null, wirings?: { __typename?: 'Wirings', terraform?: Map<string, unknown> | null, helm?: Map<string, unknown> | null } | null } | null } | null, configuration?: Array<{ __typename?: 'RecipeConfiguration', name?: string | null, type?: Datatype | null, default?: string | null, documentation?: string | null, optional?: boolean | null, placeholder?: string | null, functionName?: string | null, condition?: { __typename?: 'RecipeCondition', field: string, operation: Operation, value?: string | null } | null, validation?: { __typename?: 'RecipeValidation', type: ValidationType, regex?: string | null, message: string } | null } | null> | null } | null> | null, configuration?: Array<{ __typename?: 'RecipeConfiguration', name?: string | null, type?: Datatype | null, default?: string | null, documentation?: string | null, optional?: boolean | null, placeholder?: string | null, functionName?: string | null, condition?: { __typename?: 'RecipeCondition', field: string, operation: Operation, value?: string | null } | null, validation?: { __typename?: 'RecipeValidation', type: ValidationType, regex?: string | null, message: string } | null } | null> | null } | null> | null };
 
 export type RecipeItemFragment = { __typename?: 'RecipeItem', id?: string | null, chart?: { __typename?: 'Chart', id?: string | null, name: string, description?: string | null, latestVersion?: string | null, insertedAt?: Date | null, dependencies?: { __typename?: 'Dependencies', wait?: boolean | null, application?: boolean | null, providers?: Array<Provider | null> | null, secrets?: Array<string | null> | null, providerWirings?: Map<string, unknown> | null, outputs?: Map<string, unknown> | null, dependencies?: Array<{ __typename?: 'Dependency', name?: string | null, repo?: string | null, type?: DependencyType | null, version?: string | null, optional?: boolean | null } | null> | null, wirings?: { __typename?: 'Wirings', terraform?: Map<string, unknown> | null, helm?: Map<string, unknown> | null } | null } | null } | null, terraform?: { __typename?: 'Terraform', id?: string | null, name?: string | null, readme?: string | null, package?: string | null, description?: string | null, latestVersion?: string | null, valuesTemplate?: string | null, insertedAt?: Date | null, dependencies?: { __typename?: 'Dependencies', wait?: boolean | null, application?: boolean | null, providers?: Array<Provider | null> | null, secrets?: Array<string | null> | null, providerWirings?: Map<string, unknown> | null, outputs?: Map<string, unknown> | null, dependencies?: Array<{ __typename?: 'Dependency', name?: string | null, repo?: string | null, type?: DependencyType | null, version?: string | null, optional?: boolean | null } | null> | null, wirings?: { __typename?: 'Wirings', terraform?: Map<string, unknown> | null, helm?: Map<string, unknown> | null } | null } | null } | null, configuration?: Array<{ __typename?: 'RecipeConfiguration', name?: string | null, type?: Datatype | null, default?: string | null, documentation?: string | null, optional?: boolean | null, placeholder?: string | null, functionName?: string | null, condition?: { __typename?: 'RecipeCondition', field: string, operation: Operation, value?: string | null } | null, validation?: { __typename?: 'RecipeValidation', type: ValidationType, regex?: string | null, message: string } | null } | null> | null };
@@ -7657,6 +7701,274 @@ export function useInviteLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Inv
 export type InviteQueryHookResult = ReturnType<typeof useInviteQuery>;
 export type InviteLazyQueryHookResult = ReturnType<typeof useInviteLazyQuery>;
 export type InviteQueryResult = Apollo.QueryResult<InviteQuery, InviteQueryVariables>;
+export const SubscriptionDocument = gql`
+    query Subscription {
+  account {
+    billingCustomerId
+    grandfatheredUntil
+    delinquentAt
+    userCount
+    clusterCount
+    availableFeatures {
+      userManagement
+      audit
+    }
+    subscription {
+      id
+      plan {
+        id
+        period
+        lineItems {
+          dimension
+          cost
+        }
+      }
+    }
+    billingAddress {
+      name
+      line1
+      line2
+      zip
+      state
+      city
+      country
+    }
+  }
+}
+    `;
+
+/**
+ * __useSubscriptionQuery__
+ *
+ * To run a query within a React component, call `useSubscriptionQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSubscriptionQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSubscriptionQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useSubscriptionQuery(baseOptions?: Apollo.QueryHookOptions<SubscriptionQuery, SubscriptionQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SubscriptionQuery, SubscriptionQueryVariables>(SubscriptionDocument, options);
+      }
+export function useSubscriptionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SubscriptionQuery, SubscriptionQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SubscriptionQuery, SubscriptionQueryVariables>(SubscriptionDocument, options);
+        }
+export type SubscriptionQueryHookResult = ReturnType<typeof useSubscriptionQuery>;
+export type SubscriptionLazyQueryHookResult = ReturnType<typeof useSubscriptionLazyQuery>;
+export type SubscriptionQueryResult = Apollo.QueryResult<SubscriptionQuery, SubscriptionQueryVariables>;
+export const UpdateAccountBillingDocument = gql`
+    mutation UpdateAccountBilling($attributes: AccountAttributes!) {
+  updateAccount(attributes: $attributes) {
+    id
+  }
+}
+    `;
+export type UpdateAccountBillingMutationFn = Apollo.MutationFunction<UpdateAccountBillingMutation, UpdateAccountBillingMutationVariables>;
+
+/**
+ * __useUpdateAccountBillingMutation__
+ *
+ * To run a mutation, you first call `useUpdateAccountBillingMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateAccountBillingMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateAccountBillingMutation, { data, loading, error }] = useUpdateAccountBillingMutation({
+ *   variables: {
+ *      attributes: // value for 'attributes'
+ *   },
+ * });
+ */
+export function useUpdateAccountBillingMutation(baseOptions?: Apollo.MutationHookOptions<UpdateAccountBillingMutation, UpdateAccountBillingMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateAccountBillingMutation, UpdateAccountBillingMutationVariables>(UpdateAccountBillingDocument, options);
+      }
+export type UpdateAccountBillingMutationHookResult = ReturnType<typeof useUpdateAccountBillingMutation>;
+export type UpdateAccountBillingMutationResult = Apollo.MutationResult<UpdateAccountBillingMutation>;
+export type UpdateAccountBillingMutationOptions = Apollo.BaseMutationOptions<UpdateAccountBillingMutation, UpdateAccountBillingMutationVariables>;
+export const UpgradeToProfessionalPlanDocument = gql`
+    mutation UpgradeToProfessionalPlan($planId: ID!) {
+  createPlatformSubscription(planId: $planId) {
+    id
+  }
+}
+    `;
+export type UpgradeToProfessionalPlanMutationFn = Apollo.MutationFunction<UpgradeToProfessionalPlanMutation, UpgradeToProfessionalPlanMutationVariables>;
+
+/**
+ * __useUpgradeToProfessionalPlanMutation__
+ *
+ * To run a mutation, you first call `useUpgradeToProfessionalPlanMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpgradeToProfessionalPlanMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [upgradeToProfessionalPlanMutation, { data, loading, error }] = useUpgradeToProfessionalPlanMutation({
+ *   variables: {
+ *      planId: // value for 'planId'
+ *   },
+ * });
+ */
+export function useUpgradeToProfessionalPlanMutation(baseOptions?: Apollo.MutationHookOptions<UpgradeToProfessionalPlanMutation, UpgradeToProfessionalPlanMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpgradeToProfessionalPlanMutation, UpgradeToProfessionalPlanMutationVariables>(UpgradeToProfessionalPlanDocument, options);
+      }
+export type UpgradeToProfessionalPlanMutationHookResult = ReturnType<typeof useUpgradeToProfessionalPlanMutation>;
+export type UpgradeToProfessionalPlanMutationResult = Apollo.MutationResult<UpgradeToProfessionalPlanMutation>;
+export type UpgradeToProfessionalPlanMutationOptions = Apollo.BaseMutationOptions<UpgradeToProfessionalPlanMutation, UpgradeToProfessionalPlanMutationVariables>;
+export const DowngradeToFreePlanMutationDocument = gql`
+    mutation DowngradeToFreePlanMutation {
+  deletePlatformSubscription {
+    id
+  }
+}
+    `;
+export type DowngradeToFreePlanMutationMutationFn = Apollo.MutationFunction<DowngradeToFreePlanMutationMutation, DowngradeToFreePlanMutationMutationVariables>;
+
+/**
+ * __useDowngradeToFreePlanMutationMutation__
+ *
+ * To run a mutation, you first call `useDowngradeToFreePlanMutationMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDowngradeToFreePlanMutationMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [downgradeToFreePlanMutationMutation, { data, loading, error }] = useDowngradeToFreePlanMutationMutation({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useDowngradeToFreePlanMutationMutation(baseOptions?: Apollo.MutationHookOptions<DowngradeToFreePlanMutationMutation, DowngradeToFreePlanMutationMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DowngradeToFreePlanMutationMutation, DowngradeToFreePlanMutationMutationVariables>(DowngradeToFreePlanMutationDocument, options);
+      }
+export type DowngradeToFreePlanMutationMutationHookResult = ReturnType<typeof useDowngradeToFreePlanMutationMutation>;
+export type DowngradeToFreePlanMutationMutationResult = Apollo.MutationResult<DowngradeToFreePlanMutationMutation>;
+export type DowngradeToFreePlanMutationMutationOptions = Apollo.BaseMutationOptions<DowngradeToFreePlanMutationMutation, DowngradeToFreePlanMutationMutationVariables>;
+export const CardsDocument = gql`
+    query Cards {
+  me {
+    id
+    cards(first: 100) {
+      edges {
+        node {
+          ...Card
+        }
+      }
+    }
+  }
+}
+    ${CardFragmentDoc}`;
+
+/**
+ * __useCardsQuery__
+ *
+ * To run a query within a React component, call `useCardsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCardsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useCardsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useCardsQuery(baseOptions?: Apollo.QueryHookOptions<CardsQuery, CardsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CardsQuery, CardsQueryVariables>(CardsDocument, options);
+      }
+export function useCardsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CardsQuery, CardsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CardsQuery, CardsQueryVariables>(CardsDocument, options);
+        }
+export type CardsQueryHookResult = ReturnType<typeof useCardsQuery>;
+export type CardsLazyQueryHookResult = ReturnType<typeof useCardsLazyQuery>;
+export type CardsQueryResult = Apollo.QueryResult<CardsQuery, CardsQueryVariables>;
+export const CreateCardDocument = gql`
+    mutation CreateCard($source: String!, $address: AddressAttributes) {
+  createCard(source: $source, address: $address) {
+    id
+  }
+}
+    `;
+export type CreateCardMutationFn = Apollo.MutationFunction<CreateCardMutation, CreateCardMutationVariables>;
+
+/**
+ * __useCreateCardMutation__
+ *
+ * To run a mutation, you first call `useCreateCardMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateCardMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createCardMutation, { data, loading, error }] = useCreateCardMutation({
+ *   variables: {
+ *      source: // value for 'source'
+ *      address: // value for 'address'
+ *   },
+ * });
+ */
+export function useCreateCardMutation(baseOptions?: Apollo.MutationHookOptions<CreateCardMutation, CreateCardMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateCardMutation, CreateCardMutationVariables>(CreateCardDocument, options);
+      }
+export type CreateCardMutationHookResult = ReturnType<typeof useCreateCardMutation>;
+export type CreateCardMutationResult = Apollo.MutationResult<CreateCardMutation>;
+export type CreateCardMutationOptions = Apollo.BaseMutationOptions<CreateCardMutation, CreateCardMutationVariables>;
+export const DeleteCardDocument = gql`
+    mutation DeleteCard($id: ID!) {
+  deleteCard(id: $id) {
+    id
+  }
+}
+    `;
+export type DeleteCardMutationFn = Apollo.MutationFunction<DeleteCardMutation, DeleteCardMutationVariables>;
+
+/**
+ * __useDeleteCardMutation__
+ *
+ * To run a mutation, you first call `useDeleteCardMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteCardMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteCardMutation, { data, loading, error }] = useDeleteCardMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useDeleteCardMutation(baseOptions?: Apollo.MutationHookOptions<DeleteCardMutation, DeleteCardMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteCardMutation, DeleteCardMutationVariables>(DeleteCardDocument, options);
+      }
+export type DeleteCardMutationHookResult = ReturnType<typeof useDeleteCardMutation>;
+export type DeleteCardMutationResult = Apollo.MutationResult<DeleteCardMutation>;
+export type DeleteCardMutationOptions = Apollo.BaseMutationOptions<DeleteCardMutation, DeleteCardMutationVariables>;
 export const GetRecipeDocument = gql`
     query GetRecipe($repo: String, $name: String) {
   recipe(repo: $repo, name: $name) {

--- a/www/src/graph/payments.graphql
+++ b/www/src/graph/payments.graphql
@@ -63,3 +63,80 @@ fragment Card on Card {
   name
   brand
 }
+
+query Subscription {
+  account {
+    billingCustomerId
+    grandfatheredUntil
+    delinquentAt
+    userCount
+    clusterCount
+    availableFeatures {
+      userManagement
+      audit
+    }
+    subscription {
+      id
+      plan {
+        id
+        period
+        lineItems {
+          dimension
+          cost
+        }
+      }
+    }
+    billingAddress {
+      name
+      line1
+      line2
+      zip
+      state
+      city
+      country
+    }
+  }
+}
+
+mutation UpdateAccountBilling($attributes: AccountAttributes!) {
+  updateAccount(attributes: $attributes) {
+    id
+  }
+}
+
+mutation UpgradeToProfessionalPlan($planId: ID!) {
+  createPlatformSubscription(planId: $planId) {
+    id
+  }
+}
+
+mutation DowngradeToFreePlanMutation {
+  deletePlatformSubscription {
+    id
+  }
+}
+
+query Cards {
+  me {
+    id
+    cards(first: 100) {
+      edges {
+        node {
+          ...Card
+        }
+      }
+    }
+  }
+}
+
+mutation CreateCard($source: String!, $address: AddressAttributes) {
+  createCard(source: $source, address: $address) {
+    id
+  }
+}
+
+mutation DeleteCard($id: ID!) {
+  deleteCard(id: $id) {
+    id
+  }
+}

--- a/www/src/helpers/hostname.ts
+++ b/www/src/helpers/hostname.ts
@@ -23,7 +23,7 @@ export function apiHost() {
   const { location: { hostname } } = window
 
   if (hostname === 'localhost' || hostname.endsWith('web.app')) {
-    return 'app.dev.plural.sh'
+    return 'app.plural.sh'
   }
 
   return hostname

--- a/www/src/helpers/hostname.ts
+++ b/www/src/helpers/hostname.ts
@@ -23,7 +23,7 @@ export function apiHost() {
   const { location: { hostname } } = window
 
   if (hostname === 'localhost' || hostname.endsWith('web.app')) {
-    return 'app.plural.sh'
+    return 'app.dev.plural.sh'
   }
 
   return hostname


### PR DESCRIPTION
## Summary
Our address input not doesn't have any form of validation and is completely missing when users want to add a card that isn't in the `Upgrade now` flow. This PR adds the stripe `AddressElement` which changes the fields based on the country a user has selected, has proper validation and can also do things like autocomplete.

The `AddressElement` can be styled by changing using the `appearance` options set on the `Elements` components. The docs for the appearance API can be found [here](https://stripe.com/docs/elements/appearance-api). The docs for getting the information from the AddressElement and further validating the inputs are [here](https://stripe.com/docs/elements/address-element/collect-addresses).

**Please change the hostname in `www/src/helpers/hostname.ts` to `app.dev.plural.sh` for any testing.**


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.