### PR TITLE
Locked and Promotion email digesting

### DIFF
--- a/apps/core/lib/core/pubsub/events.ex
+++ b/apps/core/lib/core/pubsub/events.ex
@@ -70,6 +70,7 @@ defmodule Core.PubSub.DockerRepositoryUpdated, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.LicensePing, do: use Piazza.PubSub.Event
 
 defmodule Core.PubSub.InstallationLocked, do: use Piazza.PubSub.Event
+defmodule Core.PubSub.InstallationUnlocked, do: use Piazza.PubSub.Event
 
 defmodule Core.PubSub.TestCreated, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.TestUpdated, do: use Piazza.PubSub.Event
@@ -85,3 +86,7 @@ defmodule Core.PubSub.DemoProjectCreated, do: use Piazza.PubSub.Event
 defmodule Core.PubSub.DemoProjectDeleted, do: use Piazza.PubSub.Event
 
 defmodule Core.PubSub.ClusterDependencyCreated, do: use Piazza.PubSub.Event
+
+defmodule Core.PubSub.DeferredUpdateCreated, do: use Piazza.PubSub.Event
+
+defmodule Core.PubSub.UpgradesPromoted, do: use Piazza.PubSub.Event

--- a/apps/core/lib/core/pubsub/protocols/fanout.ex
+++ b/apps/core/lib/core/pubsub/protocols/fanout.ex
@@ -202,6 +202,27 @@ defimpl Core.PubSub.Fanout, for: [Core.PubSub.RepositoryCreated, Core.PubSub.Rep
   def fanout(%{item: repo}), do: Core.Services.Repositories.hydrate(repo)
 end
 
+defimpl Core.PubSub.Fanout, for: Core.PubSub.InstallationUnlocked do
+  alias Core.Schema.{Notification, Installation}
+
+  def fanout(%{item: %Installation{repository_id: id, user_id: uid}}) do
+    Notification.for_type(:locked)
+    |> Notification.for_repository(id)
+    |> Notification.for_user(uid)
+    |> Core.Repo.delete_all()
+  end
+end
+
+defimpl Core.PubSub.Fanout, for: Core.PubSub.UpgradesPromoted do
+  alias Core.Schema.{Notification}
+
+  def fanout(%{item: user}) do
+    Notification.for_type(:pending)
+    |> Notification.for_user(user.id)
+    |> Core.Repo.delete_all()
+  end
+end
+
 defimpl Core.PubSub.Fanout, for: [Core.PubSub.RoleCreated, Core.PubSub.RoleUpdated] do
   alias Core.Schema.User
   alias Core.PubSub.CacheUser

--- a/apps/core/lib/core/schema/notification.ex
+++ b/apps/core/lib/core/schema/notification.ex
@@ -2,7 +2,7 @@ defmodule Core.Schema.Notification do
   use Piazza.Ecto.Schema
   alias Core.Schema.{User, Incident, IncidentMessage, Repository}
 
-  defenum Type, message: 0, incident_update: 1, mention: 2, locked: 3
+  defenum Type, message: 0, incident_update: 1, mention: 2, locked: 3, pending: 4
 
   schema "notifications" do
     field :type, Type
@@ -18,6 +18,14 @@ defmodule Core.Schema.Notification do
     timestamps()
   end
 
+  def for_type(query \\ __MODULE__, type) do
+    from(n in query, where: n.type == ^type)
+  end
+
+  def for_repository(query \\ __MODULE__, repo_id) do
+    from(n in query, where: n.repository_id == ^repo_id)
+  end
+
   def for_user(query \\ __MODULE__, user_id) do
     from(n in query, where: n.user_id == ^user_id)
   end
@@ -28,6 +36,10 @@ defmodule Core.Schema.Notification do
 
   def cli(query \\ __MODULE__) do
     from(n in query, where: n.cli)
+  end
+
+  def preloaded(query \\ __MODULE__, preloads) do
+    from(n in query, preload: ^preloads)
   end
 
   def ordered(query \\ __MODULE__, order \\ [desc: :inserted_at]) do

--- a/apps/core/lib/core/services/clusters.ex
+++ b/apps/core/lib/core/services/clusters.ex
@@ -197,6 +197,7 @@ defmodule Core.Services.Clusters do
     |> add_operation(:user, fn _ -> do_promote(user) end)
     |> add_operation(:kick, fn _ -> Core.Services.Upgrades.kick(user) end)
     |> execute(extract: :user)
+    |> notify(:promote)
   end
   def promote(_), do: {:error, "this user doesn't have promotions enabled"}
 
@@ -242,6 +243,7 @@ defmodule Core.Services.Clusters do
   end
   defp flush_dns(_), do: :ok
 
+  defp notify({:ok, %User{} = user}, :promote), do: handle_notify(PubSub.UpgradesPromoted, user)
   defp notify({:ok, %ClusterDependency{} = dep}, :create, user),
     do: handle_notify(PubSub.ClusterDependencyCreated, dep, actor: user)
   defp notify(error, _, _), do: error

--- a/apps/core/lib/core/services/clusters/transfer.ex
+++ b/apps/core/lib/core/services/clusters/transfer.ex
@@ -29,7 +29,7 @@ defmodule Core.Services.Clusters.Transfer do
     Installation.for_user(id)
     |> Core.Repo.all()
     |> Core.Repo.preload([:repository])
-    |> Enum.reduce(start_transaction(), fn %{id: inst_id, repository: repo, oidc_provider: provider} = inst, xact ->
+    |> Enum.reduce(start_transaction(), fn %{id: inst_id, repository: repo} = inst, xact ->
       add_operation(xact, inst_id, fn _ ->
         case Repositories.get_installation(to_id, inst.repository_id) do
           nil ->

--- a/apps/core/lib/core/services/upgrades.ex
+++ b/apps/core/lib/core/services/upgrades.ex
@@ -206,6 +206,7 @@ defmodule Core.Services.Upgrades do
       dequeue_at: Timex.now()
     }))
     |> Core.Repo.insert()
+    |> notify(:create)
   end
 
   defp update_info(%ChartInstallation{id: id}), do: {:chart, id}
@@ -307,6 +308,8 @@ defmodule Core.Services.Upgrades do
     do: handle_notify(PubSub.UpgradeCreated, upgrade)
   defp notify({:ok, %UpgradeQueue{} = q}, :update),
     do: handle_notify(PubSub.UpgradeQueueUpdated, q)
+  defp notify({:ok, %DeferredUpdate{} = d}, :create),
+    do: handle_notify(PubSub.DeferredUpdateCreated, d)
 
   defp notify(pass, _), do: pass
 

--- a/apps/core/test/pubsub/notification/repository_test.exs
+++ b/apps/core/test/pubsub/notification/repository_test.exs
@@ -18,4 +18,29 @@ defmodule Core.PubSub.Notification.RepositoryTest do
       assert is_binary(notif.msg)
     end
   end
+
+  describe "DeferredUpdateCreated" do
+    test "it can lock an installation" do
+      ci = insert(:chart_installation)
+      deferred = insert(:deferred_update, chart_installation: ci, pending: true)
+
+      event = %PubSub.DeferredUpdateCreated{item: deferred}
+      [notif] = Notification.handle_event(event)
+
+      refute notif.cli
+      assert notif.type == :pending
+      assert notif.user_id == ci.installation.user_id
+      assert notif.repository_id == ci.installation.repository_id
+      assert notif.actor_id == ci.installation.user_id
+      assert is_binary(notif.msg)
+    end
+
+    test "it will ignore non-pending deferred updates" do
+      ci = insert(:chart_installation)
+      deferred = insert(:deferred_update, chart_installation: ci)
+
+      event = %PubSub.DeferredUpdateCreated{item: deferred}
+      :ok = Notification.handle_event(event)
+    end
+  end
 end

--- a/apps/core/test/services/clusters_test.exs
+++ b/apps/core/test/services/clusters_test.exs
@@ -163,6 +163,8 @@ defmodule Core.Services.ClustersTest do
 
       assert update.upgrade_to > user.upgrade_to
 
+      assert_receive {:event, %PubSub.UpgradesPromoted{item: ^update}}
+
       for def <- def_ups,
         do: assert refetch(def).dequeue_at
     end

--- a/apps/core/test/services/rollouts_test.exs
+++ b/apps/core/test/services/rollouts_test.exs
@@ -7,7 +7,7 @@ defmodule Core.Services.RolloutsTest do
     test "it will unlock locked module installations" do
       user = insert(:user)
       repo = insert(:repository)
-      inst = insert(:installation, repository: repo, user: user)
+      %{id: id} = inst = insert(:installation, repository: repo, user: user)
       cl = insert(:chart_installation, installation: inst, locked: true, chart: insert(:chart, repository: repo))
       tl = insert(:terraform_installation, installation: inst, locked: true, terraform: insert(:terraform, repository: repo))
 
@@ -17,8 +17,9 @@ defmodule Core.Services.RolloutsTest do
 
       refute refetch(cl).locked
       refute refetch(tl).locked
-
       assert refetch(ignore).locked
+
+      assert_receive {:event, %PubSub.InstallationUnlocked{item: %{id: ^id}}}
     end
   end
 

--- a/apps/core/test/services/upgrades_test.exs
+++ b/apps/core/test/services/upgrades_test.exs
@@ -115,6 +115,8 @@ defmodule Core.Services.UpgradesTest do
       assert deferred.version_id == version.id
       assert deferred.chart_installation_id == chart_inst.id
       assert deferred.dequeue_at
+
+      assert_receive {:event, %PubSub.DeferredUpdateCreated{item: ^deferred}}
     end
 
     test "it can create a deferred update for a terraform installation" do

--- a/apps/cron/lib/cron/digest/base.ex
+++ b/apps/cron/lib/cron/digest/base.ex
@@ -1,0 +1,34 @@
+defmodule Cron.Digest.Base do
+  alias Core.Schema.{Notification, User, Repository}
+
+  @doc """
+  Groups the digested notifications first by user then by repository.  After that compiles each repo group into a map
+  like:
+
+    repo -> count
+
+  where count is the number of notifications for that repo.  This can then be sent along the chain to future digest
+  emails.
+  """
+  @spec grouped([Notification.t]) :: Flow.t
+  def grouped(notifications, opts \\ []) do
+    Flow.from_enumerable(notifications, opts)
+    |> Flow.group_by(& &1.user_id)
+    |> Flow.map(fn {user_id, notifs} ->
+      notif_groups = Enum.group_by(notifs, & &1.repository_id)
+      compile(user_id, notif_groups)
+    end)
+  end
+
+  @doc """
+  Compiles information about a notification group into a format fit for digest emails.
+  """
+  @spec compile(binary, %{binary => [Notification.t]}) :: {User.t, [{Repository.t, integer}]}
+  def compile(user_id, notif_groups) do
+    user  = Core.Services.Users.get_user(user_id)
+    repos = Enum.map(notif_groups, fn {_repo_id, [%{repository: repo} | _] = notifs} ->
+      {repo, length(notifs)}
+    end)
+    {user, repos}
+  end
+end

--- a/apps/cron/lib/cron/digest/locked.ex
+++ b/apps/cron/lib/cron/digest/locked.ex
@@ -1,0 +1,19 @@
+defmodule Cron.Digest.Locked do
+  @moduledoc """
+  Wipes invites beyond the expiration time
+  """
+  use Cron
+  import Cron.Digest.Base
+  alias Core.Schema.Notification
+
+  def run() do
+    Notification.for_type(:locked)
+    |> Notification.ordered(asc: :user_id)
+    |> Notification.preloaded([:repository])
+    |> Core.Repo.all()
+    |> grouped(stages: 3)
+    |> Flow.map(fn {user, repos} -> Email.Builder.Digest.locked(user, repos) end)
+    |> Flow.map(&Core.Email.Mailer.deliver_now/1)
+    |> Flow.run()
+  end
+end

--- a/apps/cron/lib/cron/digest/pending.ex
+++ b/apps/cron/lib/cron/digest/pending.ex
@@ -1,0 +1,19 @@
+defmodule Cron.Digest.Pending do
+  @moduledoc """
+  Wipes invites beyond the expiration time
+  """
+  use Cron
+  import Cron.Digest.Base
+  alias Core.Schema.Notification
+
+  def run() do
+    Notification.for_type(:pending)
+    |> Notification.ordered(asc: :user_id)
+    |> Notification.preloaded([:repository])
+    |> Core.Repo.all()
+    |> grouped(stages: 3)
+    |> Flow.map(fn {user, repos} -> Email.Builder.Digest.pending(user, repos) end)
+    |> Flow.map(&Core.Email.Mailer.deliver_now/1)
+    |> Flow.run()
+  end
+end

--- a/apps/cron/test/cron/digest/locked_test.exs
+++ b/apps/cron/test/cron/digest/locked_test.exs
@@ -1,0 +1,24 @@
+defmodule Cron.Digest.LockedTest do
+  use Core.SchemaCase, async: false
+  use Bamboo.Test, shared: :true
+  import Cron.Digest.Base, only: [compile: 2]
+  alias Cron.Digest.Locked
+
+  describe "#run/0" do
+    test "it will prune old, unused upgrade queues" do
+      [user1, user2] = insert_list(2, :user)
+      notifs = for _ <- 1..3, do: insert(:notification, user: user1, repository: insert(:repository), type: :locked)
+      insert_list(2, :notification, user: user1, type: :pending)
+      notifs2 = for _ <- 1..2, do: insert(:notification, user: user2, repository: insert(:repository), type: :locked)
+      insert_list(3, :notification, type: :pending)
+
+      :ok = Locked.run()
+
+      {user, repos} = compile(user1.id, Enum.group_by(notifs, & &1.repository_id))
+      assert_delivered_email Email.Builder.Digest.locked(user, repos)
+
+      {user, repos} = compile(user2.id, Enum.group_by(notifs2, & &1.repository_id))
+      assert_delivered_email Email.Builder.Digest.locked(user, repos)
+    end
+  end
+end

--- a/apps/cron/test/cron/digest/pending_test.exs
+++ b/apps/cron/test/cron/digest/pending_test.exs
@@ -1,0 +1,24 @@
+defmodule Cron.Digest.PendingTest do
+  use Core.SchemaCase, async: false
+  use Bamboo.Test, shared: :true
+  import Cron.Digest.Base, only: [compile: 2]
+  alias Cron.Digest.Pending
+
+  describe "#run/0" do
+    test "it will prune old, unused upgrade queues" do
+      [user1, user2] = insert_list(2, :user)
+      notifs = for _ <- 1..3, do: insert(:notification, user: user1, repository: insert(:repository), type: :pending)
+      insert_list(2, :notification, user: user1, type: :locked)
+      notifs2 = for _ <- 1..2, do: insert(:notification, user: user2, repository: insert(:repository), type: :pending)
+      insert_list(3, :notification, type: :locked)
+
+      :ok = Pending.run()
+
+      {user, repos} = compile(user1.id, Enum.group_by(notifs, & &1.repository_id))
+      assert_delivered_email Email.Builder.Digest.pending(user, repos)
+
+      {user, repos} = compile(user2.id, Enum.group_by(notifs2, & &1.repository_id))
+      assert_delivered_email Email.Builder.Digest.pending(user, repos)
+    end
+  end
+end

--- a/apps/email/lib/email/builder/digest.ex
+++ b/apps/email/lib/email/builder/digest.ex
@@ -1,0 +1,21 @@
+defmodule Email.Builder.Digest do
+  use Email.Builder.Base
+
+  def pending(user, repositories) do
+    base_email()
+    |> to(expand_service_account(user))
+    |> subject("You have upgrades pending promotion")
+    |> assign(:user, user)
+    |> assign(:repos, repositories)
+    |> render(:pending_upgrades)
+  end
+
+  def locked(user, repositories) do
+    base_email()
+    |> to(expand_service_account(user))
+    |> subject("You have manual upgrades that have yet to be applied")
+    |> assign(:user, user)
+    |> assign(:repos, repositories)
+    |> render(:locked_upgrades)
+  end
+end

--- a/apps/email/lib/email/helper.ex
+++ b/apps/email/lib/email/helper.ex
@@ -1,5 +1,5 @@
 defmodule Email.Helper do
-  alias Core.Services.Users
+  alias Core.Services.{Users, Repositories}
   alias Core.Schema.User
 
   def confirm_email(email) do
@@ -13,4 +13,17 @@ defmodule Email.Helper do
     user = Users.get_user_by_email!(email)
     Users.create_reset_token(%{type: :password, email: user.email})
   end
+
+  def digest_email(type, email, repos) do
+    user = Users.get_user_by_email(email)
+    repos = Enum.map(repos, &Repositories.get_repository_by_name/1)
+
+    apply(Email.Builder.Digest, type, [user, Enum.map(repos, & {&1, 1})])
+    |> Core.Email.Mailer.deliver_now()
+  end
+
+  def create_publisher(name, %User{} = user), do: Users.create_publisher(%{name: name}, user)
+
+  def create_repo(name, %User{} = user),
+    do: Repositories.create_repository(%{name: name, category: :data}, user)
 end

--- a/apps/email/lib/email_web/templates/email/locked_upgrades.html.eex
+++ b/apps/email/lib/email_web/templates/email/locked_upgrades.html.eex
@@ -1,0 +1,23 @@
+<%= row do %>
+  <%= text do %>
+    You have <%= length(@repos) %> applications requiring manual upgrades, here's a breakdown of them:
+  <% end %>
+<% end %>
+<%= space() %>
+<%= row do %>
+  <%= for {repo, count} <- @repos do %>
+    <%= render "repo_panel.html", repo: repo, count: count, modifier: "manual upgrades to apply" %>
+  <% end %>
+<% end %>
+<%= space() %>
+<%= row do %>
+  <% text do %>
+    To apply manual upgrades, you'll need to run these commands in your git repo for each application,
+    replace APP with the name of each app:
+  <% end %>
+  <pre>
+  plural build --only APP
+  plural deploy --commit "applying breaking changes to APP"
+  plural repos unlock APP
+  </div>
+<% end %>

--- a/apps/email/lib/email_web/templates/email/locked_upgrades.text.eex
+++ b/apps/email/lib/email_web/templates/email/locked_upgrades.text.eex
@@ -1,0 +1,12 @@
+You have upgrades that must be applied manually, go to your git repository and apply the changes. We 
+
+<%= for {repo, _count} <- @repos do %>
+```
+plural build --only <%= repo.name %>
+plural deploy
+plural repos unlock <%= repo.name %>
+```
+
+<% end %>
+
+then once all have been applied, be sure to commit and push your changes

--- a/apps/email/lib/email_web/templates/email/pending_upgrades.html.eex
+++ b/apps/email/lib/email_web/templates/email/pending_upgrades.html.eex
@@ -1,0 +1,20 @@
+<%= row do %>
+  <%= text do %>
+    You have <%= length(@repos) %> applications pending promotion, here's a breakdown:
+  <% end %>
+<% end %>
+<%= space() %>
+<%= row do %>
+  <%= for {repo, count} <- @repos do %>
+    <%= render "repo_panel.html", repo: repo, count: count, modifier: "pending upgrades to promote" %>
+  <% end %>
+<% end %>
+<%= space() %>
+<%= row do %>
+  <%= text do %>
+    Click the button below to go to our multicluster management view and approve the promotion
+  <% end %>
+  <a class="button margin-top-large" href="<%= url("/overview/clusters") %>">
+    Promote
+  </a>
+<% end %>

--- a/apps/email/lib/email_web/templates/email/pending_upgrades.text.eex
+++ b/apps/email/lib/email_web/templates/email/pending_upgrades.text.eex
@@ -1,0 +1,6 @@
+You have upgrades pending promotion, go to <%= url("/overview/clusters") %> to manually promote them into your cluster
+
+A breakdown of changes pending:
+<%= for {repo, count} <- @repos do %>
+* <%= repo.name %> - <%= count %> upgrades
+<% end %>

--- a/apps/email/lib/email_web/templates/email/repo_panel.html.eex
+++ b/apps/email/lib/email_web/templates/email/repo_panel.html.eex
@@ -1,0 +1,19 @@
+<%= row do %>
+  <table>
+    <tr>
+      <td>
+        <%= repo_img repo: @repo %>
+      </td>
+      <td>
+        <%= text do %>
+          <%= @repo.name %>:
+        <% end %>
+      </td>
+      <td>
+        <%= text do %>
+          <%= @count %> <%= @modifier %>
+        <% end %>
+      </td>
+    </tr>
+  </table>
+<% end %>

--- a/apps/email/lib/email_web/templates/shared/image.html.eex
+++ b/apps/email/lib/email_web/templates/shared/image.html.eex
@@ -1,0 +1,1 @@
+<img src="<%= @url %>" alt="<%= @alt %>" height="<%= @height %>" width="<%= @width %>" />

--- a/apps/email/lib/email_web/views/email_view.ex
+++ b/apps/email/lib/email_web/views/email_view.ex
@@ -1,5 +1,6 @@
 defmodule EmailWeb.EmailView do
   use EmailWeb, :view
+  alias Core.Schema.Repository
 
   def url(path), do: "#{Email.conf(:host)}#{path}"
 
@@ -10,6 +11,36 @@ defmodule EmailWeb.EmailView do
   def btn(assigns \\ %{}, do: block), do: render_template("button.html", assigns, block)
 
   def space(assigns \\ %{}), do: EmailWeb.SharedView.render("space.html", Map.new(assigns))
+
+  def repo_img_url(%Repository{dark_icon: icon} = repo) when is_binary(icon),
+    do: Core.Storage.url({repo.dark_icon, repo}, :original)
+  def repo_img_url(%Repository{icon: icon} = repo) when is_binary(icon),
+    do: Core.Storage.url({repo.icon, repo}, :original)
+  def repo_img_url(_), do: nil
+
+  def repo_img(assigns \\ %{}) do
+    %{repo: repo} = assigns = Map.new(assigns) |> img_defaults()
+    case repo_img_url(repo) do
+      url when is_binary(url) ->
+        EmailWeb.SharedView.render("image.html", Map.put(assigns, :url, url))
+      _ -> ""
+    end
+  end
+
+  def img_url(item, key), do: Core.Storage.url({Map.get(item, key), item}, :original)
+
+  def img(assigns \\ %{}) do
+    assigns =
+      Map.new(assigns)
+      |> img_defaults()
+      |> Map.put(:url, img_url(assigns[:item], assigns[:key]))
+    EmailWeb.SharedView.render("image.html", assigns)
+  end
+
+  defp img_defaults(assigns) do
+    Map.put_new(assigns, :width, 50)
+    |> Map.put_new(:height, 50)
+  end
 
   defp render_template(template, assigns, block) do
     assigns =

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -59,6 +59,8 @@ config :joken,
     key_pem: pem
   ]
 
