### PR TITLE
Allow nested repo names in image dep introspection

### DIFF
--- a/apps/core/lib/core/services/charts.ex
+++ b/apps/core/lib/core/services/charts.ex
@@ -224,7 +224,7 @@ defmodule Core.Services.Charts do
       |> Enum.map(&String.trim_leading(&1, dkr_dns <> "/"))
       |> Enum.map(fn registry ->
         with [repo, repository] <- String.split(registry, "/"),
-             [repository, tag] <- String.split(repository, ":") do
+             [repository, tag] <- Enum.join(repository, "/") |> String.split(":") do
           Repositories.get_dkr_image(repo, repository, tag)
         else
           _ -> nil


### PR DESCRIPTION
## Summary

The logic for finding image deps only supported repos like `dkr.plural.sh/<repo>/<image>:<tag>`.  This makes it support images with repo names including nested `/` chars

## Test Plan
existing test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.