### PR TITLE
Implement user-bound oidc providers

### DIFF
--- a/apps/core/lib/core/policies/oauth.ex
+++ b/apps/core/lib/core/policies/oauth.ex
@@ -1,0 +1,11 @@
+defmodule Core.Policies.OAuth do
+  use Piazza.Policy
+  alias Core.Schema.{User, OIDCProvider}
+
+  def can?(%User{id: id}, %OIDCProvider{owner_id: id}, _), do: :pass
+
+  def can?(user, %Ecto.Changeset{} = cs, action),
+    do: can?(user, apply_changes(cs), action)
+
+  def can?(_, _, _), do: {:error, :forbidden}
+end

--- a/apps/core/lib/core/schema/oidc_provider.ex
+++ b/apps/core/lib/core/schema/oidc_provider.ex
@@ -1,10 +1,12 @@
 defmodule Core.Schema.OIDCProvider do
   use Piazza.Ecto.Schema
-  alias Core.Schema.{Installation, OIDCProviderBinding, Invite}
+  alias Core.Schema.{Installation, OIDCProviderBinding, Invite, User}
 
   defenum AuthMethod, post: 0, basic: 1
 
   schema "oidc_providers" do
+    field :name,              :string
+    field :description,       :string
     field :client_id,         :string
     field :client_secret,     :string
     field :redirect_uris,     {:array, :string}
@@ -14,6 +16,7 @@ defmodule Core.Schema.OIDCProvider do
     field :login,             :map, virtual: true
 
     belongs_to :installation, Installation
+    belongs_to :owner,        User
 
     has_many :invites, Invite, foreign_key: :oidc_provider_id
     has_many :bindings, OIDCProviderBinding,
@@ -23,7 +26,15 @@ defmodule Core.Schema.OIDCProvider do
     timestamps()
   end
 
-  @valid ~w(client_id client_secret installation_id redirect_uris auth_method)a
+  def for_owner(query \\ __MODULE__, owner_id) do
+    from(p in query, where: p.owner_id == ^owner_id)
+  end
+
+  def ordered(query \\ __MODULE__, order \\ [asc: :name]) do
+    from(p in query, order_by: ^order)
+  end
+
+  @valid ~w(name description client_id client_secret owner_id installation_id redirect_uris auth_method)a
 
   def changeset(model, attrs \\ %{}) do
     model
@@ -32,5 +43,6 @@ defmodule Core.Schema.OIDCProvider do
     |> unique_constraint(:installation_id)
     |> unique_constraint(:client_id)
     |> foreign_key_constraint(:installation_id)
+    |> foreign_key_constraint(:owner_id)
   end
 end

--- a/apps/core/lib/core/services/base.ex
+++ b/apps/core/lib/core/services/base.ex
@@ -1,12 +1,24 @@
 defmodule Core.Services.Base do
+  alias Core.Schema.User
+
   defmacro __using__(_) do
     quote do
       import Core.Services.Base
+      alias Core.Repo
 
       defp conf(key),
         do: Application.get_env(:core, __MODULE__)[key]
     end
   end
+
+  def find_bindings(%User{service_account: true} = user) do
+    case Core.Repo.preload(user, impersonation_policy: :bindings) do
+      %{impersonation_policy: %{bindings: [_ | _] = bindings}} ->
+        Enum.map(bindings, &Map.take(&1, [:group_id, :user_id]))
+      _ -> []
+    end
+  end
+  def find_bindings(_), do: []
 
   def ok(val), do: {:ok, val}
 

--- a/apps/core/lib/core/services/repositories.ex
+++ b/apps/core/lib/core/services/repositories.ex
@@ -575,15 +575,6 @@ defmodule Core.Services.Repositories do
     Map.put(attrs, :bindings, bindings)
   end
 
-  defp find_bindings(%User{service_account: true} = user) do
-    case Core.Repo.preload(user, impersonation_policy: :bindings) do
-      %{impersonation_policy: %{bindings: [_ | _] = bindings}} ->
-        Enum.map(bindings, &Map.take(&1, [:group_id, :user_id]))
-      _ -> []
-    end
-  end
-  defp find_bindings(_), do: []
-
   @doc """
   Inserts or updates the oidc provider for an installation
   """