+config :piazza_core, aes_key: "1HdFP1DuK7xkkcEBne41yAwUY8NSfJnYfGVylYYCS2U="
+
 config :email, EmailWeb.Endpoint,
   http: [port: 4002],
   debug_errors: true,

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -61,7 +61,7 @@ release :worker do
   set applications: [
     :runtime_tools,
     worker: :permanent,
-    core: :permanent
+    core: :permanent,
   ]
 end
 

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -370,6 +370,7 @@ enum NotificationType {
   INCIDENT_UPDATE
   MENTION
   LOCKED
+  PENDING
 }
 
 enum OnboardingState {

--- a/www/src/generated/graphql.ts
+++ b/www/src/generated/graphql.ts
@@ -1629,7 +1629,8 @@ export enum NotificationType {
   IncidentUpdate = 'INCIDENT_UPDATE',
   Locked = 'LOCKED',
   Mention = 'MENTION',
-  Message = 'MESSAGE'
+  Message = 'MESSAGE',
+  Pending = 'PENDING'
 }
 
 export type OauthAttributes = {


### PR DESCRIPTION
## Summary

This will auto-create notifications and builds a digesting system to batch them into summary emails on a weekly cadence to users.  The goal is to help nudge people to apply promotions or manual changes as best we can.

## Test Plan
unit tests, confirmed emails look ok locally as well


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.