### PR TITLE
chore(deps): bump cli to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV HELM_VERSION=v3.11.0
 ENV GOON_VERSION=v1.1.1
 
 # renovate: datasource=github-releases depName=pluralsh/plural-cli
-ENV CLI_VERSION=v0.7.6
+ENV CLI_VERSION=v0.7.7
 
 # renovate: datasource=github-releases depName=accurics/terrascan
 ENV TERRASCAN_VERSION=v1.17.1


### PR DESCRIPTION
## Summary
This PR bumps the CLI version to one that should solve the problem with the template function which we use for server-side validation and to find all the container image dependencies.