### PR TITLE
Fix some console instance wizard issues

### DIFF
--- a/apps/core/lib/core/schema/console_instance.ex
+++ b/apps/core/lib/core/schema/console_instance.ex
@@ -142,7 +142,7 @@ defmodule Core.Schema.ConsoleInstance do
     |> foreign_key_constraint(:owner_id)
     |> unique_constraint(:subdomain)
     |> unique_constraint(:name)
-    |> validate_format(:name, ~r/^[a-z][a-z0-9-]{4,14}$/, message: "must be an alphanumeric string between 5 and 15 characters, hyphens allowed")
+    |> validate_format(:name, ~r/^[a-z][a-z0-9]{4,14}$/, message: "must be an alphanumeric string between 5 and 15 characters")
     |> validate_region()
   end
 

--- a/www/src/components/create-cluster/steps/ConfigureCloudInstanceStep.tsx
+++ b/www/src/components/create-cluster/steps/ConfigureCloudInstanceStep.tsx
@@ -32,9 +32,9 @@ export function ConfigureCloudInstanceStep() {
   const { setCurStep, setContinueBtn, setConsoleInstanceId, hostingOption } =
     useCreateClusterContext()
 
+  const cloud = CloudProvider.Aws
   const [name, setName] = useState('')
   const [size, setSize] = useState<ConsoleSize>(ConsoleSize.Small)
-  const [cloud, setCloud] = useState<CloudProvider>(CloudProvider.Aws)
   const [region, setRegion] = useState<string>(REGIONS[0])
   const [confirm, setConfirm] = useState(false)
 
@@ -113,7 +113,7 @@ export function ConfigureCloudInstanceStep() {
                 : theme.colors['border-danger']
             }
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => setName(e.target.value.trim())}
           />
         </FormFieldSC>
         <FormFieldSC label="Cluster size">
@@ -129,19 +129,6 @@ export function ConfigureCloudInstanceStep() {
                   label={firstLetterUppercase(value)}
                 />
               ))}
-          </Select>
-        </FormFieldSC>
-        <FormFieldSC label="Cloud">
-          <Select
-            selectedKey={cloud}
-            onSelectionChange={(cloud) => setCloud(cloud as CloudProvider)}
-          >
-            {Object.values(CloudProvider).map((value) => (
-              <ListBoxItem
-                key={value}
-                label={value}
-              />
-            ))}
           </Select>
         </FormFieldSC>
         {cloud === CloudProvider.Aws && (
@@ -186,7 +173,7 @@ const validateName = (name: string) => {
   const nameValidity = {
     length: name.length >= 4 && name.length <= 11,
     lowercase: !/[A-Z]/.test(name),
-    alphanumeric: !!name.match(/^[a-z0-9-]+$/),
+    alphanumeric: !!name.match(/^[a-z0-9]+$/),
     startsWithLetter: !!name.at(0)?.match(/[a-z]/),
   }
   return {


### PR DESCRIPTION
Hyphen characters are apparently not safe because of how they translate to the instances db name, also remove cloud selector (unnecessary) and trim the name jsut in case


## Test Plan
n/a

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.