### PR TITLE
Make stack/category queries public

### DIFF
--- a/apps/core/lib/core/policies/recipe.ex
+++ b/apps/core/lib/core/policies/recipe.ex
@@ -11,6 +11,8 @@ defmodule Core.Policies.Recipe do
 
   def can?(%User{account_id: aid}, %Stack{account_id: aid}, _), do: :pass
 
+  def can?(_, %Stack{featured: true}, :view), do: :pass
+
   def can?(user, %Ecto.Changeset{} = cs, action),
     do: can?(user, apply_changes(cs), action)
 

--- a/apps/core/lib/core/services/recipes.ex
+++ b/apps/core/lib/core/services/recipes.ex
@@ -36,6 +36,12 @@ defmodule Core.Services.Recipes do
   end
 
   @doc """
+  Determine if an actor can view a stack
+  """
+  @spec accessible(Stack.t, term) :: stack_resp
+  def accessible(%Stack{} = s, user), do: allow(s, user, :view)
+
+  @doc """
   Will persist the given recipe for repository `repository_id`
 
   Fails if the user is not the publisher

--- a/apps/graphql/lib/graphql/schema/recipe.ex
+++ b/apps/graphql/lib/graphql/schema/recipe.ex
@@ -250,7 +250,6 @@ defmodule GraphQl.Schema.Recipe do
     end
 
     field :stack, :stack do
-      middleware Authenticated
       arg :name,     non_null(:string)
       arg :provider, non_null(:provider)
 
@@ -267,7 +266,6 @@ defmodule GraphQl.Schema.Recipe do
     end
 
     connection field :stacks, node_type: :stack do
-      middleware Authenticated
       arg :featured, :boolean
 
       resolve &Recipe.list_stacks/2

--- a/apps/graphql/lib/graphql/schema/repository.ex
+++ b/apps/graphql/lib/graphql/schema/repository.ex
@@ -385,15 +385,11 @@ defmodule GraphQl.Schema.Repository do
     end
 
     field :categories, list_of(:category_info) do
-      middleware Authenticated
-
       resolve &Repository.list_categories/2
     end
 
     field :category, :category_info do
-      middleware Authenticated
       arg :name, non_null(:category)
-
       resolve &Repository.resolve_category/2
     end
 

--- a/apps/graphql/test/queries/repository_queries_test.exs
+++ b/apps/graphql/test/queries/repository_queries_test.exs
@@ -512,6 +512,22 @@ defmodule GraphQl.RepositoryQueriesTest do
       assert by_category["DEVOPS"]["count"] == 2
       assert by_category["DATABASE"]["count"] == 1
     end
+
+    test "it will render categories and repo counts anonymously" do
+      insert_list(2, :repository, category: :devops)
+      insert(:repository, category: :database)
+
+      {:ok, %{data: %{"categories" => cats}}} = run_query("""
+        query {
+          categories { category count }
+        }
+      """, %{})
+
+      by_category = Enum.into(cats, %{}, & {&1["category"], &1})
+
+      assert by_category["DEVOPS"]["count"] == 2
+      assert by_category["DATABASE"]["count"] == 1
+    end
   end
 
   describe "category" do


### PR DESCRIPTION
## Summary
This allows non-authenticated users to query featured stacks and category data.


## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.