### PR TITLE
Fix sso login

### DIFF
--- a/apps/core/lib/core/services/users.ex
+++ b/apps/core/lib/core/services/users.ex
@@ -367,13 +367,13 @@ defmodule Core.Services.Users do
   """
   @spec bootstrap_user(Core.OAuth.method, map) :: user_resp
   def bootstrap_user(service, %{email: email} = attrs) do
-    case get_user_by_email(email) do
-      nil ->
+    case {service, get_user_by_email(email)} do
+      {_, nil} ->
         attrs
         |> Map.merge(login_args(service))
         |> Map.put(:password, Ecto.UUID.generate())
         |> create_user()
-      %User{login_method: ^service} = user ->
+      {service, %User{login_method: svc} = user} when service == :sso or service == svc ->
         update_user(login_args(service), user)
       _ -> {:error, "you don't have login with #{service} enabled"}
     end

--- a/apps/core/test/services/users_test.exs
+++ b/apps/core/test/services/users_test.exs
@@ -514,7 +514,7 @@ defmodule Core.Services.UsersTest do
     end
   end
 
-  describe "#bootstrap_users/2" do
+  describe "#bootstrap_user/2" do
     test "it will create new users and set login method" do
       {:ok, user} = Users.bootstrap_user(:google, %{email: "someone@gmail.com", name: "New User"})
 
@@ -532,10 +532,18 @@ defmodule Core.Services.UsersTest do
       assert upd.login_method == :google
     end
 
-    test "it will not allow logins w/o login method set" do
+    test "it will not allow logins w/o correct login method set" do
       user = insert(:user)
 
       {:error, _} = Users.bootstrap_user(:google, %{email: user.email})
+    end
+
+    test "it will allow sso logins w/ whatever login method set" do
+      user = insert(:user)
+
+      {:ok, upd} = Users.bootstrap_user(:sso, %{email: user.email})
+
+      assert upd.id == user.id
     end
   end
 

--- a/apps/graphql/test/mutations/user_mutation_test.exs
+++ b/apps/graphql/test/mutations/user_mutation_test.exs
@@ -50,7 +50,7 @@ defmodule GraphQl.UserMutationTest do
     end
 
     test "it will fail on invalid captchas" do
-      {:ok, user} = Users.create_user(%{
+      {:ok, _} = Users.create_user(%{
         name: "Michael Guarino",
         email: "mjg@plural.sh",
         password: "super strong password"


### PR DESCRIPTION
The login method validation technically fails for SSO (which means us lol).  We can trust that login source better than other 3p auth providers so don't validate login method there.


## Test Plan
unit test

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.