### PR TITLE
Use `sysbox-runc` as runtime class for sysbox shells

### DIFF
--- a/apps/core/lib/core/services/shell/pods.ex
+++ b/apps/core/lib/core/services/shell/pods.ex
@@ -57,7 +57,7 @@ defmodule Core.Services.Shell.Pods do
 
   def pod(name, email) do
     runtime = cri(email)
-    containers = [container() | (if runtime == "sysbox", do: [dind_container()], else: [])]
+    containers = [container() | (if runtime == "sysbox-runc", do: [dind_container()], else: [])]
 
     %CoreV1.Pod{
       metadata: %MetaV1.ObjectMeta{
@@ -79,10 +79,10 @@ defmodule Core.Services.Shell.Pods do
     }
   end
 
-  defp node_selector("sysbox"), do: %{"sysbox-runtime" => "running"}
+  defp node_selector("sysbox-runc"), do: %{"sysbox-runtime" => "running"}
   defp node_selector(_), do: %{"platform.plural.sh/instance-class" => "shell"}
 
-  defp toleration("sysbox") do
+  defp toleration("sysbox-runc") do
     %CoreV1.Toleration{
       value: "true",
       key: "plural.sh/sysbox",
@@ -99,8 +99,8 @@ defmodule Core.Services.Shell.Pods do
 
   defp cri(email) do
     case Core.conf(:sysbox_emails) do
-      ["*"] -> "sysbox"
-      [_ | _] = emails -> if email in emails, do: "sysbox", else: nil
+      ["*"] -> "sysbox-runc"
+      [_ | _] = emails -> if email in emails, do: "sysbox-runc", else: nil
       _ -> nil
     end
   end
@@ -157,7 +157,7 @@ defmodule Core.Services.Shell.Pods do
     }
   end
 
-  defp volumes("sysbox"), do: [%CoreV1.Volume{name: "docker", empty_dir: %CoreV1.EmptyDirVolumeSource{}}]
+  defp volumes("sysbox-runc"), do: [%CoreV1.Volume{name: "docker", empty_dir: %CoreV1.EmptyDirVolumeSource{}}]
   defp volumes(_), do: []
 
   defp healthcheck() do

--- a/apps/core/test/services/shell/pods_test.exs
+++ b/apps/core/test/services/shell/pods_test.exs
@@ -18,7 +18,7 @@ defmodule Core.Shell.PodsTest do
     test "a whitelisted user gets the sysbox class" do
       %{spec: %{volumes: [volume]}} = pod = Pods.pod("plrl-shell-1", "sysbox@plural.sh")
 
-      assert pod.spec.runtime_class_name == "sysbox"
+      assert pod.spec.runtime_class_name == "sysbox-runc"
       assert pod.spec.node_selector["sysbox-runtime"] == "running"
 
       assert volume.name == "docker"


### PR DESCRIPTION
## Summary
Apparently that's the name we need to use for this, so minor change

## Test Plan
unit


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.