### PR TITLE
fix: update k8s tf provider in scaffolds

### DIFF
--- a/apps/core/priv/scaffolds/terraform/providers/aws.eex
+++ b/apps/core/priv/scaffolds/terraform/providers/aws.eex
@@ -12,7 +12,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.5.0"
+      version = "~> 2.20.0"
     }
   }
 }

--- a/apps/core/priv/scaffolds/terraform/providers/azure.eex
+++ b/apps/core/priv/scaffolds/terraform/providers/azure.eex
@@ -13,7 +13,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.5.0"
+      version = "~> 2.20.0"
     }
   }
 }

--- a/apps/core/priv/scaffolds/terraform/providers/equinix.eex
+++ b/apps/core/priv/scaffolds/terraform/providers/equinix.eex
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.7.1"
+      version = "~> 2.20.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/apps/core/priv/scaffolds/terraform/providers/gcp.eex
+++ b/apps/core/priv/scaffolds/terraform/providers/gcp.eex
@@ -11,7 +11,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.5.0"
+      version = "~> 2.20.0"
     }
   }
 }

--- a/apps/core/priv/scaffolds/terraform/providers/generic.eex
+++ b/apps/core/priv/scaffolds/terraform/providers/generic.eex
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.16.1"
+      version = "~> 2.20.0"
     }
   }
 }

--- a/apps/core/priv/scaffolds/terraform/providers/kind.eex
+++ b/apps/core/priv/scaffolds/terraform/providers/kind.eex
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.8.0"
+      version = "~> 2.20.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR updates the Kubernetes terraform providers for all our cloud providers. This is needed to solve issues with people deploying new applications on K8s 1.24.


## Test Plan
Manually update the TF provider and check that nothing breaks and it solves the K8s service account creation on 1.24.


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.