### PR TITLE
fix: use the console version of the CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN apk add --update --no-cache curl ca-certificates unzip wget openssl && \
     curl -L https://github.com/alco/goon/releases/download/${GOON_VERSION}/goon_linux_${TARGETARCH}.tar.gz | tar xvz && \
     mv goon /usr/local/bin/goon && \
     # download plural cli
-    curl -L https://github.com/pluralsh/plural-cli/releases/download/${CLI_VERSION}/plural-cli_${CLI_VERSION/v/}_Linux_${TARGETARCH}.tar.gz | tar xvz plural && \
+    curl -L https://github.com/pluralsh/plural-cli/releases/download/${CLI_VERSION}/plural-cli_console_${CLI_VERSION/v/}_Linux_${TARGETARCH}.tar.gz | tar xvz plural && \
     mv plural /usr/local/bin/plural && \
     # download terrascan
     if [ "$TARGETARCH" = "amd64" ]; then \


### PR DESCRIPTION
## Summary
This PR ensures the "console" version of the CLI is installed within Plural. This is a good example of how quickly adding something without fully thinking it through can have (many) unexpected down stream consequences and break things.