### PR TITLE
fix broken tables on account tab

### DIFF
--- a/www/src/components/account/GroupsList.tsx
+++ b/www/src/components/account/GroupsList.tsx
@@ -22,10 +22,7 @@ export function GroupsList({ q }: any) {
   const { edges, pageInfo } = data.groups
 
   return (
-    <Div
-      flexGrow={1}
-      maxHeight="max-content"
-    >
+    <Div flexGrow={1}>
       {edges?.length ? (
         <StandardScroller
           listRef={listRef}

--- a/www/src/components/utils/List.tsx
+++ b/www/src/components/utils/List.tsx
@@ -93,7 +93,6 @@ const List = forwardRef<HTMLDivElement, ListProps>(
           padding={0}
           margin={0}
           flexGrow={1}
-          maxHeight="min-content"
           {...props}
           overflow="hidden"
           as={Ul}


### PR DESCRIPTION
not clear why this only recently started causing a bug, likely due to browser updates. but tables should show correctly now