--- a/apps/core/priv/repo/migrations/20241005171529_add_owner_id_oidc_provider.exs
+++ b/apps/core/priv/repo/migrations/20241005171529_add_owner_id_oidc_provider.exs
@@ -1,0 +1,11 @@
+defmodule Core.Repo.Migrations.AddOwnerIdOidcProvider do
+  use Ecto.Migration
+
+  def change do
+    alter table(:oidc_providers) do
+      add :name,        :string
+      add :description, :string
+      add :owner_id,    references(:users, type: :uuid, on_delete: :delete_all)
+    end
+  end
+end

--- a/apps/core/test/services/oauth_test.exs
+++ b/apps/core/test/services/oauth_test.exs
@@ -4,6 +4,81 @@ defmodule Core.Services.OAuthTest do
   alias Core.Schema.OIDCLogin
   use Mimic
 
+  describe "#create_oidc_provider/2" do
+    test "a user can create an oidc provider" do
+      account = insert(:account)
+      group = insert(:group, account: account)
+      expect(HTTPoison, :post, fn _, _, _ ->
+        {:ok, %{status_code: 200, body: Jason.encode!(%{client_id: "123", client_secret: "secret"})}}
+      end)
+      user = insert(:user)
+
+      {:ok, oidc} = OAuth.create_oidc_provider(%{
+        redirect_uris: ["https://example.com"],
+        auth_method: :basic,
+        bindings: [%{user_id: user.id}, %{group_id: group.id}]
+      }, user)
+
+      assert oidc.client_id == "123"
+      assert oidc.client_secret == "secret"
+      assert oidc.redirect_uris == ["https://example.com"]
+      assert oidc.owner_id == user.id
+
+      [first, second] = oidc.bindings
+
+      assert first.user_id == user.id
+      assert second.group_id == group.id
+    end
+  end
+
+  describe "#update_oidc_provider/2" do
+    test "you can update your own providers" do
+      user = insert(:user)
+      oidc = insert(:oidc_provider, owner: user)
+      expect(HTTPoison, :put, fn _, _, _ ->
+        {:ok, %{status_code: 200, body: Jason.encode!(%{client_id: "123", client_secret: "secret"})}}
+      end)
+
+      {:ok, updated} = OAuth.update_oidc_provider(%{
+        redirect_uris: ["https://example.com"],
+        auth_method: :basic
+      }, oidc.id, user)
+
+      assert updated.id == oidc.id
+      assert updated.auth_method == :basic
+    end
+
+    test "others cannot update your provider" do
+      user = insert(:user)
+      oidc = insert(:oidc_provider, owner: user)
+
+      {:error, :forbidden} = OAuth.update_oidc_provider(%{
+        redirect_uris: ["https://example.com"],
+        auth_method: :basic
+      }, oidc.id, insert(:user))
+    end
+  end
+
+  describe "#delete_oidc_provider/2" do
+    test "you can delete your own providers" do
+      user = insert(:user)
+      oidc = insert(:oidc_provider, owner: user)
+      expect(HTTPoison, :delete, fn _, _ -> {:ok, %{status_code: 204, body: ""}} end)
+
+      {:ok, deleted} = OAuth.delete_oidc_provider(oidc.id, user)
+
+      assert deleted.id == oidc.id
+      refute refetch(deleted)
+    end
+
+    test "others cannot delete your provider" do
+      user = insert(:user)
+      oidc = insert(:oidc_provider, owner: user)
+
+      {:error, :forbidden} = OAuth.delete_oidc_provider(oidc.id, insert(:user))
+    end
+  end
+
   describe "#get_login/1" do
     test "It can get information related to an oauth login" do
       provider = insert(:oidc_provider)

