### PR TITLE
fix: default version of azure provider

### DIFF
--- a/apps/core/priv/scaffolds/terraform/providers/azure.eex
+++ b/apps/core/priv/scaffolds/terraform/providers/azure.eex
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "2.57.0"
+      version = "~> 3.70.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Summary
For some reason the default provider version changed from `~> 3.22` back to what was actually defined `2.57.0`. This PR changes the default version of the azure provider to `~> 3.70.0`.

There do seem to be some issues with terraform needing to run `terraform init -reconfigure`, but I'm not sure if that is due to the first attempt where the provider got downgraded or not. We might need to do some additional testing.