### PR TITLE
Subscription upgrade cache management

### DIFF
--- a/apps/core/lib/core/pubsub/events.ex
+++ b/apps/core/lib/core/pubsub/events.ex
@@ -12,6 +12,9 @@ defmodule Core.PubSub.InstallationDeleted, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.SubscriptionUpdated, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.SubscriptionCreated, do: use Piazza.PubSub.Event
 
+defmodule Core.PubSub.PlatformSubscriptionUpdated, do: use Piazza.PubSub.Event
+defmodule Core.PubSub.PlatformSubscriptionCreated, do: use Piazza.PubSub.Event
+
 defmodule Core.PubSub.IncidentCreated, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.IncidentUpdated, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.IncidentDeleted, do: use Piazza.PubSub.Event

--- a/apps/core/lib/core/pubsub/protocols/cacheable.ex
+++ b/apps/core/lib/core/pubsub/protocols/cacheable.ex
@@ -15,6 +15,15 @@ defimpl Core.PubSub.Cacheable, for: [Core.PubSub.GroupMemberCreated, Core.PubSub
   end
 end
 
+defimpl Core.PubSub.Cacheable, for: [Core.PubSub.PlatformSubscriptionCreated] do
+  alias Core.Schema.{PlatformSubscription, User}
+
+  def cache(%{item: %PlatformSubscription{account_id: aid}}) do
+    users = User.for_account(aid) |> Core.Repo.all()
+    {:del, Enum.map(users, & {:login, &1.id}), users}
+  end
+end
+
 defimpl Core.PubSub.Cacheable, for: [Core.PubSub.UserUpdated, Core.PubSub.EmailConfirmed, Core.PubSub.CacheUser] do
   def cache(%{item: user}) do
     user = Core.Services.Rbac.preload(user)

--- a/apps/core/lib/core/services/payments.ex
+++ b/apps/core/lib/core/services/payments.ex
@@ -79,6 +79,7 @@ defmodule Core.Services.Payments do
     end)
     |> add_operation(:scaffold, fn _ -> Accounts.account_setup(root_user) end)
     |> execute(extract: :setup)
+    |> notify(:create)
   end
   def begin_trial(%User{account_id: aid}) do
     Accounts.get_account!(aid)
@@ -1162,6 +1163,8 @@ defmodule Core.Services.Payments do
 
   defp notify({:ok, %Subscription{} = sub}, :create),
     do: handle_notify(PubSub.SubscriptionCreated, sub)
+  defp notify({:ok, %PlatformSubscription{} = sub}, :create),
+    do: handle_notify(PubSub.PlatformSubscriptionCreated, sub)
   defp notify({:ok, %Subscription{} = sub}, :update),
     do: handle_notify(PubSub.SubscriptionUpdated, sub)
   defp notify(error, _), do: error

--- a/apps/core/test/pubsub/cache/accounts_test.exs
+++ b/apps/core/test/pubsub/cache/accounts_test.exs
@@ -3,6 +3,22 @@ defmodule Core.PubSub.Consumers.Cache.AccountsTest do
   alias Core.PubSub
   alias Core.PubSub.Consumers.Cache
 
+  describe "PlatformSubscriptionCreated" do
+    test "it will wipe login caches" do
+      account = insert(:account)
+      users = insert_list(3, :user, account: account)
+      sub = insert(:platform_subscription, account: account)
+      Enum.each(users, &cache/1)
+
+      event = %PubSub.PlatformSubscriptionCreated{item: sub}
+      Cache.handle_event(event)
+
+      for u <- users do
+        refute Core.Cache.get({:login, u.id})
+      end
+    end
+  end
+
   describe "GroupMemberCreated" do
     test "it will overwrite the login cache" do
       gm = insert(:group_member)

--- a/apps/core/test/services/payments_test.exs
+++ b/apps/core/test/services/payments_test.exs
@@ -268,6 +268,8 @@ defmodule Core.Services.PaymentsTest do
       assert cluster.dimension == :cluster
       assert cluster.quantity == 0
       assert cluster.external_id == "cluster_id"
+
+      assert_receive {:event, %PubSub.PlatformSubscriptionCreated{item: ^subscription}}
     end
 
     test "It can autoprovision stripe customers" do

--- a/apps/core/test/support/test_helpers.ex
+++ b/apps/core/test/support/test_helpers.ex
@@ -1,6 +1,8 @@
 defmodule Core.TestHelpers do
   alias Core.Schema.{User, Group, GroupMember}
 
+  def cache(%User{} = user), do: Core.Cache.put({:login, user.id}, user)
+
   def ids_equal(found, expected) do
     found = MapSet.new(ids(found))
     expected = MapSet.new(ids(expected))

--- a/apps/graphql/test/mutations/payments_mutation_test.exs
+++ b/apps/graphql/test/mutations/payments_mutation_test.exs
@@ -412,6 +412,8 @@ defmodule GraphQl.PaymentsMutationsTest do
       """, %{}, %{current_user: user})
 
       assert sub["plan"]["id"] == trial.id
+
+      assert_receive {:event, %Core.PubSub.PlatformSubscriptionCreated{}}
     end
   end
 


### PR DESCRIPTION
## Summary
We need to wipe all account users caches on susbcription upgrades.  This is something of a heavy operation, but upgrades are infrequent so shouldn't be too bad.

## Test Plan
unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.