### PR TITLE
Query DNS before finalizing cloud instances

### DIFF
--- a/apps/core/lib/core/schema/console_instance.ex
+++ b/apps/core/lib/core/schema/console_instance.ex
@@ -86,6 +86,10 @@ defmodule Core.Schema.ConsoleInstance do
     )
   end
 
+  def provisioned(query \\ __MODULE__) do
+    from(c in query, where: c.status == ^:provisioned)
+  end
+
   def ordered(query \\ __MODULE__, order \\ [asc: :name]) do
     from(c in query, order_by: ^order)
   end


### PR DESCRIPTION
There's some lag to externaldns registering for an ingress that could cause user-facing goofiness, just query dns until it resolves to wait for that to dissipate.


## Test Plan
existing test still works

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.