--- a/apps/graphql/lib/graphql/resolvers/oauth.ex
+++ b/apps/graphql/lib/graphql/resolvers/oauth.ex
@@ -1,6 +1,6 @@
 defmodule GraphQl.Resolvers.OAuth do
   use GraphQl.Resolvers.Base, model: Core.Schema.OIDCProvider
-  alias Core.Schema.OIDCLogin
+  alias Core.Schema.{OIDCLogin, OIDCProvider}
   alias Core.Services.{OAuth, Users}
   alias Core.OAuth, as: OAuthHandler
   alias GraphQl.Resolvers.User
@@ -8,6 +8,12 @@ defmodule GraphQl.Resolvers.OAuth do
   def list_logins(args, %{context: %{current_user: %{account_id: aid}}}) do
     OIDCLogin.for_account(aid)
     |> OIDCLogin.ordered()
+    |> paginate(args)
+  end
+
+  def list_oidc_providers(args, %{context: %{current_user: user}}) do
+    OIDCProvider.for_owner(user.id)
+    |> OIDCProvider.ordered()
     |> paginate(args)
   end
 

--- a/apps/graphql/lib/graphql/resolvers/repository.ex
+++ b/apps/graphql/lib/graphql/resolvers/repository.ex
@@ -1,6 +1,6 @@
 defmodule GraphQl.Resolvers.Repository do
   use GraphQl.Resolvers.Base, model: Core.Schema.Repository
