### PR TITLE
Fix `instlalling` -> `installing` typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ asdf plugin add elixir
 asdf install
 ```
 
-asdf can be finnicky when instlalling erlang with mac, in which case you can reshim it like so from homebrew:
+asdf can be finnicky when installing erlang with mac, in which case you can reshim it like so from homebrew:
 
 ```sh
 brew install erlang@24


### PR DESCRIPTION
Line 30 of CONTRIBUTING.md has `instlalling` (transposed letters) in the asdf+erlang setup tip.