### PR TITLE
Add begin trial api

### DIFF
--- a/apps/core/lib/core/schema/account.ex
+++ b/apps/core/lib/core/schema/account.ex
@@ -16,6 +16,7 @@ defmodule Core.Schema.Account do
     field :usage_updated,        :boolean
     field :sa_provisioned,       :boolean
     field :address_updated,      :boolean, virtual: true
+    field :trialed,              :boolean
 
     embeds_one :billing_address, Address, on_replace: :update
 
@@ -50,7 +51,7 @@ defmodule Core.Schema.Account do
     )
   end
 
-  @valid ~w(name workos_connection_id sa_provisioned)a
+  @valid ~w(name workos_connection_id sa_provisioned trialed)a
   @payment ~w(billing_customer_id delinquent_at)a
 
   def changeset(model, attrs \\ %{}) do

--- a/apps/core/lib/core/schema/cluster_dependency.ex
+++ b/apps/core/lib/core/schema/cluster_dependency.ex
@@ -13,6 +13,14 @@ defmodule Core.Schema.ClusterDependency do
     from(d in query, where: d.cluster_id == ^id)
   end
 
+  def for_account(query \\ __MODULE__, aid) do
+    from(d in query,
+      join: c in assoc(d, :cluster),
+      join: u in assoc(c, :owner),
+      where: u.account_id == ^aid
+    )
+  end
+
   def waterline(query \\ __MODULE__, user_id) do
     from(cd in query,
       join: c in assoc(cd, :cluster),

--- a/apps/core/lib/core/schema/platform_subscription.ex
+++ b/apps/core/lib/core/schema/platform_subscription.ex
@@ -46,6 +46,10 @@ defmodule Core.Schema.PlatformSubscription do
     )
   end
 
+  def ordered(query \\ __MODULE__, order \\ [asc: :id]) do
+    from(s in query, order_by: ^order)
+  end
+
   def dimension(%__MODULE__{line_items: items}, dim) do
     case Enum.find(items, & &1.dimension == dim) do
       %{quantity: quantity} -> quantity

--- a/apps/core/lib/core/schema/user.ex
+++ b/apps/core/lib/core/schema/user.ex
@@ -163,6 +163,10 @@ defmodule Core.Schema.User do
     from(u in query, where: is_nil(u.account_id))
   end
 
+  def with_waterline(query \\ __MODULE__) do
+    from(u in query, where: not is_nil(u.upgrade_to))
+  end
+
   def for_incident(query \\ __MODULE__, %Incident{creator: %{account_id: id1}, owner: %{account_id: id2}}) do
     from(u in query, where: u.account_id in ^[id1, id2])
   end

--- a/apps/core/priv/repo/migrations/20230627145817_add_trialed.exs
+++ b/apps/core/priv/repo/migrations/20230627145817_add_trialed.exs
@@ -1,0 +1,9 @@
+defmodule Core.Repo.Migrations.AddTrialed do
+  use Ecto.Migration
+
+  def change do
+    alter table(:accounts) do
+      add :trialed, :boolean
+    end
+  end
+end

--- a/apps/core/test/support/factory.ex
+++ b/apps/core/test/support/factory.ex
@@ -642,5 +642,7 @@ defmodule Core.Factory do
     sa
   end
 
+  def trial_plan(), do: insert(:platform_plan, name: "Pro Trial")
+
   def admin_user(%Schema.Account{} = account), do: insert(:user, account: account, roles: %{admin: true})
 end

--- a/apps/cron/test/cron/prune/trials_test.exs
+++ b/apps/cron/test/cron/prune/trials_test.exs
@@ -8,7 +8,7 @@ defmodule Cron.Prune.TrialsTest do
       old = insert_list(3, :platform_subscription, plan: trial_plan, inserted_at: Timex.now() |> Timex.shift(months: -5))
       insert(:platform_subscription)
 
-      {3, _} = Trials.run()
+      :ok = Trials.run()
 
       for s <- old,
         do: refute refetch(s)

--- a/apps/graphql/lib/graphql/resolvers/payments.ex
+++ b/apps/graphql/lib/graphql/resolvers/payments.ex
@@ -116,6 +116,9 @@ defmodule GraphQl.Resolvers.Payments do
   def cancel_platform_subscription(_, %{context: %{current_user: user}}),
     do: Payments.cancel_platform_subscription(user)
 
