### PR TITLE
Fix setup_trial tool

### DIFF
--- a/apps/core/lib/core/mcp/tools/setup_trial.ex
+++ b/apps/core/lib/core/mcp/tools/setup_trial.ex
@@ -3,7 +3,7 @@ defmodule Core.MCP.Tools.SetupTrial do
   import Core.MCP.Tools.Utils
   alias Core.Services.{Payments}
   alias Core.Repo
-  alias Core.Schema.{Account, PlatformSubscription}
+  alias Core.Schema.{Account, PlatformSubscription, PlatformPlan}
 
   def name(), do: "setup_trial"
 
@@ -24,18 +24,28 @@ defmodule Core.MCP.Tools.SetupTrial do
 
   def invoke(%{"account_id" => id}) do
     with {:account, {:ok, %Account{} = account}} <- {:account, get_account(id)},
-         {:ok, _} <- maybe_setup_trial(Repo.preload(account, [:subscription])) do
-      {:ok, "trial setup for #{id}"}
+         {:plan, %PlatformPlan{} = plan} <- {:plan, get_plan()},
+         {:ok, _} <- maybe_setup_trial(Repo.preload(account, [:subscription]), plan) do
+      {:ok, "trial established for #{id}"}
     else
       {:account, {:error, err}} -> {:ok, err}
       {:account, _} -> {:ok, "no account with id #{id}"}
+      {:plan, _} -> {:ok, "no trial plan defined"}
       err -> err
     end
   end
-
   def invoke(_), do: {:error, "account id is required"}
 
-  defp maybe_setup_trial(%Account{subscription: %PlatformSubscription{}}),
+  defp get_plan() do
+    Core.conf(:trial_plan)
+    |> Payments.get_platform_plan_by_name!()
+  end
+
+  defp maybe_setup_trial(%Account{subscription: %PlatformSubscription{}}, _plan),
     do: {:error, "account already has a subscription"}
-  defp maybe_setup_trial(%Account{} = account), do: Payments.begin_trial(%Account{account | trialed: false})
+  defp maybe_setup_trial(%Account{} = account, %PlatformPlan{id: id}) do
+    %PlatformSubscription{account_id: account.id}
+    |> PlatformSubscription.changeset(%{plan_id: id})
+    |> Core.Repo.insert()
+  end
 end

--- a/apps/core/test/mcp/tools/setup_trial.exs
+++ b/apps/core/test/mcp/tools/setup_trial.exs
@@ -1,0 +1,18 @@
+defmodule Core.MCP.Tools.SetupTrialTest do
+  use Core.SchemaCase, async: true
+  alias Core.MCP.Tools.SetupTrial
+
+  describe "invoke/1" do
+    setup [:setup_trial]
+    test "it will fetch a users account info", %{plan: plan} do
+      account = insert(:account)
+
+      {:ok, res} = SetupTrial.invoke(%{"account_id" => account.id})
+
+      assert is_binary(res)
+
+      %{subscription: sub} = Repo.preload(account, [:subscription], force: true)
+      assert sub.plan_id == plan.id
+    end
+  end
+end


### PR DESCRIPTION
This was calling a service function that also did initial account creation that fails if run twice, just add the tiral subscription instead


## Test Plan
n/a

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.