### PR TITLE
Allow group_ids for updateUser to be a full sync

### DIFF
--- a/apps/core/test/services/users_test.exs
+++ b/apps/core/test/services/users_test.exs
@@ -140,6 +140,7 @@ defmodule Core.Services.UsersTest do
       %{account: account} = Core.Repo.preload(user, [:account])
       groups = insert_list(3, :group, account: account)
       %{group: group} = insert(:group_member, user: user, group: build(:group, account: account))
+      rm = insert(:group_member, user: user, group: build(:group, account: account))
       admin = insert(:user, account: account, roles: %{admin: true})
 
       {:ok, updated} = Users.update_user(%{
@@ -157,6 +158,8 @@ defmodule Core.Services.UsersTest do
 
       for g <- [group | groups],
         do: assert member?(user, g)
+
+      refute member?(user, rm.group)
     end
 
     test "nonadmins cannot update users" do


### PR DESCRIPTION
## Summary
This is apparently the expected behavior for the modal.

## Test Plan
unit


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.