+  def begin_trial(_, %{context: %{current_user: user}}),
+    do: Payments.begin_trial(user)
+
   def default_payment_method(%{id: id}, %{context: %{current_user: user}}) do
     with {:ok, _} <- Payments.default_payment_method(user, id),
       do: {:ok, true}

--- a/apps/graphql/lib/graphql/schema/payments.ex
+++ b/apps/graphql/lib/graphql/schema/payments.ex
@@ -384,6 +384,12 @@ defmodule GraphQl.Schema.Payments do
       safe_resolve &Payments.create_platform_subscription/2
     end
 
+    field :begin_trial, :platform_subscription do
+      middleware Authenticated
+
+      safe_resolve &Payments.begin_trial/2
+    end
+
     field :delete_platform_subscription, :account do
       middleware Authenticated
 

--- a/apps/graphql/test/mutations/payments_mutation_test.exs
+++ b/apps/graphql/test/mutations/payments_mutation_test.exs
@@ -397,6 +397,24 @@ defmodule GraphQl.PaymentsMutationsTest do
     end
   end
 
+  describe "beginTrial" do
+    setup [:setup_root_user]
+    test "it can set up a new trial", %{user: user} do
+      trial = trial_plan()
+
+      {:ok, %{data: %{"beginTrial" => sub}}} = run_query("""
+        mutation {
+          beginTrial {
+            id
+            plan { id }
+          }
+        }
+      """, %{}, %{current_user: user})
+
+      assert sub["plan"]["id"] == trial.id
+    end
+  end
+
   describe "defaultPaymentMethod" do
     test "it will set the default payment method for an account" do
       account = insert(:account, billing_customer_id: "cus_id", user_count: 2, cluster_count: 0)

--- a/config/config.exs
+++ b/config/config.exs
@@ -139,7 +139,8 @@ config :core,
   openai_token: "openai",
   stripe_webhook_secret: "bogus",
   github_demo_token: "test-pat",
