### PR TITLE
Handle dangling dns records on demo project delete

### DIFF
--- a/apps/core/lib/core.ex
+++ b/apps/core/lib/core.ex
@@ -65,7 +65,7 @@ defmodule Core do
   end
 
   def retry(fun, attempts \\ 0)
-  def retry(fun, 3), do: fun.()
+  def retry(fun, 4), do: fun.()
   def retry(fun, attempts) do
     case fun.() do
       :ok -> :ok


### PR DESCRIPTION
## Summary

If a demo project fails to delete downstream, dns records can dangle and potentially break the rest of the cleanup process.


## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.