### PR TITLE
fix: Data syncing issue with virtualized lists

### DIFF
--- a/www/src/components/account/DnsRecords.tsx
+++ b/www/src/components/account/DnsRecords.tsx
@@ -108,6 +108,7 @@ export function DnsRecords({ domain, setDomain }: any) {
             placeholder={Placeholder}
             mapper={({ node }, { next }) => (
               <TableRow
+                key={node.id}
                 last={!next.node}
                 suffix={(
                   <DeleteRecord

--- a/www/src/components/account/Domains.tsx
+++ b/www/src/components/account/Domains.tsx
@@ -263,6 +263,7 @@ function DomainsInner({ q, setDomainSelected }: any) {
               placeholder={Placeholder}
               mapper={({ node }, { next }) => (
                 <Domain
+                  key={node.id}
                   node={node}
                   last={!next.node}
                   setDomain={setDomainWrapper}

--- a/www/src/components/account/GroupsList.tsx
+++ b/www/src/components/account/GroupsList.tsx
@@ -33,6 +33,7 @@ export function GroupsList({ q }: any) {
           items={edges}
           mapper={({ node: group }, { prev, next }) => (
             <ListItem
+              key={group.id}
               first={!prev.node}
               last={!next.node}
             >

--- a/www/src/components/account/Invites.tsx
+++ b/www/src/components/account/Invites.tsx
@@ -144,6 +144,7 @@ export function Invites() {
             items={edges}
             mapper={({ node }, { prev, next }) => (
               <ListItem
+                key={node.id}
                 first={!prev.node}
                 last={!next.node}
               >

--- a/www/src/components/account/Roles.tsx
+++ b/www/src/components/account/Roles.tsx
@@ -117,6 +117,7 @@ function RolesInner({ q }: any) {
           items={edges}
           mapper={({ node: role }, { prev, next }) => (
             <ListItem
+              key={role.id}
               first={!prev.node}
               last={!next.node}
             >

--- a/www/src/components/account/ServiceAccounts.tsx
+++ b/www/src/components/account/ServiceAccounts.tsx
@@ -72,6 +72,7 @@ function ServiceAccountsInner({
           items={edges}
           mapper={({ node: user }, { prev, next }) => (
             <ListItem
+              key={user.id}
               first={!prev.node}
               last={!next.node}
             >

--- a/www/src/components/account/UsersList.tsx
+++ b/www/src/components/account/UsersList.tsx
@@ -61,6 +61,7 @@ export function UsersList() {
             items={edges}
             mapper={({ node: user }, { prev, next }) => (
               <ListItem
+                key={user.id}
                 first={!prev.node}
                 last={!next.node}
               >

--- a/www/src/components/profile/AccessTokens.tsx
+++ b/www/src/components/profile/AccessTokens.tsx
@@ -88,7 +88,10 @@ function TokenAudits({ token }: any) {
             loading={loading}
             placeholder={Placeholder}
             mapper={({ node }, { next }) => (
-              <TableRow last={!next.node}>
+              <TableRow
+                key={node.id}
+                last={!next.node}
+              >
                 <TableData>{node.ip}</TableData>
                 <TableData>{formatLocation(node.country, node.city)}</TableData>
                 <TableData>{moment(node.timestamp).format('lll')}</TableData>
@@ -327,6 +330,7 @@ export function AccessTokens() {
               items={edges}
               mapper={({ node }, { next, prev }) => (
                 <AccessToken
+                  key={node.id}
                   token={node}
                   first={!prev.node}
                   last={!next.node}

--- a/www/src/components/profile/PublicKeys.tsx
+++ b/www/src/components/profile/PublicKeys.tsx
@@ -124,6 +124,7 @@ export function PublicKeys() {
               placeholder={Placeholder}
               mapper={({ node }, { prev, next }) => (
                 <PublicKey
+                  key={node.id}
                   pubkey={node}
                   first={isEmpty(prev.node)}
                   last={isEmpty(next.node)}

--- a/www/src/components/repository/packages/helm/PackageUpdateQueue.tsx
+++ b/www/src/components/repository/packages/helm/PackageUpdateQueue.tsx
@@ -56,7 +56,10 @@ export default function PackageUpdateQueue() {
               items={edges}
               loading={loading}
               mapper={({ node }, { next }) => (
-                <TableRow last={!next.node}>
+                <TableRow
+                  key={node.id}
+                  last={!next.node}
+                >
                   <TableData>{node?.version?.version}</TableData>
                   <TableData>
                     <Date date={node?.dequeueAt} />

--- a/www/src/models/user.ts
+++ b/www/src/models/user.ts
@@ -65,6 +65,7 @@ export const TokenFragment = gql`
 
 export const TokenAuditFragment = gql`
   fragment TokenAuditFragment on PersistedTokenAudit {
+    id
     ip
     timestamp
     count


### PR DESCRIPTION
Updated all `mapper` functions in `<StandardScroller>` components to have `key` props set. This fixes issue with component states getting out of sync with the underlying data.