### PR TITLE
Add groups to invites

### DIFF
--- a/apps/core/lib/core/schema/invite.ex
+++ b/apps/core/lib/core/schema/invite.ex
@@ -1,6 +1,6 @@
 defmodule Core.Schema.Invite do
   use Piazza.Ecto.Schema
-  alias Core.Schema.{Account, User}
+  alias Core.Schema.{Account, User, InviteGroup}
 
   @email_re ~r/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9-\.]+\.[a-zA-Z]{2,}$/
 
@@ -10,6 +10,9 @@ defmodule Core.Schema.Invite do
 
     belongs_to :user,    User
     belongs_to :account, Account
+
+    has_many :invite_groups, InviteGroup, on_replace: :delete
+    has_many :groups, through: [:invite_groups, :group]
 
     timestamps()
   end
@@ -28,6 +31,7 @@ defmodule Core.Schema.Invite do
   def changeset(model, attrs \\ %{}) do
     model
     |> cast(attrs, @valid)
+    |> cast_assoc(:invite_groups)
     |> put_new_change(:secure_id, &gen_external_id/0)
     |> foreign_key_constraint(:account_id)
     |> unique_constraint(:secure_id)

--- a/apps/core/lib/core/schema/invite_group.ex
+++ b/apps/core/lib/core/schema/invite_group.ex
@@ -1,0 +1,22 @@
+defmodule Core.Schema.InviteGroup do
+  use Piazza.Ecto.Schema
+  alias Core.Schema.{Invite, Group}
+
+  schema "invite_groups" do
+    belongs_to :invite, Invite
+    belongs_to :group, Group
+
+    timestamps()
+  end
+
+  @valid ~w(group_id invite_id)a
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, @valid)
+    |> foreign_key_constraint(:group_id)
+    |> foreign_key_constraint(:invite_id)
+    |> unique_constraint(:invite_id, name: index_name(:invite_groups, [:invite_id, :user_id]))
+    |> validate_required([:group_id])
+  end
+end

--- a/apps/core/priv/repo/migrations/20230516192249_add_invite_groups.exs
+++ b/apps/core/priv/repo/migrations/20230516192249_add_invite_groups.exs
@@ -1,0 +1,17 @@
+defmodule Core.Repo.Migrations.AddInviteGroups do
+  use Ecto.Migration
+
+  def change do
+    create table(:invite_groups, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :invite_id, references(:invites, type: :uuid, on_delete: :delete_all)
+      add :group_id, references(:groups, type: :uuid, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+
+    create unique_index(:invite_groups, [:invite_id, :group_id])
+    create index(:invite_groups, [:invite_id])
+  end
+end

--- a/apps/core/test/support/test_helpers.ex
+++ b/apps/core/test/support/test_helpers.ex
@@ -1,4 +1,6 @@
 defmodule Core.TestHelpers do
+  alias Core.Schema.{User, Group, GroupMember}
+
   def ids_equal(found, expected) do
     found = MapSet.new(ids(found))
     expected = MapSet.new(ids(expected))
@@ -26,6 +28,9 @@ defmodule Core.TestHelpers do
   def id(id) when is_binary(id), do: id
 
   def refetch(%{__struct__: schema, id: id}), do: Core.Repo.get(schema, id)
+
+  def member?(%User{id: uid}, %Group{id: gid}),
+    do: Core.Repo.get_by(GroupMember, user_id: uid, group_id: gid)
 
   def update_record(struct, attrs) do
     Ecto.Changeset.change(struct, attrs)

--- a/apps/graphql/lib/graphql/schema/account.ex
+++ b/apps/graphql/lib/graphql/schema/account.ex
@@ -22,6 +22,7 @@ defmodule GraphQl.Schema.Account do
 
   input_object :invite_attributes do
     field :email, :string
+    field :invite_groups, list_of(:binding_attributes)
   end
 
   input_object :group_attributes do
@@ -139,6 +140,7 @@ defmodule GraphQl.Schema.Account do
 
     field :account, :account, resolve: dataloader(Account)
     field :user,    :user, resolve: dataloader(User)
+    field :groups,  list_of(:group), resolve: dataloader(Account)
 
     timestamps()
   end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -630,6 +630,7 @@ input FileAttributes {
 
 input InviteAttributes {
   email: String
+  inviteGroups: [BindingAttributes]
 }
 
 input ServiceAccountAttributes {
@@ -1170,6 +1171,7 @@ type Invite {
   expiresAt: DateTime
   account: Account
   user: User
+  groups: [Group]
   insertedAt: DateTime
   updatedAt: DateTime
 }

--- a/www/src/generated/graphql.ts
+++ b/www/src/generated/graphql.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+/* prettier-ignore */
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
@@ -1357,6 +1358,7 @@ export type Invite = {
   email?: Maybe<Scalars['String']>;
   existing: Scalars['Boolean'];
   expiresAt?: Maybe<Scalars['DateTime']>;
+  groups?: Maybe<Array<Maybe<Group>>>;
   id: Scalars['ID'];
   insertedAt?: Maybe<Scalars['DateTime']>;
   secureId?: Maybe<Scalars['String']>;
@@ -1366,6 +1368,7 @@ export type Invite = {
 
 export type InviteAttributes = {
   email?: InputMaybe<Scalars['String']>;
+  inviteGroups?: InputMaybe<Array<InputMaybe<BindingAttributes>>>;
 };
 
 export type InviteConnection = {


### PR DESCRIPTION
## Summary
This will allow users to automatically be added to relevant groups at invite time and simplify user provisioning a good bit.


## Test Plan
unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.