### PR TITLE
fix billing table on safari

### DIFF
--- a/www/src/components/account/billing/BillingPricingTable.tsx
+++ b/www/src/components/account/billing/BillingPricingTable.tsx
@@ -25,7 +25,7 @@ export default function BillingPricingTable({
   return (
     <TableSC>
       <colgroup>
-        <col style={{ width: 'fit-content' }} />
+        <col />
         {plans.map((plan) => (
           <col
             // makes the label column a little smaller than the others


### PR DESCRIPTION
not sure why this was only happening on safari, but fixes this issue:
![image](https://github.com/user-attachments/assets/b822eb28-2293-4012-a972-71f3bec9c0a8)
