### PR TITLE
Don't allow url based uploads

### DIFF
--- a/apps/core/lib/core/schema/account.ex
+++ b/apps/core/lib/core/schema/account.ex
@@ -63,7 +63,7 @@ defmodule Core.Schema.Account do
     |> unique_constraint(:name)
     |> validate_required([:name])
     |> generate_uuid(:icon_id)
-    |> cast_attachments(attrs, [:icon], allow_urls: true)
+    |> cast_attachments(attrs, [:icon])
     |> set_address_updated()
     |> reject_urls(:name)
   end

--- a/apps/core/lib/core/schema/artifact.ex
+++ b/apps/core/lib/core/schema/artifact.ex
@@ -34,7 +34,7 @@ defmodule Core.Schema.Artifact do
     |> validate_required([:name, :platform, :type, :arch])
     |> foreign_key_constraint(:repository_id)
     |> unique_constraint(:repository_id, name: index_name(:artifacts, [:repository_id, :name, :platform, :arch]))
-    |> cast_attachments(attrs, [:blob], allow_urls: true)
+    |> cast_attachments(attrs, [:blob])
     |> add_sha(attrs)
     |> add_filesize(attrs)
   end

--- a/apps/core/lib/core/schema/crd.ex
+++ b/apps/core/lib/core/schema/crd.ex
@@ -21,7 +21,7 @@ defmodule Core.Schema.Crd do
     |> generate_uuid(:blob_id)
     |> foreign_key_constraint(:version_id)
     |> unique_constraint(:name, name: index_name(:crds, [:version_id, :name]))
-    |> cast_attachments(attrs, [:blob], allow_urls: true)
+    |> cast_attachments(attrs, [:blob])
     |> validate_required([:name, :version_id])
   end
 end

--- a/apps/core/lib/core/schema/file.ex
+++ b/apps/core/lib/core/schema/file.ex
@@ -39,7 +39,7 @@ defmodule Core.Schema.File do
     model
     |> cast(attrs, @valid)
     |> generate_uuid(:blob_id)
-    |> cast_attachments(attrs, [:blob], allow_urls: true)
+    |> cast_attachments(attrs, [:blob])
     |> foreign_key_constraint(:message_id)
     |> put_change(:filename, filename(upload))
     |> put_change(:filesize, file_size(upload))

--- a/apps/core/lib/core/schema/integration.ex
+++ b/apps/core/lib/core/schema/integration.ex
@@ -51,7 +51,7 @@ defmodule Core.Schema.Integration do
     |> foreign_key_constraint(:repository_id)
     |> unique_constraint(:name, name: index_name(:integrations, [:repository_id, :name]))
     |> generate_uuid(:icon_id)
-    |> cast_attachments(attrs, [:icon], allow_urls: true)
+    |> cast_attachments(attrs, [:icon])
     |> validate_required([:name, :spec])
   end
 

--- a/apps/core/lib/core/schema/publisher.ex
+++ b/apps/core/lib/core/schema/publisher.ex
@@ -75,7 +75,7 @@ defmodule Core.Schema.Publisher do
     |> unique_constraint(:owner_id)
     |> validate_length(:name, max: 255)
     |> generate_uuid(:avatar_id)
-    |> cast_attachments(attrs, [:avatar], allow_urls: true)
+    |> cast_attachments(attrs, [:avatar])
   end
 
   @stripe_valid ~w(billing_account_id)a

--- a/apps/core/lib/core/schema/repository.ex
+++ b/apps/core/lib/core/schema/repository.ex
@@ -232,7 +232,7 @@ defmodule Core.Schema.Repository do
     |> unique_constraint(:name)
     |> validate_required([:name, :category])
     |> generate_uuid(:icon_id)
-    |> cast_attachments(attrs, [:icon, :dark_icon, :docs], allow_urls: true)
+    |> cast_attachments(attrs, [:icon, :dark_icon, :docs])
   end
 
   @keyvalid ~w(public_key private_key)a

--- a/apps/core/lib/core/schema/terraform.ex
+++ b/apps/core/lib/core/schema/terraform.ex
@@ -49,7 +49,7 @@ defmodule Core.Schema.Terraform do
     |> unique_constraint(:name, name: index_name(:terraform, [:repository_id, :name]))
     |> foreign_key_constraint(:repository_id)
     |> bump_version(schema)
-    |> cast_attachments(attrs, [:package], allow_urls: true)
+    |> cast_attachments(attrs, [:package])
     |> validate_required([:name, :repository_id])
   end
 

--- a/apps/core/lib/core/schema/user.ex
+++ b/apps/core/lib/core/schema/user.ex
@@ -90,6 +90,10 @@ defmodule Core.Schema.User do
     timestamps()
   end
 
+  def mark_url_safe(), do: Process.put({__MODULE__, :url_safe}, true)
+
+  def url_safe?(), do: !!Process.get({__MODULE__, :url_safe})
+
   def intercom_id(%__MODULE__{id: id}), do: Core.sha("#{id}:#{Core.conf(:intercom_salt)}")
 
   def service_account(query \\ __MODULE__, is_svc \\ :yes)
@@ -209,7 +213,7 @@ defmodule Core.Schema.User do
     |> hash_password()
     |> generate_uuid(:avatar_id)
     |> change_markers(password_hash: :password_change)
-    |> cast_attachments(attrs, [:avatar], allow_urls: true)
+    |> cast_attachments(attrs, [:avatar], (if url_safe?(), do: [allow_urls: true], else: []))
     |> set_email_changed()
     |> reject_passwordless()
   end

--- a/apps/core/lib/core/schema/version.ex
+++ b/apps/core/lib/core/schema/version.ex
@@ -59,7 +59,7 @@ defmodule Core.Schema.Version do
     |> cast_assoc(:tags)
     |> validate_required([:version])
     |> generate_uuid(:package_id)
-    |> cast_attachments(attrs, [:package], allow_urls: true)
+    |> cast_attachments(attrs, [:package])
     |> unique_constraint(:chart_id, name: index_name(:versions, [:chart_id, :version]))
     |> unique_constraint(:terraform_id, name: index_name(:versions, [:terraform_id, :version]))
     |> foreign_key_constraint(:chart_id)

--- a/apps/core/lib/core/services/users.ex
+++ b/apps/core/lib/core/services/users.ex
@@ -367,6 +367,7 @@ defmodule Core.Services.Users do
   """
   @spec bootstrap_user(Core.OAuth.method, map) :: user_resp
   def bootstrap_user(service, %{email: email} = attrs) do
+    User.mark_url_safe()
     case {service, get_user_by_email(email)} do
       {_, nil} ->
         attrs


### PR DESCRIPTION
This is technically somewhat insecure (not that bad, since requests are auto-ignored if not jpeg/png files).  Should also think of a way to refactor the avatar upload out of the oidc login path entirely, and move it async, just not a priority.


## Test Plan
regression

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.