### PR TITLE
feat: Add multi-cluster management

### DIFF
--- a/www/src/components/account/billing/BillingStartTrialModal.tsx
+++ b/www/src/components/account/billing/BillingStartTrialModal.tsx
@@ -40,10 +40,7 @@ function BillingStartTrialModal({
   onClose,
 }: BillingStartTrialModalProps) {
   const [beginTrial, { loading, error }] = useBeginTrialMutation({
-    onCompleted: () => {
-      window.location.reload()
-      onClose()
-    },
+    onCompleted: window.location.reload,
   })
 
   return (

--- a/www/src/components/account/billing/BillingStartTrialModal.tsx
+++ b/www/src/components/account/billing/BillingStartTrialModal.tsx
@@ -40,7 +40,10 @@ function BillingStartTrialModal({
   onClose,
 }: BillingStartTrialModalProps) {
   const [beginTrial, { loading, error }] = useBeginTrialMutation({
-    onCompleted: onClose,
+    onCompleted: () => {
+      window.location.reload()
+      onClose()
+    },
   })
 
   return (

--- a/www/src/components/account/billing/BillingStartTrialModal.tsx
+++ b/www/src/components/account/billing/BillingStartTrialModal.tsx
@@ -40,7 +40,10 @@ function BillingStartTrialModal({
   onClose,
 }: BillingStartTrialModalProps) {
   const [beginTrial, { loading, error }] = useBeginTrialMutation({
-    onCompleted: window.location.reload,
+    onCompleted: () => {
+      onClose()
+      window.location.reload()
+    },
   })
 
   return (

--- a/www/src/components/account/queries.ts
+++ b/www/src/components/account/queries.ts
@@ -21,10 +21,11 @@ export const USERS_Q = gql`
     $serviceAccount: Boolean
     $all: Boolean
     $cursor: String
+    $first: Int = 20
   ) {
     users(
       q: $q
-      first: 20
+      first: $first
       after: $cursor
       serviceAccount: $serviceAccount
       all: $all

--- a/www/src/components/cluster/ClusterAdminsModal.tsx
+++ b/www/src/components/cluster/ClusterAdminsModal.tsx
@@ -1,14 +1,19 @@
 import { Button, Modal } from '@pluralsh/design-system'
 import { Flex } from 'honorable'
-import { useState } from 'react'
+import { useContext, useState } from 'react'
 import { useMutation } from '@apollo/client'
+
+import subscriptionContext from '../../contexts/SubscriptionContext'
 
 import { BindingInput } from '../account/Typeaheads'
 import { GqlError } from '../utils/Alert'
 import { UPDATE_SERVICE_ACCOUNT } from '../account/queries'
 import { sanitize } from '../account/utils'
 
+import UpgradeNeededModal from './UpgradeNeededModal'
+
 export function ClusterAdminsModal({ open, setOpen, serviceAccount }) {
+  const { isPaidPlan, isTrialPlan } = useContext(subscriptionContext)
   const [bindings, setBindings] = useState(
     serviceAccount.impersonationPolicy?.bindings || []
   )
@@ -20,6 +25,14 @@ export function ClusterAdminsModal({ open, setOpen, serviceAccount }) {
     },
     onCompleted: () => setOpen(false),
   })
+
+  if (!(isPaidPlan || isTrialPlan))
+    return (
+      <UpgradeNeededModal
+        open={open}
+        onClose={() => setOpen(false)}
+      />
+    )
 
   return (
     <Modal

--- a/www/src/components/cluster/ClusterDependencyModal.tsx
+++ b/www/src/components/cluster/ClusterDependencyModal.tsx
@@ -1,13 +1,17 @@
 import { ArrowLeftIcon, Button, Modal } from '@pluralsh/design-system'
 import { Div, Flex } from 'honorable'
-import { Dispatch, useCallback, useState } from 'react'
+import { Dispatch, useCallback, useContext, useState } from 'react'
 import { useMutation } from '@apollo/client'
+
+import subscriptionContext from '../../contexts/SubscriptionContext'
 
 import { Cluster } from '../../generated/graphql'
 import { ClusterPicker } from '../utils/ClusterPicker'
 import { GqlError } from '../utils/Alert'
 
 import { CLUSTERS, CREATE_CLUSTER_DEPENDENCY } from '../overview/queries'
+
+import UpgradeNeededModal from './UpgradeNeededModal'
 
 type ClusterDependencyModalProps = {
   open: boolean
@@ -20,6 +24,7 @@ export function ClusterDependencyModal({
   setOpen,
   destination,
 }: ClusterDependencyModalProps) {
+  const { isPaidPlan, isTrialPlan } = useContext(subscriptionContext)
   const [source, setSource] = useState<Cluster | undefined>()
 
   const close = useCallback(() => {
@@ -48,6 +53,14 @@ export function ClusterDependencyModal({
     },
     [destination]
   )
+
+  if (!(isPaidPlan || isTrialPlan))
+    return (
+      <UpgradeNeededModal
+        open={open}
+        onClose={close}
+      />
+    )
 
   return (
     <Modal

--- a/www/src/components/cluster/UpgradeNeededModal.tsx
+++ b/www/src/components/cluster/UpgradeNeededModal.tsx
@@ -1,0 +1,55 @@
+import { Button, Modal, WarningIcon } from '@pluralsh/design-system'
+import { ReactElement } from 'react'
+import { useNavigate } from 'react-router-dom'
+import styled from 'styled-components'
+
+const Wrap = styled.div((_) => ({
+  display: 'flex',
+  flexDirection: 'column',
+}))
+
+const Message = styled.div(({ theme }) => ({
+  ...theme.partials.text.body2,
+  marginBottom: theme.spacing.large,
+}))
+
+const Header = styled.div(({ theme }) => ({
+  ...theme.partials.text.overline,
+  display: 'flex',
+}))
+
+function UpgradeNeededModal({ open, onClose }): ReactElement {
+  const navigate = useNavigate()
+
+  return (
+    <Modal
+      BackdropProps={{ zIndex: 20 }}
+      header={
+        <Header>
+          <WarningIcon
+            color="icon-warning"
+            marginRight="xsmall"
+          />
+          Upgrade needed
+        </Header>
+      }
+      open={open}
+      onClose={() => onClose()}
+      style={{ padding: 0 }}
+    >
+      <Wrap>
+        <Message>
+          Upgrade to Plural Professional to access multi-cluster-management.
+        </Message>
+        <Button
+          alignSelf="flex-end"
+          onClick={() => navigate('/account/billing')}
+        >
+          Review plans
+        </Button>
+      </Wrap>
+    </Modal>
+  )
+}
+
+export default UpgradeNeededModal

--- a/www/src/components/overview/CreateClusterAction.tsx
+++ b/www/src/components/overview/CreateClusterAction.tsx
@@ -1,0 +1,24 @@
+import { Button } from '@pluralsh/design-system'
+import { ReactElement, useState } from 'react'
+
+import CreateClusterModal from './CreateClusterModal'
+
+function CreateClusterButton(): ReactElement {
+  const [createClusterModalOpen, setCreateClusterModalOpen] = useState(false)
+
+  return (
+    <>
+      <Button onClick={() => setCreateClusterModalOpen(true)}>
+        Create cluster
+      </Button>
+      {createClusterModalOpen && (
+        <CreateClusterModal
+          open={createClusterModalOpen}
+          onClose={() => setCreateClusterModalOpen(false)}
+        />
+      )}
+    </>
+  )
+}
+
+export default CreateClusterButton

--- a/www/src/components/overview/CreateClusterModal.tsx
+++ b/www/src/components/overview/CreateClusterModal.tsx
@@ -168,6 +168,7 @@ function ClusterOwnerSelect({
   items,
   selectedKey,
   setSelectedKey,
+  onClose,
 }): ReactElement {
   const navigate = useNavigate()
   const me = useCurrentUser()
@@ -214,17 +215,25 @@ function ClusterOwnerSelect({
           ))}
         </Select>
       </FormField>
-      <Button
-        alignSelf="flex-end"
-        disabled={!selectedKey}
-        onClick={() =>
-          navigate(
-            `/shell${me.id !== selectedKey ? `?user=${selectedKey}` : ''}`
-          )
-        }
-      >
-        Create cluster
-      </Button>
+      <ActionContainer>
+        <Button
+          secondary
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+        <Button
+          alignSelf="flex-end"
+          disabled={!selectedKey}
+          onClick={() =>
+            navigate(
+              `/shell${me.id !== selectedKey ? `?user=${selectedKey}` : ''}`
+            )
+          }
+        >
+          Create cluster
+        </Button>
+      </ActionContainer>
     </>
   )
 }
@@ -234,6 +243,7 @@ function ClusterOwnerInput({
   showBackButton,
   refetch,
   setSelectedKey,
+  onClose,
 }): ReactElement {
   const me = useCurrentUser()
   const [name, setName] = useState<string>()
@@ -295,14 +305,23 @@ function ClusterOwnerInput({
           </Button>
         </ActionContainer>
       ) : (
-        <Button
-          alignSelf="flex-end"
-          onClick={mutation}
-          loading={loading}
-          disabled={loading}
-        >
-          Create
-        </Button>
+        <ActionContainer>
+          <Button
+            secondary
+            onClick={onClose}
+            disabled={loading}
+          >
+            Cancel
+          </Button>
+          <Button
+            alignSelf="flex-end"
+            onClick={mutation}
+            loading={loading}
+            disabled={loading}
+          >
+            Create
+          </Button>
+        </ActionContainer>
       )}
     </>
   )
@@ -366,6 +385,7 @@ function CreateClusterModal({ open, onClose }): ReactElement {
               items={items}
               selectedKey={selectedKey}
               setSelectedKey={setSelectedKey}
+              onClose={onClose}
             />
           ) : (
             <ClusterOwnerInput
@@ -373,6 +393,7 @@ function CreateClusterModal({ open, onClose }): ReactElement {
               showBackButton={items.length > 0}
               refetch={refetch}
               setSelectedKey={setSelectedKey}
+              onClose={onClose}
             />
           )}
         </Wrap>

--- a/www/src/components/overview/CreateClusterModal.tsx
+++ b/www/src/components/overview/CreateClusterModal.tsx
@@ -1,0 +1,404 @@
+import { useMutation, useQuery } from '@apollo/client'
+import {
+  AppIcon,
+  Button,
+  CaretLeftIcon,
+  FormField,
+  Input,
+  ListBoxFooter,
+  ListBoxItem,
+  Modal,
+  PlusIcon,
+  Select,
+  WarningIcon,
+} from '@pluralsh/design-system'
+import {
+  Key,
+  ReactElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import { useNavigate } from 'react-router-dom'
+import styled from 'styled-components'
+
+import ClustersContext from '../../contexts/ClustersContext'
+import { useCurrentUser } from '../../contexts/CurrentUserContext'
+import subscriptionContext from '../../contexts/SubscriptionContext'
+import {
+  Cluster,
+  RootMutationType,
+  RootMutationTypeCreateServiceAccountArgs,
+  RootQueryType,
+  RootQueryTypeUsersArgs,
+  User,
+} from '../../generated/graphql'
+import { CREATE_SERVICE_ACCOUNT, USERS_Q } from '../account/queries'
+import { GqlError } from '../utils/Alert'
+import LoadingIndicator from '../utils/LoadingIndicator'
+
+const toUserList = (connection: Pick<RootQueryType, 'users'>): Array<User> =>
+  connection?.users?.edges?.map((u) => u!.node!) ?? []
+
+function useGetUsersWithoutCluster(clusters: Array<Cluster>) {
+  const {
+    data,
+    fetchMore,
+    refetch: refetchUsers,
+  } = useQuery<Pick<RootQueryType, 'users'>, RootQueryTypeUsersArgs>(USERS_Q, {
+    variables: { serviceAccount: true },
+  })
+  const [users, setUsers] = useState<Array<User>>([])
+  const [loaded, setLoaded] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  const ownerSet = useMemo(
+    () => new Set<string>(clusters.map((c) => c.owner?.id ?? '')),
+    [clusters]
+  )
+
+  const refetch = useCallback(() => {
+    setUsers([])
+    setLoading(false)
+    setLoaded(false)
+    refetchUsers()
+  }, [refetchUsers])
+
+  useEffect(() => {
+    if (!data || loaded || loading) return
+
+    setLoading(true)
+    const fetch = async () => {
+      let hasNextPage = data?.users?.pageInfo.hasNextPage ?? false
+      let cursor = data?.users?.pageInfo.endCursor
+      let limit = 0
+
+      while (hasNextPage && limit < 3) {
+        const { data: connection } = await fetchMore({
+          variables: { serviceAccount: true, cursor },
+        })
+
+        hasNextPage = connection?.users?.pageInfo.hasNextPage ?? false
+        cursor = connection?.users?.pageInfo.endCursor
+        setUsers((users) => [...users, ...toUserList(connection)])
+        limit++
+      }
+
+      setUsers((users) =>
+        users.filter((u) => !ownerSet.has(u.id) && !u.hasInstallations)
+      )
+      setLoaded(true)
+      setLoading(false)
+    }
+
+    fetch()
+  }, [data, fetchMore, loaded, loading, ownerSet])
+
+  return { users, loaded, refetch }
+}
+
+const Wrap = styled.div((_) => ({
+  display: 'flex',
+  flexDirection: 'column',
+}))
+
+const Message = styled.div(({ theme }) => ({
+  ...theme.partials.text.body2,
+  marginBottom: theme.spacing.large,
+}))
+
+const Header = styled.div(({ theme }) => ({
+  ...theme.partials.text.overline,
+  display: 'flex',
+}))
+
+const ActionContainer = styled.div((_) => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+}))
+
+const Spacer = styled.div(({ theme }) => ({
+  marginTop: theme.spacing.large,
+}))
+
+function UpgradeNeededModal({ open, onClose }): ReactElement {
+  const navigate = useNavigate()
+
+  return (
+    <Modal
+      BackdropProps={{ zIndex: 20 }}
+      header={
+        <Header>
+          <WarningIcon
+            color="icon-warning"
+            marginRight="xsmall"
+          />
+          Upgrade needed
+        </Header>
+      }
+      open={open}
+      onClose={() => onClose()}
+      style={{ padding: 0 }}
+    >
+      <Wrap>
+        <Message>
+          Upgrade to Plural Professional to access multi-cluster-management.
+        </Message>
+        <Button
+          alignSelf="flex-end"
+          onClick={() => navigate('/account/billing')}
+        >
+          Review plans
+        </Button>
+      </Wrap>
+    </Modal>
+  )
+}
+
+const CreateNewServiceAccountButton = styled(
+  CreateNewServiceAccountButtonUnstyled
+)(({ theme }) => ({
+  ...theme.partials.text.body2,
+  color: theme.colors['text-primary-accent'],
+}))
+
+function CreateNewServiceAccountButtonUnstyled({ onClick, ...props }) {
+  return (
+    <ListBoxFooter
+      onClick={onClick}
+      leftContent={
+        <PlusIcon
+          color="text-primary-accent"
+          size={16}
+        />
+      }
+      {...props}
+    >
+      Create new Service Account
+    </ListBoxFooter>
+  )
+}
+
+enum UserSelectionMode {
+  Select,
+  Input,
+}
+
+function ClusterOwnerSelect({
+  setMode,
+  items,
+  selectedKey,
+  setSelectedKey,
+}): ReactElement {
+  const navigate = useNavigate()
+  const me = useCurrentUser()
+  const [selectOpen, setSelectOpen] = useState(false)
+
+  return (
+    <>
+      <Message>
+        Choose an owner for the cluster. Only users without existing cluster are
+        available for selection.
+      </Message>
+      <FormField
+        label="Cluster owner"
+        marginBottom="large"
+      >
+        <Select
+          label="Select owner"
+          isOpen={selectOpen}
+          onOpenChange={(open) => setSelectOpen(open)}
+          selectedKey={selectedKey}
+          onSelectionChange={(key) => setSelectedKey(key as Key)}
+          dropdownFooterFixed={
+            <CreateNewServiceAccountButton
+              onClick={() => setMode(UserSelectionMode.Input)}
+            />
+          }
+        >
+          {items.map(({ id, name, email, avatar }) => (
+            <ListBoxItem
+              key={id}
+              label={name}
+              textValue={`${name} - ${email}`}
+              description={email}
+              leftContent={
+                <AppIcon
+                  spacing={avatar ? 'none' : undefined}
+                  hue="lightest"
+                  size="xsmall"
+                  name={name}
+                  url={avatar ?? undefined}
+                />
+              }
+            />
+          ))}
+        </Select>
+      </FormField>
+      <Button
+        alignSelf="flex-end"
+        disabled={!selectedKey}
+        onClick={() =>
+          navigate(
+            `/shell${me.id !== selectedKey ? `?user=${selectedKey}` : ''}`
+          )
+        }
+      >
+        Create cluster
+      </Button>
+    </>
+  )
+}
+
+function ClusterOwnerInput({
+  setMode,
+  showBackButton,
+  refetch,
+  setSelectedKey,
+}): ReactElement {
+  const me = useCurrentUser()
+  const [name, setName] = useState<string>()
+  const [mutation, { loading, error }] = useMutation<
+    Pick<RootMutationType, 'createServiceAccount'>,
+    RootMutationTypeCreateServiceAccountArgs
+  >(CREATE_SERVICE_ACCOUNT, {
+    variables: {
+      attributes: {
+        name,
+        impersonationPolicy: { bindings: [{ userId: me.id }] },
+      },
+    },
+    onCompleted: (result) => {
+      refetch()
+      setMode(UserSelectionMode.Select)
+      setSelectedKey(result.createServiceAccount?.id)
+    },
+  })
+
+  return (
+    <>
+      {error && (
+        <>
+          <GqlError error={error} />
+          <Spacer />
+        </>
+      )}
+      <Message>
+        Create a new service account that will become an owner of the cluster.
+      </Message>
+      <FormField
+        label="Service Account"
+        marginBottom="large"
+      >
+        <Input
+          value={name}
+          onChange={({ target: { value } }) => setName(value)}
+          placeholder="Name"
+        />
+      </FormField>
+      {showBackButton ? (
+        <ActionContainer>
+          <Button
+            secondary
+            onClick={() => setMode(UserSelectionMode.Select)}
+            disabled={loading}
+          >
+            <CaretLeftIcon marginRight="small" />
+            Back
+          </Button>
+          <Button
+            alignSelf="flex-end"
+            onClick={mutation}
+            loading={loading}
+            disabled={loading}
+          >
+            Create
+          </Button>
+        </ActionContainer>
+      ) : (
+        <Button
+          alignSelf="flex-end"
+          onClick={mutation}
+          loading={loading}
+          disabled={loading}
+        >
+          Create
+        </Button>
+      )}
+    </>
+  )
+}
+
+function CreateClusterModal({ open, onClose }): ReactElement {
+  const { isPaidPlan, isTrialPlan } = useContext(subscriptionContext)
+  const [mode, setMode] = useState<UserSelectionMode>(UserSelectionMode.Select)
+  const me = useCurrentUser()
+  const { clusters } = useContext(ClustersContext)
+  const { users, loaded, refetch } = useGetUsersWithoutCluster(clusters)
+
+  const hasCluster = useMemo(
+    () => clusters.some((c) => c.owner?.id === me.id),
+    [clusters, me.id]
+  )
+
+  const items = useMemo(
+    () => [...(hasCluster ? [...users] : [...users, me])],
+    [hasCluster, me, users]
+  )
+
+  const [selectedKey, setSelectedKey] = useState<Key | undefined>(
+    hasCluster ? undefined : me.id
+  )
+
+  useEffect(
+    () =>
+      setMode(
+        items.length === 0 ? UserSelectionMode.Input : UserSelectionMode.Select
+      ),
+    [items.length]
+  )
+
+  if (!(isPaidPlan || isTrialPlan))
+    return (
+      <UpgradeNeededModal
+        open={open}
+        onClose={onClose}
+      />
+    )
+
+  return (
+    <Modal
+      BackdropProps={{ zIndex: 20 }}
+      header={<Header>Create cluster</Header>}
+      open={open}
+      onClose={onClose}
+      style={{ padding: 0 }}
+    >
+      {!loaded ? (
+        <LoadingIndicator />
+      ) : (
+        <Wrap>
+          {mode === UserSelectionMode.Select ? (
+            <ClusterOwnerSelect
+              setMode={setMode}
+              items={items}
+              selectedKey={selectedKey}
+              setSelectedKey={setSelectedKey}
+            />
+          ) : (
+            <ClusterOwnerInput
+              setMode={setMode}
+              showBackButton={items.length > 0}
+              refetch={refetch}
+              setSelectedKey={setSelectedKey}
+            />
+          )}
+        </Wrap>
+      )}
+    </Modal>
+  )
+}
+
+export default CreateClusterModal

--- a/www/src/components/overview/CreateClusterModal.tsx
+++ b/www/src/components/overview/CreateClusterModal.tsx
@@ -10,7 +10,6 @@ import {
   Modal,
   PlusIcon,
   Select,
-  WarningIcon,
 } from '@pluralsh/design-system'
 import {
   Key,
@@ -36,6 +35,7 @@ import {
   User,
 } from '../../generated/graphql'
 import { CREATE_SERVICE_ACCOUNT, USERS_Q } from '../account/queries'
+import UpgradeNeededModal from '../cluster/UpgradeNeededModal'
 import { GqlError } from '../utils/Alert'
 import LoadingIndicator from '../utils/LoadingIndicator'
 
@@ -133,40 +133,6 @@ const ActionContainer = styled.div((_) => ({
 const Spacer = styled.div(({ theme }) => ({
   marginTop: theme.spacing.large,
 }))
-
-function UpgradeNeededModal({ open, onClose }): ReactElement {
-  const navigate = useNavigate()
-
-  return (
-    <Modal
-      BackdropProps={{ zIndex: 20 }}
-      header={
-        <Header>
-          <WarningIcon
-            color="icon-warning"
-            marginRight="xsmall"
-          />
-          Upgrade needed
-        </Header>
-      }
-      open={open}
-      onClose={() => onClose()}
-      style={{ padding: 0 }}
-    >
-      <Wrap>
-        <Message>
-          Upgrade to Plural Professional to access multi-cluster-management.
-        </Message>
-        <Button
-          alignSelf="flex-end"
-          onClick={() => navigate('/account/billing')}
-        >
-          Review plans
-        </Button>
-      </Wrap>
-    </Modal>
-  )
-}
 
 const CreateNewServiceAccountButton = styled(
   CreateNewServiceAccountButtonUnstyled

--- a/www/src/components/overview/OverviewHeader.tsx
+++ b/www/src/components/overview/OverviewHeader.tsx
@@ -1,9 +1,11 @@
 import { SubTab, TabList } from '@pluralsh/design-system'
+import { Flex } from 'honorable'
 import { ReactElement, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
-import { Flex } from 'honorable'
 
 import { LinkTabWrap } from '../utils/Tabs'
+
+import CreateClusterButton from './CreateClusterAction'
 
 const DIRECTORY = [
   { path: '/overview/clusters', label: 'Cluster overview' },
@@ -16,7 +18,10 @@ export default function OverviewHeader(): ReactElement {
   const currentTab = DIRECTORY.find((tab) => pathname?.startsWith(tab.path))
 
   return (
-    <Flex marginBottom="medium">
+    <Flex
+      marginBottom="medium"
+      justifyContent="space-between"
+    >
       <TabList
         stateRef={tabStateRef}
         stateProps={{
@@ -34,6 +39,7 @@ export default function OverviewHeader(): ReactElement {
           </LinkTabWrap>
         ))}
       </TabList>
+      <CreateClusterButton />
     </Flex>
   )
 }

--- a/www/src/components/overview/clusters/ClusterHealth.tsx
+++ b/www/src/components/overview/clusters/ClusterHealth.tsx
@@ -25,19 +25,20 @@ export default function ClusterHealth({
     return () => clearInterval(int)
   }, [])
 
+  const pinged = pingedAt !== null
   const healthy =
     pingedAt && now.clone().subtract(2, 'minutes').isBefore(pingedAt)
 
   return (
     <Flex gap="xsmall">
       <Chip
-        severity={healthy ? 'success' : 'error'}
+        severity={pinged ? (healthy ? 'success' : 'error') : 'warning'}
         size={size}
         hue={hue}
       >
-        {healthy ? 'Healthy' : 'Unhealthy'}
+        {pinged ? (healthy ? 'Healthy' : 'Unhealthy') : 'Pending'}
       </Chip>
-      {!healthy && showTooltip && (
+      {pinged && !healthy && showTooltip && (
         <Tooltip
           label="Clusters that have recently been destroyed will show as Unhealthy while resources are cleaned up. All references should be removed within 24 hours."
           width={350}

--- a/www/src/components/overview/clusters/ClusterList.tsx
+++ b/www/src/components/overview/clusters/ClusterList.tsx
@@ -1,19 +1,60 @@
 import { Table } from '@pluralsh/design-system'
-import { ComponentProps, memo, useContext, useMemo } from 'react'
+import { Div } from 'honorable'
 import isEmpty from 'lodash/isEmpty'
+import { ComponentProps, memo, useContext, useMemo } from 'react'
 
-import { Cluster } from '../../../generated/graphql'
-import { ensureURLValidity } from '../../../utils/url'
 import ClustersContext from '../../../contexts/ClustersContext'
+import CurrentUserContext, {
+  CurrentUser,
+} from '../../../contexts/CurrentUserContext'
+import { Cluster, Source, User } from '../../../generated/graphql'
+import { ensureURLValidity } from '../../../utils/url'
 
-import CurrentUserContext from '../../../contexts/CurrentUserContext'
-
-import { ClusterListElement } from './types'
 import ClusterListEmptyState from './ClusterListEmptyState'
+import { ClusterListElement } from './types'
 
 type ClustersListProps = Omit<ComponentProps<typeof Table>, 'data'> & {
   clusters?: (Cluster | null)[]
   columns: any[]
+}
+
+function fromClusterList(
+  clusters: Array<Cluster>,
+  user: CurrentUser
+): Array<ClusterListElement> {
+  return clusters
+    .filter((cluster): cluster is Cluster => !!cluster)
+    .map((cluster) => {
+      const acked = cluster.queue?.acked
+      const deliveryStatuses = cluster.queue?.upgrades?.edges?.map((edge) => {
+        const id = edge?.node?.id
+
+        return !!id && !!acked && id <= acked
+      })
+      const delivered = !!deliveryStatuses && !deliveryStatuses.includes(false)
+
+      return {
+        id: cluster.id,
+        name: cluster.name,
+        provider: cluster.provider,
+        source: cluster.source,
+        gitUrl: cluster.gitUrl,
+        consoleUrl: ensureURLValidity(cluster.consoleUrl),
+        pingedAt: cluster.pingedAt,
+        accessible:
+          cluster.owner?.id === user.id || cluster.owner?.serviceAccount,
+        delivered,
+        hasDependency: !!cluster.dependency,
+        owner: {
+          id: cluster.owner?.id,
+          name: cluster.owner?.name,
+          email: cluster.owner?.email,
+          avatar: cluster.owner?.avatar,
+          hasShell: cluster.owner?.hasShell,
+        },
+        raw: cluster,
+      }
+    })
 }
 
 export const ClusterList = memo(({ columns, ...props }: ClustersListProps) => {
@@ -21,43 +62,8 @@ export const ClusterList = memo(({ columns, ...props }: ClustersListProps) => {
   const { clusters } = useContext(ClustersContext)
 
   const tableData: ClusterListElement[] = useMemo(
-    () =>
-      (clusters || [])
-        .filter((cluster): cluster is Cluster => !!cluster)
-        .map((cluster) => {
-          const acked = cluster.queue?.acked
-          const deliveryStatuses = cluster.queue?.upgrades?.edges?.map(
-            (edge) => {
-              const id = edge?.node?.id
-
-              return !!id && !!acked && id <= acked
-            }
-          )
-          const delivered =
-            !!deliveryStatuses && !deliveryStatuses.includes(false)
-
-          return {
-            id: cluster.id,
-            name: cluster.name,
-            provider: cluster.provider,
-            source: cluster.source,
-            gitUrl: cluster.gitUrl,
-            consoleUrl: ensureURLValidity(cluster.consoleUrl),
-            pingedAt: cluster.pingedAt,
-            accessible:
-              cluster.owner?.id === me.id || cluster.owner?.serviceAccount,
-            delivered,
-            hasDependency: !!cluster.dependency,
-            owner: {
-              name: cluster.owner?.name,
-              email: cluster.owner?.email,
-              avatar: cluster.owner?.avatar,
-              hasShell: cluster.owner?.hasShell,
-            },
-            raw: cluster,
-          }
-        }),
-    [clusters, me.id]
+    () => [...fromClusterList(clusters, me)],
+    [clusters, me]
   )
 
   if (isEmpty(clusters)) return <ClusterListEmptyState />
@@ -66,7 +72,6 @@ export const ClusterList = memo(({ columns, ...props }: ClustersListProps) => {
     <Table
       data={tableData}
       columns={columns}
-      virtualizeRows
       {...props}
     />
   )

--- a/www/src/components/overview/clusters/ClusterList.tsx
+++ b/www/src/components/overview/clusters/ClusterList.tsx
@@ -1,5 +1,4 @@
 import { Table } from '@pluralsh/design-system'
-import { Div } from 'honorable'
 import isEmpty from 'lodash/isEmpty'
 import { ComponentProps, memo, useContext, useMemo } from 'react'
 
@@ -7,7 +6,7 @@ import ClustersContext from '../../../contexts/ClustersContext'
 import CurrentUserContext, {
   CurrentUser,
 } from '../../../contexts/CurrentUserContext'
-import { Cluster, Source, User } from '../../../generated/graphql'
+import { Cluster } from '../../../generated/graphql'
 import { ensureURLValidity } from '../../../utils/url'
 
 import ClusterListEmptyState from './ClusterListEmptyState'

--- a/www/src/components/overview/clusters/Clusters.tsx
+++ b/www/src/components/overview/clusters/Clusters.tsx
@@ -1,12 +1,11 @@
 import { Flex } from 'honorable'
-import { ReactElement, useContext, useMemo } from 'react'
 import { isEmpty } from 'lodash'
+import { ReactElement, useContext, useMemo } from 'react'
 
 import ClustersContext from '../../../contexts/ClustersContext'
 
-import Upgrades from './Upgrades'
-import ClustersHelpSection from './ClustersHelpSection'
 import { ClusterList } from './ClusterList'
+import ClustersHelpSection from './ClustersHelpSection'
 import {
   ColActions,
   ColCloudShell,
@@ -17,6 +16,8 @@ import {
   ColPromotions,
   ColUpgrades,
 } from './columns'
+
+import Upgrades from './Upgrades'
 
 export function Clusters(): ReactElement | null {
   const { clusters } = useContext(ClustersContext)
@@ -56,7 +57,10 @@ export function Clusters(): ReactElement | null {
       gap="medium"
       grow={1}
     >
-      <ClusterList columns={columns} />
+      <ClusterList
+        columns={columns}
+        maxHeight="600px"
+      />
       <Upgrades />
       {isEmpty(clusters) && <ClustersHelpSection />}
     </Flex>

--- a/www/src/components/overview/clusters/types.ts
+++ b/www/src/components/overview/clusters/types.ts
@@ -12,6 +12,7 @@ export type ClusterListElement = {
   delivered: boolean
   hasDependency: boolean
   owner?: {
+    id?: string
     name?: string
     email?: string
     avatar?: string | null

--- a/www/src/components/shell/OAuthCallback.tsx
+++ b/www/src/components/shell/OAuthCallback.tsx
@@ -61,12 +61,24 @@ function OAuthCallback({ provider }: any) {
   )
 
   useEffect(() => {
+    const url = restoredContext?.impersonation?.userId
+      ? `/shell?user=${restoredContext?.impersonation?.userId}`
+      : `/shell`
+
     if (!data && !error) return
-    if (!token) navigate('shell')
+    if (!token) navigate(url)
 
     save(updatedContext)
-    navigate('/shell')
-  }, [data, error, navigate, save, token, updatedContext])
+    navigate(url)
+  }, [
+    data,
+    error,
+    navigate,
+    restoredContext?.impersonation?.userId,
+    save,
+    token,
+    updatedContext,
+  ])
 
   return <LoadingIndicator />
 }

--- a/www/src/components/shell/context/impersonation.tsx
+++ b/www/src/components/shell/context/impersonation.tsx
@@ -1,0 +1,35 @@
+import { ReactElement, createContext, useEffect, useState } from 'react'
+
+import { User, useMeQuery } from '../../../generated/graphql'
+import LoadingIndicator from '../../utils/LoadingIndicator'
+
+interface ContextProps {
+  user: User
+  skip: boolean
+}
+
+const ImpersonationContext = createContext<ContextProps>({} as ContextProps)
+
+function WithImpersonation({ skip, children }): ReactElement {
+  const { data, loading } = useMeQuery({ fetchPolicy: 'network-only' })
+  const [context, setContext] = useState<ContextProps>({} as ContextProps)
+
+  useEffect(() => {
+    if (data?.me) {
+      setContext({ user: data.me as User, skip })
+    }
+  }, [data?.me, skip])
+
+  if (!data?.me || loading) {
+    return <LoadingIndicator />
+  }
+
+  return (
+    <ImpersonationContext.Provider value={context}>
+      {children}
+    </ImpersonationContext.Provider>
+  )
+}
+
+export type { ContextProps }
+export { ImpersonationContext, WithImpersonation }

--- a/www/src/components/shell/onboarding/Onboarding.tsx
+++ b/www/src/components/shell/onboarding/Onboarding.tsx
@@ -1,21 +1,19 @@
 import { Flex } from 'honorable'
-import { useTheme } from 'styled-components'
-import { Dispatch, ReactElement, useEffect, useMemo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 
 import IsEmpty from 'lodash/isEmpty'
+import { Dispatch, ReactElement, useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTheme } from 'styled-components'
+
+import { ResponsiveLayoutContentContainer } from '../../utils/layout/ResponsiveLayoutContentContainer'
+import { ResponsiveLayoutSidenavContainer } from '../../utils/layout/ResponsiveLayoutSidenavContainer'
+import { ResponsiveLayoutSpacer } from '../../utils/layout/ResponsiveLayoutSpacer'
 
 import { useDevTokenInputSecretCode } from '../hooks/useDevToken'
 import useOnboarded from '../hooks/useOnboarded'
-import { ResponsiveLayoutSpacer } from '../../utils/layout/ResponsiveLayoutSpacer'
-import { ResponsiveLayoutContentContainer } from '../../utils/layout/ResponsiveLayoutContentContainer'
-import { ResponsiveLayoutSidenavContainer } from '../../utils/layout/ResponsiveLayoutSidenavContainer'
 
-import OnboardingHeader from './OnboardingHeader'
-import OnboardingSidenav from './OnboardingSidenav'
-import { OnboardingFlow } from './OnboardingFlow'
-import { ContextProps, OnboardingContext } from './context/onboarding'
 import { defaultSections, useContextStorage, useSection } from './context/hooks'
+import { ContextProps, OnboardingContext } from './context/onboarding'
 import {
   CloudProps,
   CreateCloudShellSectionState,
@@ -25,6 +23,10 @@ import {
   Sections,
   WorkspaceProps,
 } from './context/types'
+import { OnboardingFlow } from './OnboardingFlow'
+
+import OnboardingHeader from './OnboardingHeader'
+import OnboardingSidenav from './OnboardingSidenav'
 
 function Onboarding({
   active,
@@ -121,6 +123,10 @@ function OnboardingWithContext({ ...props }: OnboardingProps): ReactElement {
   const [workspace, setWorkspace] = useState<WorkspaceProps>(
     restoredContext?.workspace ?? {}
   )
+  const impersonation = useMemo(
+    () => restoredContext?.impersonation,
+    [restoredContext?.impersonation]
+  )
 
   // This is to make sure there is only a one-time state restore after oauth callback.
   // We should not store any sensitive data in the local storage longer than required.
@@ -140,8 +146,9 @@ function OnboardingWithContext({ ...props }: OnboardingProps): ReactElement {
       setSection,
       workspace,
       setWorkspace,
+      impersonation,
     }),
-    [scm, cloud, valid, sections, section, workspace]
+    [scm, cloud, valid, sections, section, workspace, impersonation]
   )
 
   return (

--- a/www/src/components/shell/onboarding/checklist/Checklist.tsx
+++ b/www/src/components/shell/onboarding/checklist/Checklist.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client'
-import { A, Flex, Span } from 'honorable'
 import {
   BrowseAppsIcon,
   Button,
@@ -10,6 +9,7 @@ import {
   TerminalIcon,
   Toast,
 } from '@pluralsh/design-system'
+import { A, Flex, Span } from 'honorable'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
@@ -20,15 +20,13 @@ import {
   RootMutationType,
   RootMutationTypeUpdateUserArgs,
 } from '../../../../generated/graphql'
-import { UPDATE_USER } from '../../../users/queries'
-import CurrentUserContext from '../../../../contexts/CurrentUserContext'
-
-import { updateUserFragment } from '../../../../utils/graphql'
-
 import { isOnboardingChecklistHidden } from '../../../../helpers/localStorage'
+import { updateUserFragment } from '../../../../utils/graphql'
+import { UPDATE_USER } from '../../../users/queries'
+import { ImpersonationContext } from '../../context/impersonation'
 
-import { ChecklistFooter } from './Footer'
 import { ChecklistComplete } from './Complete'
+import { ChecklistFooter } from './Footer'
 
 const CHECKLIST_ORDER = [
   OnboardingChecklistState.New,
@@ -47,7 +45,7 @@ export function OnboardingChecklist() {
     dismissed: dismissedFromContext,
     setDismissed: setDismissedFromContext,
   } = useContext(OnboardingChecklistContext)
-  const user = useContext(CurrentUserContext)
+  const { user } = useContext(ImpersonationContext)
 
   // State
   const [status, setStatus] = useState<OnboardingChecklistState>(

--- a/www/src/components/shell/onboarding/context/hooks.ts
+++ b/www/src/components/shell/onboarding/context/hooks.ts
@@ -17,6 +17,7 @@ import {
   CloudProvider,
   CloudProviderBase,
   CloudType,
+  Impersonation,
   Section,
   SectionKey,
   Sections,
@@ -214,12 +215,15 @@ const useSetCloudProviderKeys = <T extends CloudProviderBase>(
 const useContextStorage = () => {
   const LOCAL_STORAGE_KEY = 'plural-onboarding-context'
 
-  const save = useCallback((context: ContextProps) => {
-    localStorage.setItem(
-      LOCAL_STORAGE_KEY,
-      JSON.stringify(toSerializableContext(context))
-    )
-  }, [])
+  const save = useCallback(
+    (context: ContextProps, impersonation?: Impersonation) => {
+      localStorage.setItem(
+        LOCAL_STORAGE_KEY,
+        JSON.stringify(toSerializableContext(context, impersonation))
+      )
+    },
+    []
+  )
 
   const restoredContext = useMemo(
     (): SerializableContextProps =>

--- a/www/src/components/shell/onboarding/context/onboarding.ts
+++ b/www/src/components/shell/onboarding/context/onboarding.ts
@@ -2,6 +2,7 @@ import { Dispatch, SetStateAction, createContext } from 'react'
 
 import {
   CloudProps,
+  Impersonation,
   SCMProps,
   Section,
   Sections,
@@ -30,6 +31,7 @@ interface SerializableContextProps {
   valid: boolean
   section: Section
   sections?: Sections
+  impersonation?: Impersonation
 }
 
 const toSerializableSection = (section: Section): Partial<Section> => ({
@@ -40,7 +42,8 @@ const toSerializableSection = (section: Section): Partial<Section> => ({
 })
 
 const toSerializableContext = (
-  context: ContextProps
+  context: ContextProps,
+  impersonation?: Impersonation
 ): SerializableContextProps => ({
   valid: context.valid,
   scm: context.scm,
@@ -50,6 +53,7 @@ const toSerializableContext = (
     provider: context?.cloud?.provider,
   },
   section: toSerializableSection(context.section) as Section,
+  impersonation,
 })
 
 const OnboardingContext = createContext<ContextProps>({} as ContextProps)

--- a/www/src/components/shell/onboarding/context/types.ts
+++ b/www/src/components/shell/onboarding/context/types.ts
@@ -4,6 +4,7 @@ import {
   AuthorizationUrl,
   Provider,
   ScmProvider,
+  User,
 } from '../../../../generated/graphql'
 
 enum CloudProvider {
@@ -127,6 +128,11 @@ interface WorkspaceProps {
   subdomain?: string
 }
 
+interface Impersonation {
+  userId?: string
+  user?: User
+}
+
 export type {
   Sections,
   Section,
@@ -138,6 +144,7 @@ export type {
   AzureCloudProvider,
   CloudProviderBase,
   SCMOrg,
+  Impersonation,
 }
 export {
   SectionKey,

--- a/www/src/components/shell/onboarding/sections/cli/CLICompletionStep.tsx
+++ b/www/src/components/shell/onboarding/sections/cli/CLICompletionStep.tsx
@@ -1,13 +1,13 @@
-import { A, Flex, P } from 'honorable'
-
-import { useState } from 'react'
-
 import { Button, Checkbox, Codeline } from '@pluralsh/design-system'
+import { A, Flex, P } from 'honorable'
+import { useContext, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { ImpersonationContext } from '../../../context/impersonation'
 import useOnboarded from '../../../hooks/useOnboarded'
 
 function CliCompletion({ onBack }) {
+  const { user, skip } = useContext(ImpersonationContext)
   const [completed, setCompleted] = useState(false)
   const navigate = useNavigate()
   const { mutation } = useOnboarded()
@@ -20,7 +20,9 @@ function CliCompletion({ onBack }) {
         gap="medium"
         marginVertical="large"
       >
-        <Codeline>plural init</Codeline>
+        <Codeline>
+          plural init {!skip && `--service-account=${user.email}`}
+        </Codeline>
         <Codeline>
           plural bundle install &lt;app-name&gt; &lt;bundle-name&gt;
         </Codeline>

--- a/www/src/components/shell/onboarding/sections/cloud/ProviderSelection.tsx
+++ b/www/src/components/shell/onboarding/sections/cloud/ProviderSelection.tsx
@@ -1,5 +1,3 @@
-import { Flex, Span } from 'honorable'
-import { useContext, useEffect, useMemo, useState } from 'react'
 import {
   CloudIcon,
   InfoOutlineIcon,
@@ -7,17 +5,23 @@ import {
   Radio,
   Tooltip,
 } from '@pluralsh/design-system'
+import { Flex, Span } from 'honorable'
+import { useContext, useEffect, useMemo, useState } from 'react'
+
+import { ImpersonationContext } from '../../../context/impersonation'
+
+import GCPLogoIcon from '../../assets/GCPLogoIcon.svg'
 
 import { OnboardingContext } from '../../context/onboarding'
 import { CloudType } from '../../context/types'
-import GCPLogoIcon from '../../assets/GCPLogoIcon.svg'
-import CurrentUserContext from '../../../../../contexts/CurrentUserContext'
 
 import { CloudOption } from './CloudOption'
 
 function ProviderSelection() {
-  const me = useContext(CurrentUserContext)
   const { cloud, setCloud, setValid } = useContext(OnboardingContext)
+  const {
+    user: { demoed },
+  } = useContext(ImpersonationContext)
   const [path, setPath] = useState(cloud?.type)
   const isValid = useMemo(() => path !== undefined, [path])
 
@@ -49,9 +53,9 @@ function ProviderSelection() {
           data-phid="select-cloud-demo"
           selected={path === CloudType.Demo}
           onClick={() => setPath(CloudType.Demo)}
-          disabled={me?.demoed}
+          disabled={demoed}
           tooltip={
-            me?.demoed
+            demoed
               ? 'You have reached the maximum number of demo environment usage.'
               : undefined
           }

--- a/www/src/components/shell/onboarding/sections/repository/ProviderSelection.tsx
+++ b/www/src/components/shell/onboarding/sections/repository/ProviderSelection.tsx
@@ -1,21 +1,20 @@
-import { Div, Flex, Text } from 'honorable'
-import { useCallback, useContext, useMemo, useState } from 'react'
 import {
   Button,
   Callout,
   GitHubLogoIcon,
   GitLabLogoIcon,
 } from '@pluralsh/design-system'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { Div, Flex, Text } from 'honorable'
+import { useCallback, useContext, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 import { ImpersonationContext } from '../../../context/impersonation'
-
 import { useDevToken } from '../../../hooks/useDevToken'
-import OnboardingCardButton from '../../OnboardingCardButton'
 import useOnboarded from '../../../hooks/useOnboarded'
 import { useContextStorage, useSectionState } from '../../context/hooks'
-import { ConfigureCloudSectionState } from '../../context/types'
 import { OnboardingContext } from '../../context/onboarding'
+import { ConfigureCloudSectionState } from '../../context/types'
+import OnboardingCardButton from '../../OnboardingCardButton'
 
 const providerToLogo = {
   github: <GitHubLogoIcon size={40} />,

--- a/www/src/components/shell/onboarding/sections/repository/ProviderSelection.tsx
+++ b/www/src/components/shell/onboarding/sections/repository/ProviderSelection.tsx
@@ -70,14 +70,16 @@ function ProviderSelection({ data }) {
             key={provider}
             selected={context?.scm?.provider === provider}
             onClick={() => {
-              save({
-                ...context,
-                section: {
-                  ...context?.section,
-                  state: ConfigureCloudSectionState.RepositoryConfiguration,
+              save(
+                {
+                  ...context,
+                  section: {
+                    ...context?.section,
+                    state: ConfigureCloudSectionState.RepositoryConfiguration,
+                  },
                 },
-                ...(!skip ? { impersonation: { userId } } : {}),
-              })
+                !skip ? { userId } : undefined
+              )
 
               // HACK to navigate the onboarding on staging environments
               if (import.meta.env.MODE !== 'production' && devToken) {

--- a/www/src/components/shell/onboarding/sections/repository/ProviderSelection.tsx
+++ b/www/src/components/shell/onboarding/sections/repository/ProviderSelection.tsx
@@ -6,7 +6,9 @@ import {
   GitHubLogoIcon,
   GitLabLogoIcon,
 } from '@pluralsh/design-system'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+import { ImpersonationContext } from '../../../context/impersonation'
 
 import { useDevToken } from '../../../hooks/useDevToken'
 import OnboardingCardButton from '../../OnboardingCardButton'
@@ -36,6 +38,10 @@ function ProviderSelection({ data }) {
   const { fresh: isOnboarding, mutation } = useOnboarded()
   const setSectionState = useSectionState()
   const context = useContext(OnboardingContext)
+  const {
+    user: { id: userId },
+    skip,
+  } = useContext(ImpersonationContext)
   const { save } = useContextStorage()
   const [expanded, setExpanded] = useState(false)
 
@@ -71,6 +77,7 @@ function ProviderSelection({ data }) {
                   ...context?.section,
                   state: ConfigureCloudSectionState.RepositoryConfiguration,
                 },
+                ...(!skip ? { impersonation: { userId } } : {}),
               })
 
               // HACK to navigate the onboarding on staging environments

--- a/www/src/components/shell/terminal/actionbar/ActionBar.tsx
+++ b/www/src/components/shell/terminal/actionbar/ActionBar.tsx
@@ -1,14 +1,13 @@
-import { Dispatch, ReactElement, forwardRef, useContext, useState } from 'react'
-import { Button, ButtonProps, Flex } from 'honorable'
 import { CliIcon, ToolIcon, Tooltip } from '@pluralsh/design-system'
+import { Button, ButtonProps, Flex } from 'honorable'
+import { Dispatch, ReactElement, forwardRef, useContext, useState } from 'react'
 
-import CurrentUserContext from '../../../../contexts/CurrentUserContext'
-
-import { TerminalThemeSelector } from './theme/Selector'
+import { ImpersonationContext } from '../../context/impersonation'
 
 import { Cheatsheet } from './cheatsheet/Cheatsheet'
-import { MoreOptions } from './options/MoreOptions'
 import { DeleteDemoModal } from './options/DeleteShellModal'
+import { MoreOptions } from './options/MoreOptions'
+import { TerminalThemeSelector } from './theme/Selector'
 
 type ActionBarItemProps = {
   tooltip?: string
@@ -53,7 +52,9 @@ const ActionBarItem = forwardRef(ActionBarItemRef)
 
 function ActionBar({ onRepairViewport }) {
   const [demoDelete, setDemoDelete] = useState(false)
-  const { demoing } = useContext(CurrentUserContext)
+  const {
+    user: { demoing },
+  } = useContext(ImpersonationContext)
   const [showCheatsheet, setShowCheatsheet] = useState(false)
 
   return (

--- a/www/src/components/shell/terminal/actionbar/options/DeleteShellModal.tsx
+++ b/www/src/components/shell/terminal/actionbar/options/DeleteShellModal.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useContext, useState } from 'react'
 import { useMutation } from '@apollo/client'
 import {
   Chip,
@@ -8,12 +7,14 @@ import {
   WarningIcon,
 } from '@pluralsh/design-system'
 import { A, Button, Flex, Span } from 'honorable'
+import { useCallback, useContext, useState } from 'react'
+
+import { ImpersonationContext } from '../../../context/impersonation'
 
 import {
   DELETE_DEMO_PROJECT_MUTATION,
   DELETE_SHELL_MUTATION,
 } from '../../../queries'
-import CurrentUserContext from '../../../../../contexts/CurrentUserContext'
 
 function DeleteDemoModal({ onClose }) {
   const [open, setOpen] = useState(true)
@@ -84,7 +85,9 @@ function DeleteDemoModal({ onClose }) {
 }
 
 function DeleteShellModal({ onClose }) {
-  const { demoing } = useContext(CurrentUserContext)
+  const {
+    user: { demoing },
+  } = useContext(ImpersonationContext)
   const [open, setOpen] = useState(true)
   const [canDelete, setCanDelete] = useState(false)
   const [deleteShell, { loading: deleteShellLoading }] = useMutation(

--- a/www/src/components/shell/terminal/sidebar/installer/Installer.tsx
+++ b/www/src/components/shell/terminal/sidebar/installer/Installer.tsx
@@ -1,3 +1,12 @@
+import { useApolloClient, useQuery } from '@apollo/client'
+import { ApolloError } from '@apollo/client/errors'
+import {
+  GraphQLToast,
+  Wizard,
+  WizardNavigation,
+  WizardStepConfig,
+  WizardStepper,
+} from '@pluralsh/design-system'
 import { Div, Flex } from 'honorable'
 import {
   Dispatch,
@@ -8,22 +17,13 @@ import {
   useRef,
   useState,
 } from 'react'
-import { useApolloClient, useQuery } from '@apollo/client'
-import {
-  GraphQLToast,
-  Wizard,
-  WizardNavigation,
-  WizardStepConfig,
-  WizardStepper,
-} from '@pluralsh/design-system'
-import { ApolloError } from '@apollo/client/errors'
 import { useSearchParams } from 'react-router-dom'
 
-import useOnboarded from '../../../hooks/useOnboarded'
-import { State, TerminalContext } from '../../context/terminal'
-import CurrentUserContext from '../../../../../contexts/CurrentUserContext'
 import { PosthogEvent, posthogCapture } from '../../../../../utils/posthog'
 import LoadingIndicator from '../../../../utils/LoadingIndicator'
+import { ImpersonationContext } from '../../../context/impersonation'
+import useOnboarded from '../../../hooks/useOnboarded'
+import { State, TerminalContext } from '../../context/terminal'
 import { useSelectCluster } from '../Sidebar'
 
 import { InstallerContext } from './context'
@@ -44,7 +44,9 @@ function Installer({ onInstallSuccess }) {
     configuration,
     setState,
   } = useContext(TerminalContext)
-  const me = useContext(CurrentUserContext)
+  const {
+    user: { demoing },
+  } = useContext(ImpersonationContext)
   const onResetRef = useRef<{ onReset: Dispatch<void> }>({ onReset: () => {} })
   const [searchParams] = useSearchParams()
   const { clusters } = useSelectCluster()
@@ -88,7 +90,7 @@ function Installer({ onInstallSuccess }) {
         .filter((app) => !FILTERED_APPS.includes(app?.name)),
     [applicationNodes]
   )
-  const limit = useMemo(() => (me?.demoing ? 3 : 5), [me?.demoing])
+  const limit = useMemo(() => (demoing ? 3 : 5), [demoing])
   const preselectedApps = useMemo(() => {
     const names = searchParams.get('install')
 
@@ -214,7 +216,7 @@ function Installer({ onInstallSuccess }) {
                 <WizardNavigation
                   onInstall={onInstall}
                   tooltip={
-                    me?.demoing ? 'Max 3 applications on GCP demo' : undefined
+                    demoing ? 'Max 3 applications on GCP demo' : undefined
                   }
                 />
               ),

--- a/www/src/components/utils/InstallAppButton.tsx
+++ b/www/src/components/utils/InstallAppButton.tsx
@@ -1,5 +1,3 @@
-import { Key, useContext, useEffect, useMemo, useRef, useState } from 'react'
-import { Button, Div, Flex, H2, ModalBaseProps, P } from 'honorable'
 import {
   Codeline,
   Modal,
@@ -7,13 +5,21 @@ import {
   TabList,
   TabPanel,
 } from '@pluralsh/design-system'
-import { Link } from 'react-router-dom'
+import { Button, Div, Flex, H2, ModalBaseProps, P } from 'honorable'
 import isEmpty from 'lodash/isEmpty'
 import upperFirst from 'lodash/upperFirst'
+import { Key, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
 
 import ClustersContext from '../../contexts/ClustersContext'
-import { Cluster, Provider } from '../../generated/graphql'
 import { useCurrentUser } from '../../contexts/CurrentUserContext'
+import { Cluster, Provider } from '../../generated/graphql'
+
+import {
+  CloudShellClusterPicker,
+  clusterFilter,
+  clusterHasCloudShell,
+} from './ClusterPicker'
 
 import {
   InstallAppButtonProps,
@@ -23,12 +29,6 @@ import {
   providerToLongName,
   providerToShortName,
 } from './recipeHelpers'
-import {
-  CloudShellClusterPicker,
-  NEW_CLUSTER_ID,
-  clusterFilter,
-  clusterHasCloudShell,
-} from './ClusterPicker'
 
 function CliCommand({
   recipe,

--- a/www/src/components/utils/InstallAppButton.tsx
+++ b/www/src/components/utils/InstallAppButton.tsx
@@ -230,8 +230,7 @@ function InstallModal({
   const clusterProvider = currentCluster?.provider
 
   const isCloudShellCluster =
-    clusterId === NEW_CLUSTER_ID ||
-    (currentCluster && clusterHasCloudShell(currentCluster))
+    currentCluster && clusterHasCloudShell(currentCluster)
   const header = `Install ${name}`
   const recipe =
     type === 'stack' && !clusterProvider
@@ -295,9 +294,9 @@ function InstallModal({
             primary
             width="100%"
             as={Link}
-            to={`/shell?${
-              clusterId !== NEW_CLUSTER_ID ? `cluster=${clusterId}` : ''
-            }&install=${apps && !isEmpty(apps) ? `${apps.join(',')}` : name}`}
+            to={`/shell?${`user=${currentCluster.owner?.id}`}&install=${
+              apps && !isEmpty(apps) ? `${apps.join(',')}` : name
+            }`}
           >
             Start install
           </Button>

--- a/www/src/contexts/ClustersContext.tsx
+++ b/www/src/contexts/ClustersContext.tsx
@@ -41,7 +41,12 @@ export function ClustersContextProvider({ children }) {
       data?.clusters?.edges
         ?.map((edge) => edge?.node)
         .filter((node): node is Cluster => !!node)
-        .filter((c) => c.source === Source.Default || c.owner?.hasShell) ?? []
+        .filter(
+          (c) =>
+            c.source === Source.Default ||
+            c.owner?.hasShell ||
+            c.owner?.hasInstallations
+        ) ?? []
 
     return { clusters, refetchClusters: refetch }
   }, [data, refetch])

--- a/www/src/contexts/ClustersContext.tsx
+++ b/www/src/contexts/ClustersContext.tsx
@@ -8,6 +8,7 @@ import {
   Cluster,
   RootQueryType,
   RootQueryTypeClustersArgs,
+  Source,
 } from '../generated/graphql'
 
 type ClustersContextType = {
@@ -39,7 +40,8 @@ export function ClustersContextProvider({ children }) {
     const clusters =
       data?.clusters?.edges
         ?.map((edge) => edge?.node)
-        .filter((node): node is Cluster => !!node) || []
+        .filter((node): node is Cluster => !!node)
+        .filter((c) => c.source === Source.Default || c.owner?.hasShell) ?? []
 
     return { clusters, refetchClusters: refetch }
   }, [data, refetch])

--- a/www/src/contexts/ClustersContext.tsx
+++ b/www/src/contexts/ClustersContext.tsx
@@ -1,14 +1,14 @@
-import { createContext, useMemo } from 'react'
 import { useQuery } from '@apollo/client'
+import { createContext, useMemo } from 'react'
 import styled from 'styled-components'
 
+import { CLUSTERS } from '../components/overview/queries'
+import LoadingIndicator from '../components/utils/LoadingIndicator'
 import {
   Cluster,
   RootQueryType,
   RootQueryTypeClustersArgs,
 } from '../generated/graphql'
-import LoadingIndicator from '../components/utils/LoadingIndicator'
-import { CLUSTERS } from '../components/overview/queries'
 
 type ClustersContextType = {
   clusters: Cluster[]

--- a/www/src/models/user.ts
+++ b/www/src/models/user.ts
@@ -36,6 +36,7 @@ export const UserFragment = gql`
     emailConfirmBy
     backgroundColor
     serviceAccount
+    hasShell
     roles {
       admin
     }

--- a/www/src/models/user.ts
+++ b/www/src/models/user.ts
@@ -37,6 +37,7 @@ export const UserFragment = gql`
     backgroundColor
     serviceAccount
     hasShell
+    hasInstallations
     roles {
       admin
     }


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Add `Create Cluster` button to cluster overview
- Add create cluster modal
  - Block access for Open Source users
  - Support selection of Service Accounts without cluster and shell
  - Support creation of new Service Account if needed
- Update clusters list to properly display and give access to clusters that were not fully provisioned
- Update cluster picker to display cluster owner email (useful when there are multiple clusters with same name)
- Update `ClustersContext` logic to filter out "dead" clusters. In case the cluster is not CLI-based it will be checked for existing shell or installations.
- Update `shell` view and onboarding experience to properly support user impersonation
- Remove `Create new cluster` action from cluster picker on `shell` view
- and more... :slightly_smiling_face: 

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.