### PR TITLE
fix: Marketplace search field coverd by page content

### DIFF
--- a/www/src/components/marketplace/MarketplaceRepositories.tsx
+++ b/www/src/components/marketplace/MarketplaceRepositories.tsx
@@ -264,6 +264,7 @@ function MarketplaceRepositories({ publisher }: { publisher?: any }) {
                 position="sticky"
                 top="0"
                 backgroundColor="fill-zero"
+                zIndex={1}
               >
                 <Flex gap="small">
                   <SearchBar


### PR DESCRIPTION
The sticky search field is hidden by the page content when you scroll down. Fixed by setting z-index on search area.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205326690071012