### PR TITLE
Add cluster ping api

### DIFF
--- a/apps/graphql/lib/graphql/resolvers/cluster.ex
+++ b/apps/graphql/lib/graphql/resolvers/cluster.ex
@@ -58,4 +58,7 @@ defmodule GraphQl.Resolvers.Cluster do
 
   def transfer_ownership(%{name: n, email: e}, %{context: %{current_user: user}}),
     do: Clusters.transfer_ownership(n, e, user)
+
+  def ping_cluster(%{attributes: attrs}, %{context: %{current_user: user}}),
+    do: Clusters.ping_cluster(attrs, user)
 end

--- a/apps/graphql/lib/graphql/schema/cluster.ex
+++ b/apps/graphql/lib/graphql/schema/cluster.ex
@@ -17,6 +17,17 @@ defmodule GraphQl.Schema.Cluster do
     field :domain,      :string, description: "The domain name used for applications deployed on the cluster."
   end
 
+  input_object :cluster_ping_attributes do
+    field :cluster, non_null(:cluster_attributes), description: "the cluster to ping"
+    field :usage, non_null(:cluster_usage_attributes), description: "the usage of the cluster"
+  end
+
+  input_object :cluster_usage_attributes do
+    field :bytes_ingested, :integer, description: "the number of bytes ingested by the cluster"
+    field :services, :integer, description: "the number of services deployed on the cluster"
+    field :clusters, :integer, description: "the number of clusters in the cluster"
+  end
+
   @desc "A Kubernetes cluster that can be used to deploy applications on with Plural."
   object :cluster do
     field :id,           non_null(:id), description: "The ID of the cluster."
@@ -108,6 +119,12 @@ defmodule GraphQl.Schema.Cluster do
   end
 
   object :cluster_mutations do
+    field :ping_cluster, :cluster do
+      arg :attributes, non_null(:cluster_ping_attributes), description: "The input attributes for the cluster that will be pinged."
+
+      safe_resolve &Cluster.ping_cluster/2
+    end
+
     @desc "Create a new cluster."
     field :create_cluster, :cluster do
       arg :attributes, non_null(:cluster_attributes), description: "The input attributes for the cluster that will be created."

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -520,6 +520,11 @@ type RootMutationType {
 
   publishLogs(id: ID!, logs: String!): TestStep
 
+  pingCluster(
+    "The input attributes for the cluster that will be pinged."
+    attributes: ClusterPingAttributes!
+  ): Cluster
+
   "Create a new cluster."
   createCluster(
     "The input attributes for the cluster that will be created."
@@ -740,6 +745,25 @@ input ClusterAttributes {
 
   "The domain name used for applications deployed on the cluster."
   domain: String
+}
+
+input ClusterPingAttributes {
+  "the cluster to ping"
+  cluster: ClusterAttributes!
+
+  "the usage of the cluster"
+  usage: ClusterUsageAttributes!
+}
+
+input ClusterUsageAttributes {
+  "the number of bytes ingested by the cluster"
+  bytesIngested: Int
+
+  "the number of services deployed on the cluster"
+  services: Int
+
+  "the number of clusters in the cluster"
+  clusters: Int
 }
 
 "A Kubernetes cluster that can be used to deploy applications on with Plural."

--- a/www/src/components/overview/clusters/ClusterHealth.tsx
+++ b/www/src/components/overview/clusters/ClusterHealth.tsx
@@ -53,5 +53,5 @@ export function useIsClusterHealthy(pingedAt?: Date | null) {
     return () => clearInterval(int)
   }, [])
 
-  return pingedAt && now.clone().subtract(2, 'minutes').isBefore(pingedAt)
+  return pingedAt && now.clone().subtract(2, 'hours').isBefore(pingedAt)
 }

--- a/www/src/generated/graphql.ts
+++ b/www/src/generated/graphql.ts
@@ -526,6 +526,22 @@ export type ClusterInformationAttributes = {
   version?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type ClusterPingAttributes = {
+  /** the cluster to ping */
+  cluster: ClusterAttributes;
+  /** the usage of the cluster */
+  usage: ClusterUsageAttributes;
+};
+
+export type ClusterUsageAttributes = {
+  /** the number of bytes ingested by the cluster */
+  bytesIngested?: InputMaybe<Scalars['Int']['input']>;
+  /** the number of clusters in the cluster */
+  clusters?: InputMaybe<Scalars['Int']['input']>;
+  /** the number of services deployed on the cluster */
+  services?: InputMaybe<Scalars['Int']['input']>;
+};
+
 /** A record of the utilization in a given cluster */
 export type ClusterUsageHistory = {
   __typename?: 'ClusterUsageHistory';
@@ -2956,6 +2972,7 @@ export type RootMutationType = {
   oauthCallback?: Maybe<User>;
   oauthConsent?: Maybe<OauthResponse>;
   passwordlessLogin?: Maybe<User>;
+  pingCluster?: Maybe<Cluster>;
   pingWebhook?: Maybe<WebhookResponse>;
   /** moves up the upgrade waterline for a user */
   promote?: Maybe<User>;
@@ -3524,6 +3541,11 @@ export type RootMutationTypeOauthConsentArgs = {
 
 export type RootMutationTypePasswordlessLoginArgs = {
   token: Scalars['String']['input'];
+};
+
+
+export type RootMutationTypePingClusterArgs = {
+  attributes: ClusterPingAttributes;
 };
 
 


### PR DESCRIPTION
This will be used to replace the legacy websocket based mechanism of cluster reporting that's currently in place.  Will be a lot less noisy and more efficient


## Test Plan
n/a

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.