### PR TITLE
Allow admins to impersonate service accounts

### DIFF
--- a/apps/core/lib/core/policies/account.ex
+++ b/apps/core/lib/core/policies/account.ex
@@ -27,6 +27,10 @@ defmodule Core.Policies.Account do
   end
 
   def can?(%User{id: id}, %User{id: id}, :impersonate), do: :pass
+  def can?(%User{account_id: aid, roles: %{admin: true}}, %User{account_id: aid, service_account: true}, :impersonate),
+    do: :pass
+  def can?(%User{account_id: aid, id: id, account: %Account{root_user_id: id}}, %User{account_id: aid, service_account: true}, :impersonate),
+    do: :pass
   def can?(%User{} = user, %User{service_account: true} = sa, :impersonate) do
     with %{impersonation_policy: %{bindings: _} = policy} <- Core.Repo.preload(sa, [impersonation_policy: [:bindings]]),
           :pass <- Core.Services.Rbac.evaluate_policy(user, policy) do

--- a/apps/core/lib/core/schema/cluster.ex
+++ b/apps/core/lib/core/schema/cluster.ex
@@ -44,7 +44,7 @@ defmodule Core.Schema.Cluster do
 
   def for_user(query \\ __MODULE__, user)
 
-  def for_user(query, %User{id: uid, account: %{root_user_id: uid}, account_id: aid} = user),
+  def for_user(query, %User{id: uid, account: %{root_user_id: uid}, account_id: aid}),
     do: for_account(query, aid)
 
   def for_user(query, %User{roles: %{admin: true}, account_id: aid}), do: for_account(query, aid)

--- a/apps/core/lib/core/services/clusters.ex
+++ b/apps/core/lib/core/services/clusters.ex
@@ -166,7 +166,7 @@ defmodule Core.Services.Clusters do
   deletes the cluster reference and flushes associated records
   """
   @spec delete_cluster(binary, binary | atom, User.t | binary) :: cluster_resp
-  def delete_cluster(name, provider, %User{id: user_id} = user) do
+  def delete_cluster(name, provider, %User{id: user_id}) do
     start_transaction()
     |> add_operation(:cluster, fn _ ->
       case get_cluster(user_id, provider, name) do


### PR DESCRIPTION
## Summary
This will be useful for occasional dangling resources (technically still possible since admins have global ability to modify SA impersonation policies)


## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.