### PR TITLE
feat: Hide installer steps for already installed apps

### DIFF
--- a/www/src/components/shell/terminal/sidebar/Sidebar.tsx
+++ b/www/src/components/shell/terminal/sidebar/Sidebar.tsx
@@ -251,4 +251,4 @@ function SidebarUnstyled({ refetch, ...props }) {
   )
 }
 
-export { Sidebar }
+export { Sidebar, useSelectCluster }

--- a/www/src/components/shell/terminal/sidebar/installed/Installed.tsx
+++ b/www/src/components/shell/terminal/sidebar/installed/Installed.tsx
@@ -1,7 +1,9 @@
-import styled from 'styled-components'
-import { AppList, AppProps, LoopingLogo } from '@pluralsh/design-system/dist'
-import { useContext, useMemo } from 'react'
 import { useQuery } from '@apollo/client'
+import { AppList, AppProps } from '@pluralsh/design-system/dist'
+import { useContext, useMemo } from 'react'
+import styled from 'styled-components'
+
+import LoadingIndicator from '../../../../utils/LoadingIndicator'
 
 import { TerminalContext } from '../../context/terminal'
 import { FULL_APPLICATIONS_QUERY } from '../installer/queries'
@@ -20,7 +22,6 @@ const Installed = styled(InstalledUnstyled)(({ theme }) => ({
 
   '&#loader': {
     display: 'flex',
-    flexGrow: 0,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -77,7 +78,7 @@ function InstalledUnstyled({ ...props }): JSX.Element {
         id="loader"
         {...props}
       >
-        <LoopingLogo />
+        <LoadingIndicator />
       </div>
     )
   }

--- a/www/src/components/shell/terminal/sidebar/installer/helpers.tsx
+++ b/www/src/components/shell/terminal/sidebar/installer/helpers.tsx
@@ -92,7 +92,8 @@ const toDependencySteps = (
 const buildSteps = async (
   client: ApolloClient<unknown>,
   provider: Provider,
-  selectedApplications: Array<WizardStepConfig>
+  selectedApplications: Array<WizardStepConfig>,
+  installedApplications: Set<string>
 ) => {
   const dependencyMap = new Map<
     string,
@@ -117,9 +118,13 @@ const buildSteps = async (
       variables: { id: recipeBase?.id },
     })
 
-    const sections = recipe.recipe.recipeSections!.filter(
-      (section) => section!.repository!.name !== app.label
-    )
+    const sections = recipe.recipe
+      .recipeSections!.filter(
+        (section) => section!.repository!.name !== app.label
+      )
+      .filter(
+        (section) => !installedApplications.has(section!.repository!.name)
+      )
 
     sections.forEach((section) => {
       if (


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
When building dependency steps already installed apps will not be visible.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally.

Tested with demo setup after installing console. Installed `airbyte`, `calendso` and couple of other apps. `context.yaml` was merged correctly and apps were installed successfully also.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.