### PR TITLE
Add anchors to name regex

### DIFF
--- a/apps/core/lib/core/schema/console_instance.ex
+++ b/apps/core/lib/core/schema/console_instance.ex
@@ -113,13 +113,13 @@ defmodule Core.Schema.ConsoleInstance do
     |> cast(attrs, @valid)
     |> cast_embed(:configuration, with: &configuration_changeset/2)
     |> cast_embed(:instance_status, with: &status_changeset/2)
-    |> validate_required(@valid -- ~w(external_id postgres_id cluster_id)a)
+    |> validate_required(@valid -- ~w(external_id name postgres_id cluster_id)a)
     |> foreign_key_constraint(:cluster_id)
     |> foreign_key_constraint(:postgres_id)
     |> foreign_key_constraint(:owner_id)
     |> unique_constraint(:subdomain)
     |> unique_constraint(:name)
-    |> validate_format(:name, ~r/[a-z][a-z0-9]{5,10}/, message: "must be an alphanumeric string between 5 and 11 characters")
+    |> validate_format(:name, ~r/^[a-z][a-z0-9-]{4,14}$/, message: "must be an alphanumeric string between 5 and 15 characters, hyphens allowed")
     |> validate_region()
   end
 
@@ -133,7 +133,7 @@ defmodule Core.Schema.ConsoleInstance do
     |> foreign_key_constraint(:owner_id)
     |> unique_constraint(:subdomain)
     |> unique_constraint(:name)
-    |> validate_format(:name, ~r/[a-z][a-z0-9]{5,10}/, message: "must be an alphanumeric string between 5 and 11 characters")
+    |> validate_format(:name, ~r/^[a-z][a-z0-9-]{4,14}$/, message: "must be an alphanumeric string between 5 and 15 characters, hyphens allowed")
     |> validate_region()
   end
 

--- a/apps/core/test/services/cloud_test.exs
+++ b/apps/core/test/services/cloud_test.exs
@@ -71,6 +71,21 @@ defmodule Core.Services.CloudTest do
       assert_receive {:event, %PubSub.ConsoleInstanceCreated{item: ^instance}}
     end
 
+    test "cannot create instances w/ capitalized names" do
+      account = insert(:account)
+      enterprise_plan(account)
+      user = admin_user(account)
+      insert(:repository, name: "console")
+
+      {:error, _} = Cloud.create_instance(%{
+        type: :dedicated,
+        name: "My-Cluster",
+        cloud: :aws,
+        region: "us-east-1",
+        size: :small
+      }, user)
+    end
+
     test "nonenterprise plans cannot create a dedicated cloud console instance" do
       account = insert(:account)
       enable_features(account, [:cd])


### PR DESCRIPTION
apparently validate_format doesn't default to whole-string matches, regex anchors solve for that


## Test Plan
unit

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.