### PR TITLE
fix: Recipe upsert doesn't trigger stack foreign key

### DIFF
--- a/apps/core/lib/core/schema/recipe_section.ex
+++ b/apps/core/lib/core/schema/recipe_section.ex
@@ -14,6 +14,10 @@ defmodule Core.Schema.RecipeSection do
     timestamps()
   end
 
+  def for_recipe(query \\ __MODULE__, recipe_id) do
+    from(r in query, where: r.recipe_id == ^recipe_id)
+  end
+
   @valid ~w(index repository_id recipe_id)a
 
   def changeset(model, attrs \\ %{}) do

--- a/apps/core/test/services/recipes_test.exs
+++ b/apps/core/test/services/recipes_test.exs
@@ -127,6 +127,11 @@ defmodule Core.Services.RecipesTest do
       other_repo_section = Enum.find(recipe.recipe_sections, & &1.repository_id == other_repo.id)
       assert length(other_repo_section.configuration) == 1
 
+      # verify stack membership has no effect
+      stack = insert(:stack)
+      collection = insert(:stack_collection, provider: :aws, stack: stack)
+      insert(:stack_recipe, collection: collection, recipe: recipe)
+
       {:ok, new} = Recipes.upsert(%{
         name: "recipe",
         sections: [


### PR DESCRIPTION
## Summary

We used a delete -> recreate upsert on recipes to simplify this process, but since stacks refer to them w/ a foreign key, this can cause issues.  A more robust solve resolves this.

## Test Plan
unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.