### PR TITLE
chore: update CLI version used by Plural

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV HELM_VERSION=v3.11.0
 ENV GOON_VERSION=v1.1.1
 
 # renovate: datasource=github-releases depName=pluralsh/plural-cli
-ENV CLI_VERSION=v0.5.34
+ENV CLI_VERSION=v0.7.6
 
 # renovate: datasource=github-releases depName=accurics/terrascan
 ENV TERRASCAN_VERSION=v1.17.1


### PR DESCRIPTION
## Summary
This PR updates the CLI version used by Plural to the latest release. This is needed as pushing charts with the new `chartInstalled` template function currently fail (see https://github.com/pluralsh/plural-artifacts/actions/runs/6159915713/job/16715910451).