### PR TITLE
fix: Make Roadmap search inputs maintain full height

### DIFF
--- a/www/src/components/roadmap/RoadmapFeedback.tsx
+++ b/www/src/components/roadmap/RoadmapFeedback.tsx
@@ -8,19 +8,22 @@ function RoadmapFeedback() {
       <P
         body2
         color="text-xlight"
+        marginBottom="small"
       >
         Hearing your feedback is important to us and helps shape our roadmap and
         make our product better.
       </P>
-      <A
-        inline
-        display="block"
-        target="_blank"
-        rel="noopener noreferrer"
-        href="https://discord.gg/pluralsh"
-      >
-        Give us feedback on discord.
-      </A>
+      <P>
+        <A
+          inline
+          display="block"
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://discord.gg/pluralsh"
+        >
+          Give us feedback on discord.
+        </A>
+      </P>
     </ScrollablePage>
   )
 }

--- a/www/src/components/roadmap/RoadmapSearchBox.tsx
+++ b/www/src/components/roadmap/RoadmapSearchBox.tsx
@@ -150,6 +150,7 @@ function RoadmapSearchBox({
           onChange={e => setSearch(e.target.value)}
           borderBottomLeftRadius={0}
           borderBottomRightRadius={0}
+          flexShrink={0}
         />
         <Flex
           direction="column"


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
Fixes issue with squished search inputs on Roadmap pages.
![image](https://github.com/pluralsh/plural/assets/85062/6c9538fb-06be-4dc9-a0bb-28b33b63be5a)

<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.