-  github_demo_org: "pluralsh-demos"
+  github_demo_org: "pluralsh-demos",
+  trial_plan: "Pro Trial"
 
 config :briefly,
   directory: [{:system, "TMPDIR"}, {:system, "TMP"}, {:system, "TEMP"}, "/tmp"],

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1734,6 +1734,8 @@ type RootMutationType {
 
   createPlatformSubscription(planId: ID!, billingAddress: AddressAttributes, paymentMethod: String): PlatformSubscription
 
+  beginTrial: PlatformSubscription
+
   deletePlatformSubscription: Account
 
   cancelPlatformSubscription: PlatformSubscription

--- a/www/src/components/shell/terminal/NextSteps.tsx
+++ b/www/src/components/shell/terminal/NextSteps.tsx
@@ -10,7 +10,6 @@ import {
 } from '@pluralsh/design-system'
 import { Flex, P, Span } from 'honorable'
 import { cloneElement, useContext, useEffect, useState } from 'react'
-import Fireworks from '@fireworks-js/react'
 
 import useOnboarded from '../hooks/useOnboarded'
 
@@ -47,159 +46,138 @@ function NextStepsModal() {
   )
 
   return (
-    <>
-      {open && (
-        <Fireworks
-          options={{}}
-          style={{
-            top: 0,
-            left: 0,
-            width: '100vw',
-            height: '100vh',
-            position: 'fixed',
-            background: 'transparent',
-            zIndex: 999,
-          }}
-        />
-      )}
-
-      <Modal
-        size="large"
-        open={open}
-        style={{ padding: 0 }}
-        onClose={() => setOpen(false)}
+    <Modal
+      size="large"
+      open={open}
+      style={{ padding: 0 }}
+      onClose={() => setOpen(false)}
+    >
+      <Flex
+        direction="column"
+        gap="large"
       >
         <Flex
-          direction="column"
-          gap="large"
+          justify="space-between"
+          align="center"
         >
-          <Flex
-            justify="space-between"
-            align="center"
+          <Span
+            color="text-xlight"
+            body2
           >
-            <Span
-              color="text-xlight"
-              body2
-            >
-              NEXT STEPS
-            </Span>
-            <IconFrame
-              clickable
-              onClick={() => setOpen(false)}
-              icon={<CloseIcon color="icon-light" />}
+            NEXT STEPS
+          </Span>
+          <IconFrame
+            clickable
+            onClick={() => setOpen(false)}
+            icon={<CloseIcon color="icon-light" />}
+          />
+        </Flex>
+        <Flex
+          gap="medium"
+          direction="column"
+        >
+          <Span body1>
+            Congratulations! You’ve started your first deployment.
+          </Span>
+          <Span body1>
+            It may take up to thirty minutes for your Plural Console and
+            applications to be fully up and running.
+          </Span>
+        </Flex>
+        <Flex
+          justify="space-between"
+          align="center"
+        >
+          <Span
+            body2
+            fontWeight={600}
+          >
+            How was your experience?
+          </Span>
+          <Flex>
+            <HoveredIcon
+              data-phid="feedback-negative"
+              size="small"
+              icon={
+                feedback === 'bad' ? (
+                  <ThumbsUpFilledIcon transform="scale(1, -1)" />
+                ) : (
+                  <ThumbsUpIcon transform="scale(1, -1)" />
+                )
+              }
+              color={feedback === 'bad' ? 'icon-danger' : 'icon-light'}
+              hoveredColor="icon-danger"
+              textValue="Bad"
+              onClick={() => setFeedback('bad')}
+            />
+            <HoveredIcon
+              data-phid="feedback-positive"
+              size="small"
+              icon={
+                feedback === 'good' ? <ThumbsUpFilledIcon /> : <ThumbsUpIcon />
+              }
+              color={feedback === 'good' ? 'icon-success' : 'icon-light'}
+              hoveredColor="icon-success"
+              textValue="Good"
+              onClick={() => setFeedback('good')}
             />
           </Flex>
-          <Flex
-            gap="medium"
-            direction="column"
-          >
-            <Span body1>
-              Congratulations! You’ve started your first deployment.
-            </Span>
-            <Span body1>
-              It may take up to thirty minutes for your Plural Console and
-              applications to be fully up and running.
-            </Span>
-          </Flex>
-          <Flex
-            justify="space-between"
-            align="center"
-          >
-            <Span
-              body2
-              fontWeight={600}
-            >
-              How was your experience?
-            </Span>
-            <Flex>
-              <HoveredIcon
-                data-phid="feedback-negative"
-                size="small"
-                icon={
-                  feedback === 'bad' ? (
-                    <ThumbsUpFilledIcon transform="scale(1, -1)" />
-                  ) : (
-                    <ThumbsUpIcon transform="scale(1, -1)" />
-                  )
-                }
-                color={feedback === 'bad' ? 'icon-danger' : 'icon-light'}
-                hoveredColor="icon-danger"
-                textValue="Bad"
-                onClick={() => setFeedback('bad')}
-              />
-              <HoveredIcon
-                data-phid="feedback-positive"
-                size="small"
-                icon={
-                  feedback === 'good' ? (
-                    <ThumbsUpFilledIcon />
-                  ) : (
-                    <ThumbsUpIcon />
-                  )
-                }
-                color={feedback === 'good' ? 'icon-success' : 'icon-light'}
-                hoveredColor="icon-success"
-                textValue="Good"
-                onClick={() => setFeedback('good')}
-              />
-            </Flex>
-          </Flex>
         </Flex>
+      </Flex>
 
-        {feedback === 'good' && (
-          <Flex
-            align="center"
-            justify="space-between"
-            marginTop="medium"
+      {feedback === 'good' && (
+        <Flex
+          align="center"
+          justify="space-between"
+          marginTop="medium"
+        >
+          <P
+            body2
+            color="text-light"
           >
-            <P
-              body2
-              color="text-light"
-            >
-              Great! Support our project with a star.
-            </P>
-            <Button
-              data-phid="feedback-positive-github"
-              secondary
-              small
-              startIcon={<StarIcon />}
-              as="a"
-              href="https://github.com/pluralsh/plural"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              GitHub
-            </Button>
-          </Flex>
-        )}
-        {feedback === 'bad' && (
-          <Flex
-            align="center"
-            justify="space-between"
-            marginTop="medium"
+            Great! Support our project with a star.
+          </P>
+          <Button
+            data-phid="feedback-positive-github"
+            secondary
+            small
+            startIcon={<StarIcon />}
+            as="a"
+            href="https://github.com/pluralsh/plural"
+            target="_blank"
+            rel="noopener noreferrer"
           >
-            <P
-              body2
-              color="text-light"
-            >
-              We're here to help. Ping us on Discord.
-            </P>
-            <Button
-              data-phid="feedback-negative-discord"
-              secondary
-              small
-              startIcon={<DiscordIcon />}
-              as="a"
-              href="https://discord.gg/pluralsh"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Discord
-            </Button>
-          </Flex>
-        )}
-      </Modal>
-    </>
+            GitHub
+          </Button>
+        </Flex>
+      )}
+      {feedback === 'bad' && (
+        <Flex
+          align="center"
+          justify="space-between"
+          marginTop="medium"
+        >
+          <P
+            body2
+            color="text-light"
+          >
+            We're here to help. Ping us on Discord.
+          </P>
+          <Button
+            data-phid="feedback-negative-discord"
+            secondary
+            small
+            startIcon={<DiscordIcon />}
+            as="a"
+            href="https://discord.gg/pluralsh"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Discord
+          </Button>
+        </Flex>
+      )}
+    </Modal>
   )
 }
 

