### PR TITLE
Add shell uniqueness detection

### DIFF
--- a/apps/core/lib/core/schema/cloud_shell.ex
+++ b/apps/core/lib/core/schema/cloud_shell.ex
@@ -1,6 +1,6 @@
 defmodule Core.Schema.CloudShell do
   use Piazza.Ecto.Schema
-  alias Piazza.Ecto.EncryptedString
+  alias Piazza.Ecto.{EncryptedString, Types.Erlang}
   alias Core.Schema.{User, Dependencies.Provider, DemoProject}
 
   defmodule Workspace do
@@ -128,6 +128,7 @@ defmodule Core.Schema.CloudShell do
     field :aes_key,         EncryptedString
     field :ssh_public_key,  EncryptedString
     field :ssh_private_key, EncryptedString
+    field :owner_pid,       Erlang
     field :bucket_prefix,   :string
     field :missing,         {:array, :string}, virtual: true
 
@@ -168,6 +169,12 @@ defmodule Core.Schema.CloudShell do
     |> put_new_change(:aes_key, &aes_key/0)
     |> validate_required([:provider, :pod_name, :aes_key])
     |> mv_bucket_prefix()
+  end
+
+  def pid_changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, ~w(owner_pid)a)
+    |> validate_required([:owner_pid])
   end
 
   def update_changeset(model, attrs \\ %{}) do

--- a/apps/core/lib/core/services/shell/pods.ex
+++ b/apps/core/lib/core/services/shell/pods.ex
@@ -103,6 +103,14 @@ defmodule Core.Services.Shell.Pods do
     }
   end
 
+  def new_cri?(email) do
+    case Core.conf(:sysbox_emails) do
+      ["*"] -> true
+      [_ | _] = emails -> if email in emails, do: true, else: false
+      _ -> false
+    end
+  end
+
   defp cri(email) do
     case Core.conf(:sysbox_emails) do
       ["*"] -> "sysbox-runc"

--- a/apps/core/priv/repo/migrations/20230906192008_shell_owner.exs
+++ b/apps/core/priv/repo/migrations/20230906192008_shell_owner.exs
@@ -1,0 +1,9 @@
+defmodule Core.Repo.Migrations.ShellOwner do
+  use Ecto.Migration
+
+  def change do
+    alter table(:cloud_shells) do
+      add :owner_pid, :binary
+    end
+  end
+end

--- a/apps/rtc/lib/rtc_web/channels/shell_channel.ex
+++ b/apps/rtc/lib/rtc_web/channels/shell_channel.ex
@@ -1,19 +1,19 @@
 defmodule RtcWeb.ShellChannel do
   use RtcWeb, :channel
   alias Core.Services.{Shell.Pods, Shell}
-  alias Core.Schema.CloudShell
+  alias Core.Schema.{CloudShell, User}
 
   require Logger
 
   def join("shells:me", _, socket) do
-    with %CloudShell{pod_name: name} <- Shell.get_shell(socket.assigns.user.id),
-         url <- Pods.PodExec.exec_url(name),
-         {:ok, pid} <- Pods.PodExec.start_link(url, self()) do
+    with %CloudShell{pod_name: name} = shell <- Shell.get_shell(socket.assigns.user.id),
+         {:ok, socket} <- gated_available(shell, socket, socket.assigns.user),
+         {:ok, pid} <- exec_pod(name, socket) do
       {:ok, assign(socket, :wss_pid, pid)}
     else
       err ->
         Logger.info "failed to exec pod with #{inspect(err)}"
-        {:error, %{reason: inspect(err)}}
+        {:error, %{reason: format(err)}}
     end
   end
 
@@ -32,6 +32,52 @@ defmodule RtcWeb.ShellChannel do
     {:reply, :ok, socket}
   end
 
+  defp exec_pod(_, %{assigns: %{wss_pid: pid}}) when is_pid(pid), do: {:ok, pid}
+  defp exec_pod(name, _) do
+    Pods.PodExec.exec_url(name)
+    |> Pods.PodExec.start_link(self())
+  end
+
+  defp gated_available(shell, socket, %User{email: email}) do
+    # just use this for now to control end-to-end testing
+    case Core.Services.Shell.Pods.new_cri?(email) do
+      true -> available(shell, socket)
+      false -> {:ok, socket}
+    end
+  end
+
+  defp available(%CloudShell{owner_pid: pid}, %{assigns: %{owner_pid: pid}} = socket), do: {:ok, socket}
+  defp available(%CloudShell{owner_pid: {_, _} = pid} = shell, socket) do
+    case alive?(pid) do
+      true -> "cloud shell already taken by another window"
+      _ -> write_pid(shell, socket)
+    end
+  end
+  defp available(%CloudShell{} = shell, socket), do: write_pid(shell, socket)
+
+  defp me(), do: {node(), self()}
+
+  defp write_pid(%CloudShell{} = shell, socket)  do
+    CloudShell.pid_changeset(shell, %{owner_pid: me()})
+    |> Core.Repo.update()
+    |> case do
+      {:ok, %CloudShell{owner_pid: pid}} -> {:ok, assign(socket, :owner_pid, pid)}
+      error -> error
+    end
+  end
+
+  defp alive?({:nonode@nohost, pid}), do: Process.alive?(pid)
+  defp alive?({node, pid}) do
+    case Node.ping(node) do
+      :pong -> :rpc.call(node, Process, :alive?, [pid])
+      _ -> false
+    end
+  end
+
   defp fmt_cmd(cmd) when is_binary(cmd), do: cmd
   defp fmt_cmd(cmd) when is_list(cmd), do: Enum.join(cmd, " ")
+
+  defp format(err) when is_binary(err), do: err
+  defp format({:error, err}), do: "error: #{inspect(err)}"
+  defp format(err), do: inspect(err)
 end


### PR DESCRIPTION
## Summary

Some terminal session managers behave strangely when there are too many clients contending for a session, this should add relatively robust checks for that.  There are a few cases:

1.  A websocket networks to a running channel process in-cluster, in that case we should detect it already has a wss established and not connect again.
2.  A websocket creates an entirely fresh channel somewhere in-cluster and there's already a live process elsewhere, we can rpc to that node check if its alive, then bail if so.
3.  A websocket creates a fresh channel, but the adjacent process has died.  We will detect this by either seeing its node died or an rpc to a live node w/o that process fails to see the process there.

Also added a feature gate like we have for sysbox to test end-to-end

## Test Plan
some unit tests, need end to end tests to really verify though


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.