### PR TITLE
Add query to fetch license keys for enterprise accounts

### DIFF
--- a/apps/core/lib/core/services/payments.ex
+++ b/apps/core/lib/core/services/payments.ex
@@ -128,6 +128,11 @@ defmodule Core.Services.Payments do
   def allow(%Subscription{} = subscription, %User{} = user),
     do: allow(subscription, user, :access)
 
+  def allow_billing(%User{} = user) do
+    %{account: account} = Repo.preload(user, [:account])
+    allow(account, user, :pay)
+  end
+
   @doc """
   List all invoices against a subscription
   """

--- a/apps/core/test/services/accounts_test.exs
+++ b/apps/core/test/services/accounts_test.exs
@@ -794,4 +794,31 @@ defmodule Core.Services.AccountsTest do
       assert updated.usage_updated
     end
   end
+
+  describe "#license_key/1" do
+    test "enterprise billing users can download license keys" do
+      account = insert(:account, billing_customer_id: "cus_id", user_count: 2, cluster_count: 0)
+      user = insert(:user, roles: %{admin: true}, account: account)
+      enterprise_plan(account)
+
+      {:ok, key} = Accounts.license_key(user)
+
+      assert is_binary(key)
+    end
+
+    test "non billing users cannot downlod license keys" do
+      account = insert(:account, billing_customer_id: "cus_id", user_count: 2, cluster_count: 0)
+      user = insert(:user, account: account)
+      enterprise_plan(account)
+
+      {:error, _} = Accounts.license_key(user)
+    end
+
+    test "non enterprise accounts cannot downlod license keys" do
+      account = insert(:account, billing_customer_id: "cus_id", user_count: 2, cluster_count: 0)
+      user = insert(:user, roles: %{admin: true}, account: account)
+
+      {:error, _} = Accounts.license_key(user)
+    end
+  end
 end

--- a/apps/graphql/lib/graphql/resolvers/account.ex
+++ b/apps/graphql/lib/graphql/resolvers/account.ex
@@ -88,6 +88,9 @@ defmodule GraphQl.Resolvers.Account do
   def resolve_invite(%{id: secure_id}, _),
     do: {:ok, Accounts.get_invite(secure_id)}
 
+  def license_key(_, %{context: %{current_user: user}}),
+    do: Accounts.license_key(user)
+
   def create_service_account(%{attributes: attrs}, %{context: %{current_user: user}}),
     do: Accounts.create_service_account(attrs, user)
 

--- a/apps/graphql/lib/graphql/schema/account.ex
+++ b/apps/graphql/lib/graphql/schema/account.ex
@@ -302,6 +302,12 @@ defmodule GraphQl.Schema.Account do
 
       resolve &Account.list_oauth_integrations/2
     end
+
+    field :license_key, :string do
+      middleware Authenticated
+
+      resolve &Account.license_key/2
+    end
   end
 
   object :account_mutations do

--- a/apps/graphql/test/queries/account_queries_test.exs
+++ b/apps/graphql/test/queries/account_queries_test.exs
@@ -329,4 +329,20 @@ defmodule GraphQl.AccountQueriesTest do
              |> ids_equal(invites)
     end
   end
+
+  describe "licenseKey" do
+    test "enterprise billing users can download license keys" do
+      account = insert(:account, billing_customer_id: "cus_id", user_count: 2, cluster_count: 0)
+      user = insert(:user, roles: %{admin: true}, account: account)
+      enterprise_plan(account)
+
+      {:ok, %{data: %{"licenseKey" => k}}} = run_query("""
+        query {
+          licenseKey
+        }
+      """, %{}, %{current_user: user})
+
+      assert is_binary(k)
+    end
+  end
 end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -130,6 +130,8 @@ type RootQueryType {
 
   oauthIntegrations: [OauthIntegration]
 
+  licenseKey: String
+
   incidents(
     after: String, first: Int, before: String, last: Int, repositoryId: ID, supports: Boolean, q: String, sort: IncidentSort, order: Order, filters: [IncidentFilter]
   ): IncidentConnection

--- a/www/src/generated/graphql.ts
+++ b/www/src/generated/graphql.ts
@@ -3806,6 +3806,7 @@ export type RootQueryType = {
   invoices?: Maybe<InvoiceConnection>;
   keyBackup?: Maybe<KeyBackup>;
   keyBackups?: Maybe<KeyBackupConnection>;
+  licenseKey?: Maybe<Scalars['String']['output']>;
   loginMethod?: Maybe<LoginMethodResponse>;
   loginMetrics?: Maybe<Array<Maybe<GeoMetric>>>;
   me?: Maybe<User>;


### PR DESCRIPTION
This will allow the license renewal process to be more self-service

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.