### PR TITLE
fix: Repo page broken when no recipes are provided

### DIFF
--- a/www/src/components/utils/InstallAppButton.tsx
+++ b/www/src/components/utils/InstallAppButton.tsx
@@ -160,9 +160,9 @@ function InstallAppButton({
       ),
     [clusters, userId]
   )
-  const { name, apps } = props
+  const { name, apps, recipes } = props
 
-  if (!name) {
+  if (!name || isEmpty(recipes)) {
     return null
   }
 

--- a/www/src/components/utils/recipeHelpers.tsx
+++ b/www/src/components/utils/recipeHelpers.tsx
@@ -1,6 +1,7 @@
 import { Sidecar } from '@pluralsh/design-system'
 import { A } from 'honorable'
 import { ReactNode, useState } from 'react'
+import isEmpty from 'lodash/isEmpty'
 
 import { Provider, Recipe } from '../../generated/graphql'
 
@@ -81,17 +82,21 @@ export function ProvidersSidecar({
 }: {
   type: RecipeType
   name: string
-  recipes?: RecipeSubset[]
+  recipes?: (RecipeSubset | null | undefined)[]
 }) {
   const [expanded, setExpanded] = useState(false)
 
-  if (!recipes) {
+  let filteredRecipes = recipes?.filter(
+    (r: RecipeSubset | null | undefined): r is RecipeSubset => !!r
+  )
+
+  if (!filteredRecipes || isEmpty(filteredRecipes)) {
     return null
   }
-  const showViewMore = recipes.length > MAX_RECIPES && !expanded
+  const showViewMore = filteredRecipes.length > MAX_RECIPES && !expanded
 
   if (showViewMore) {
-    recipes = recipes.slice(0, MAX_RECIPES - 1)
+    filteredRecipes = filteredRecipes.slice(0, MAX_RECIPES - 1)
   }
 
   return (
@@ -101,20 +106,14 @@ export function ProvidersSidecar({
       flexDirection="column"
       gap="xxsmall"
     >
-      {recipes?.map((recipe, i) => {
-        if (!recipe) {
-          return null
-        }
-
-        return (
-          <InstallCommandCopyButton
-            name={name}
-            type={type}
-            key={recipe?.name ?? i}
-            recipe={recipe}
-          />
-        )
-      })}
+      {filteredRecipes?.map((recipe, i) => (
+        <InstallCommandCopyButton
+          name={name}
+          type={type}
+          key={recipe?.name ?? i}
+          recipe={recipe}
+        />
+      ))}
       {showViewMore && (
         <A
           inline


### PR DESCRIPTION
Repo pages would show infinte load screen if the repo didn’t have any recipes. This fixes it. Problem can be seen at https://app.plural.sh/repository/grafana-tempo