--- a/www/src/components/shell/terminal/sidebar/installed/helpers.tsx
+++ b/www/src/components/shell/terminal/sidebar/installed/helpers.tsx
@@ -108,15 +108,19 @@ function Status({ app }) {
   )
 }
 
+const appLink = (app) =>
+  app?.spec?.links?.length > 0 ? app.spec?.links[0].url : null
+
 const toAppProps = (
   { node: repository }: RepositoryEdge,
   appInfo: any,
   onAction: Dispatch<string>
 ): AppProps => {
   const app = appInfo[repository!.name]
-  const domain = app?.spec?.links?.length > 0 ? app.spec?.links[0].url : null
+  const domain = appLink(app)
   const isAlive = !!repository!.installation?.pingedAt
   const promoted = PROMOTED_APPS.includes(repository!.name)
+  const consoleUrl = appLink(appInfo.console)
 
   return {
     isAlive,
@@ -133,12 +137,13 @@ const toAppProps = (
         name={repository!.name}
       />
     ) : undefined,
-    actions: toActions(repository!, onAction),
+    actions: toActions(repository!, consoleUrl, onAction),
   }
 }
 
 const toActions = (
   repository: Repository,
+  consoleUrl: string | null,
   onAction: Dispatch<string>
 ): Array<AppMenuAction> => {
   const rebuildCommand = `plural build --only ${repository.name} && plural deploy --from ${repository.name} --commit "rebuilding ${repository.name}"`
@@ -146,6 +151,12 @@ const toActions = (
   const watchCommand = `plural watch ${repository.name}`
 
   return [
+    {
+      label: 'Manage in Console',
+      leftContent: <ArrowTopRightIcon />,
+      onSelect: () =>
+        window.open(`https://${consoleUrl}/apps/${repository.name}`, '_blank'),
+    },
     {
       label: 'Rebuild',
       onSelect: () => onAction(rebuildCommand),

--- a/www/src/generated/graphql.ts
+++ b/www/src/generated/graphql.ts
@@ -2635,6 +2635,7 @@ export type RootMutationType = {
   acceptIncident?: Maybe<Incident>;
   acceptLogin?: Maybe<OauthResponse>;
   acquireLock?: Maybe<ApplyLock>;
+  beginTrial?: Maybe<PlatformSubscription>;
   cancelPlatformSubscription?: Maybe<PlatformSubscription>;
   completeIncident?: Maybe<Incident>;
   createArtifact?: Maybe<Artifact>;


### PR DESCRIPTION
## Summary

Will be used to allow untrialed existing users to start trials.  Also adds some better trial teardown logic, in particular:

* existing cluster promos need to be deleted and flushed.

small fix to the cloud shell ui to add console links where relevant as well.


## Test Plan
unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.