-  alias Core.Services.{Repositories, Users}
+  alias Core.Services.{Repositories, Users, OAuth}
   alias Core.Schema.{
     Installation,
     Integration,
@@ -205,14 +205,22 @@ defmodule GraphQl.Resolvers.Repository do
   def reset_installations(_, %{context: %{current_user: user}}),
     do: Repositories.reset_installations(user)
 
-  def create_oidc_provider(%{attributes: attrs, installation_id: id}, %{context: %{current_user: user}}),
-    do: Repositories.create_oidc_provider(attrs, id, user)
+  def create_oidc_provider(%{attributes: attrs, installation_id: id}, %{context: %{current_user: user}})
+    when is_binary(id), do: Repositories.create_oidc_provider(attrs, id, user)
+  def create_oidc_provider(%{attributes: attrs}, %{context: %{current_user: user}}),
+    do: OAuth.create_oidc_provider(attrs, user)
 
-  def update_oidc_provider(%{attributes: attrs, installation_id: id}, %{context: %{current_user: user}}),
-    do: Repositories.update_oidc_provider(attrs, id, user)
+  def update_oidc_provider(%{attributes: attrs, installation_id: id}, %{context: %{current_user: user}})
+    when is_binary(id), do: Repositories.update_oidc_provider(attrs, id, user)
+  def update_oidc_provider(%{attributes: attrs, id: id}, %{context: %{current_user: user}})
+    when is_binary(id), do: OAuth.update_oidc_provider(attrs, id, user)
+  def update_oidc_provider(_, _), do: {:error, "you must provide either id or installation id"}
 
   def upsert_oidc_provider(%{attributes: attrs, installation_id: id}, %{context: %{current_user: user}}),
     do: Repositories.upsert_oidc_provider(attrs, id, user)
+
+  def delete_oidc_provider(%{id: id}, %{context: %{current_user: user}})
+    when is_binary(id), do: OAuth.delete_oidc_provider(id, user)
 
   def create_artifact(%{repository_id: repo_id, attributes: attrs}, %{context: %{current_user: user}}),
     do: Repositories.create_artifact(attrs, repo_id, user)

--- a/apps/graphql/lib/graphql/schema/oauth.ex
+++ b/apps/graphql/lib/graphql/schema/oauth.ex
@@ -100,6 +100,12 @@ defmodule GraphQl.Schema.OAuth do
 
       resolve &OAuth.login_metrics/2
     end
+
+    connection field :oidc_providers, node_type: :oidc_provider do
+      middleware Authenticated
+
+      safe_resolve &OAuth.list_oidc_providers/2
+    end
   end
 
   object :oauth_mutations do

--- a/apps/graphql/test/queries/oauth_queries_test.exs
+++ b/apps/graphql/test/queries/oauth_queries_test.exs
@@ -3,6 +3,27 @@ defmodule GraphQl.OAuthQueriesTest do
   import GraphQl.TestHelpers
   use Mimic
 
+  describe "oidcProviders" do
+    test "it will list oidc providers" do
+      user = insert(:user)
+      providers = insert_list(3, :oidc_provider, owner: user)
+      insert_list(2, :oidc_provider)
+
+      {:ok, %{data: %{"oidcProviders" => found}}} = run_query("""
+        query {
+          oidcProviders(first: 5) {
+            edges {
+              node { id }
+            }
+          }
+        }
+      """, %{}, %{current_user: user})
+
+      assert from_connection(found)
+             |> ids_equal(providers)
+    end
+  end
+
   describe "oauthLogin" do
     test "it can fetch an oauth login's details" do
       provider = insert(:oidc_provider)

--- a/config/config.exs
+++ b/config/config.exs
@@ -197,4 +197,6 @@ config :recaptcha,
   public_key: {:system, "RECAPTCHA_SITE_KEY"},
   secret: {:system, "RECAPTURE_SECRET_KEY"}
 
+config :tzdata, :autoupdate, :disabled
+
 import_config "#{config_env()}.exs"

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -166,6 +166,8 @@ type RootQueryType {
 
   loginMetrics: [GeoMetric]
 
+  oidcProviders(after: String, first: Int, before: String, last: Int): OidcProviderConnection
+
   dnsDomain(id: ID!): DnsDomain
 
   dnsDomains(after: String, first: Int, before: String, last: Int, q: String): DnsDomainConnection
@@ -324,15 +326,17 @@ type RootMutationType {
   createArtifact(repositoryId: ID, repositoryName: String, attributes: ArtifactAttributes!): Artifact
 
   createOidcProvider(
-    "The installation ID"
-    installationId: ID!
+    "The installation ID this provider will be bound to"
+    installationId: ID
 
     attributes: OidcAttributes!
   ): OidcProvider
 
-  updateOidcProvider(installationId: ID!, attributes: OidcAttributes!): OidcProvider
+  updateOidcProvider(id: ID, installationId: ID, attributes: OidcAttributes!): OidcProvider
 
   upsertOidcProvider(installationId: ID!, attributes: OidcAttributes!): OidcProvider
+
+  deleteOidcProvider(id: ID!): OidcProvider
 
   acquireLock(repository: String!): ApplyLock
 
@@ -2642,6 +2646,10 @@ input ArtifactAttributes {
 
 "Input for creating or updating the OIDC attributes of an application installation."
 input OidcAttributes {
+  name: String
+
+  description: String
+
   "The redirect URIs for the OIDC provider."
   redirectUris: [String]
 
@@ -2900,12 +2908,15 @@ type Integration {
 
 type OidcProvider {
   id: ID!
+  name: String
+  description: String
   clientSecret: String!
   clientId: String!
   redirectUris: [String]
   authMethod: OidcAuthMethod!
   configuration: OuathConfiguration
   consent: ConsentRequest
+  owner: User
   invites: [Invite]
   bindings: [OidcProviderBinding]
   insertedAt: DateTime
@@ -2952,6 +2963,11 @@ type InstallationConnection {
 type IntegrationConnection {
   pageInfo: PageInfo!
   edges: [IntegrationEdge]
+}
+
+type OidcProviderConnection {
+  pageInfo: PageInfo!
+  edges: [OidcProviderEdge]
 }
 
 enum PlanType {
@@ -3752,6 +3768,11 @@ type CardEdge {
 
 type InvoiceEdge {
   node: Invoice
+  cursor: String
+}
+
+type OidcProviderEdge {
+  node: OidcProvider
   cursor: String
 }
 

--- a/www/src/generated/graphql.ts
+++ b/www/src/generated/graphql.ts
@@ -1821,6 +1821,8 @@ export type OidcAttributes = {
   authMethod: OidcAuthMethod;
   /** The users or groups that can login through the OIDC provider. */
   bindings?: InputMaybe<Array<InputMaybe<BindingAttributes>>>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** The redirect URIs for the OIDC provider. */
   redirectUris?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
@@ -1866,9 +1868,12 @@ export type OidcProvider = {
   clientSecret: Scalars['String']['output'];
   configuration?: Maybe<OuathConfiguration>;
   consent?: Maybe<ConsentRequest>;
+  description?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   insertedAt?: Maybe<Scalars['DateTime']['output']>;
   invites?: Maybe<Array<Maybe<Invite>>>;
+  name?: Maybe<Scalars['String']['output']>;
+  owner?: Maybe<User>;
   redirectUris?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   updatedAt?: Maybe<Scalars['DateTime']['output']>;
 };
@@ -1880,6 +1885,18 @@ export type OidcProviderBinding = {
   insertedAt?: Maybe<Scalars['DateTime']['output']>;
   updatedAt?: Maybe<Scalars['DateTime']['output']>;
   user?: Maybe<User>;
+};
+
+export type OidcProviderConnection = {
+  __typename?: 'OidcProviderConnection';
+  edges?: Maybe<Array<Maybe<OidcProviderEdge>>>;
+  pageInfo: PageInfo;
+};
+
+export type OidcProviderEdge = {
+  __typename?: 'OidcProviderEdge';
+  cursor?: Maybe<Scalars['String']['output']>;
+  node?: Maybe<OidcProvider>;
 };
 
 export type OidcSettings = {
@@ -2864,6 +2881,7 @@ export type RootMutationType = {
   deleteInvite?: Maybe<Invite>;
   deleteKeyBackup?: Maybe<KeyBackup>;
   deleteMessage?: Maybe<IncidentMessage>;
+  deleteOidcProvider?: Maybe<OidcProvider>;
   deletePaymentMethod?: Maybe<PaymentMethod>;
   deletePlatformSubscription?: Maybe<Account>;
   deletePublicKey?: Maybe<PublicKey>;
@@ -3080,7 +3098,7 @@ export type RootMutationTypeCreateOauthIntegrationArgs = {
 
 export type RootMutationTypeCreateOidcProviderArgs = {
   attributes: OidcAttributes;
-  installationId: Scalars['ID']['input'];
+  installationId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 
@@ -3292,6 +3310,11 @@ export type RootMutationTypeDeleteKeyBackupArgs = {
 
 
 export type RootMutationTypeDeleteMessageArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type RootMutationTypeDeleteOidcProviderArgs = {
   id: Scalars['ID']['input'];
 };
 
@@ -3632,7 +3655,8 @@ export type RootMutationTypeUpdateMessageArgs = {
 
 export type RootMutationTypeUpdateOidcProviderArgs = {
   attributes: OidcAttributes;
-  installationId: Scalars['ID']['input'];
+  id?: InputMaybe<Scalars['ID']['input']>;
+  installationId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 
@@ -3793,6 +3817,7 @@ export type RootQueryType = {
   oidcConsent?: Maybe<OidcStepResponse>;
   oidcLogin?: Maybe<OidcStepResponse>;
   oidcLogins?: Maybe<OidcLoginConnection>;
+  oidcProviders?: Maybe<OidcProviderConnection>;
   oidcToken?: Maybe<Scalars['String']['output']>;
   platformMetrics?: Maybe<PlatformMetrics>;
   platformPlans?: Maybe<Array<Maybe<PlatformPlan>>>;
@@ -4141,6 +4166,14 @@ export type RootQueryTypeOidcLoginArgs = {
 
 
 export type RootQueryTypeOidcLoginsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type RootQueryTypeOidcProvidersArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;


### PR DESCRIPTION
This will allow us to enable api-driven oidc provider generation in a more general way.  It can also help us unify the basics of the legacy OSS provisioning w/ our current fleet management approach, while also allowing users to support internal apps w/ it.


## Test Plan
unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.