### PR TITLE
Fix key backup delete

### DIFF
--- a/apps/core/lib/core/clients/vault.ex
+++ b/apps/core/lib/core/clients/vault.ex
@@ -5,7 +5,11 @@ defmodule Core.Clients.Vault do
 
   def write(path, value), do: call(:write, [vpath(path), value])
 
-  def delete(path), do: call(:delete, [vpath(path)])
+  def delete(path) do
+    with {:ok, vault} <- client() do
+      Vault.request(vault, :delete, v2_path(vpath(path), "metadata"))
+    end
+  end
 
   def client() do
     Vault.new(
@@ -25,6 +29,11 @@ defmodule Core.Clients.Vault do
   def vpath(path), do: "plural/#{path}"
 
   defp host(), do: Core.conf(:vault)
+
+  defp v2_path(path, prefix) do
+    String.split(path, "/", parts: 2)
+    |> Enum.join("/#{prefix}/")
+  end
 
   defp kube_jwt() do
     Path.join("/var/run/secrets/kubernetes.io/serviceaccount", "token")

--- a/apps/core/test/services/encryption_test.exs
+++ b/apps/core/test/services/encryption_test.exs
@@ -79,9 +79,9 @@ defmodule Core.Services.EncryptionTest do
     test "it will delete by name" do
       backup = insert(:key_backup)
 
-      vpath = "plural#{backup.vault_path}"
+      vpath = "plural/metadata#{backup.vault_path}"
       expect(Vault, :auth, fn _, %{role: "plural", jwt: _} -> {:ok, :vault} end)
-      expect(Vault, :delete, fn :vault, ^vpath -> {:ok, %{}} end)
+      expect(Vault, :request, fn :vault, :delete, ^vpath -> {:ok, %{}} end)
 
       {:ok, del} = Encryption.delete_backup(backup.name, backup.user)
 


### PR DESCRIPTION
## Summary
Calls the vault metadata delete api instead, which i believe deletes all vsns of a key


## Test Plan
unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.