### PR TITLE
fix: Verify reCAPTCHA on submit

### DIFF
--- a/www/src/components/users/MagicLogin.tsx
+++ b/www/src/components/users/MagicLogin.tsx
@@ -408,16 +408,14 @@ function LoginInternal() {
   })
 
   const isPasswordLogin =
-    state === State.PwdLogin ||
-    state === State.PwdLogin_CheckingPwd
+    state === State.PwdLogin || state === State.PwdLogin_CheckingPwd
   const disableSubmit = isPasswordLogin
     ? password.length === 0 || isVerifyingCaptcha || !executeRecaptcha
     : !isValidEmail(email)
   const recaptchaErrorMessage = captchaError
   const recaptchaHintMessage =
     recaptchaErrorMessage ||
-    ((isPasswordLogin && !executeRecaptcha) &&
-      'Loading reCAPTCHA...')
+    (isPasswordLogin && !executeRecaptcha && 'Loading reCAPTCHA...')
   const passwordHint = passwordErrorMsg || recaptchaHintMessage
   const passwordError = !!passwordErrorMsg || !!recaptchaErrorMessage
   const submitPasswordLogin = useCallback(async () => {

--- a/www/src/components/users/MagicLogin.tsx
+++ b/www/src/components/users/MagicLogin.tsx
@@ -413,9 +413,11 @@ function LoginInternal() {
     ? password.length === 0 || isVerifyingCaptcha || !executeRecaptcha
     : !isValidEmail(email)
   const recaptchaErrorMessage = captchaError
-  const recaptchaHintMessage =
-    recaptchaErrorMessage ||
-    (isPasswordLogin && !executeRecaptcha && 'Loading reCAPTCHA...')
+  const recaptchaHintMessage = recaptchaErrorMessage
+    ? recaptchaErrorMessage
+    : isPasswordLogin && !executeRecaptcha
+      ? 'Loading reCAPTCHA...'
+      : undefined
   const passwordHint = passwordErrorMsg || recaptchaHintMessage
   const passwordError = !!passwordErrorMsg || !!recaptchaErrorMessage
   const submitPasswordLogin = useCallback(async () => {

--- a/www/src/components/users/MagicLogin.tsx
+++ b/www/src/components/users/MagicLogin.tsx
@@ -403,29 +403,24 @@ function LoginInternal() {
 
   const loginMethod = loginMethodData?.loginMethod
 
-  const { data: oAuthData } = useOauthUrlsQuery({
-    variables: { host: host() },
-  })
+  const { data: oAuthData } = useOauthUrlsQuery({ variables: { host: host() } })
 
   const isPasswordLogin =
     state === State.PwdLogin || state === State.PwdLogin_CheckingPwd
   const disableSubmit = isPasswordLogin
     ? password.length === 0 || isVerifyingCaptcha || !executeRecaptcha
     : !isValidEmail(email)
-  const recaptchaErrorMessage = captchaError
-  const recaptchaHintMessage = recaptchaErrorMessage
-    ? recaptchaErrorMessage
+  const hintMessage = captchaError
+    ? captchaError
     : isPasswordLogin && !executeRecaptcha
-      ? 'Loading reCAPTCHA...'
-      : undefined
-  const passwordHint = passwordErrorMsg || recaptchaHintMessage
-  const passwordError = !!passwordErrorMsg || !!recaptchaErrorMessage
+    ? 'Loading reCAPTCHA...'
+    : undefined
+  const passwordHint = passwordErrorMsg || hintMessage
+  const passwordError = !!passwordErrorMsg || !!captchaError
+
   const submitPasswordLogin = useCallback(async () => {
     const captcha = await handleReCaptchaVerify()
-
-    if (!captcha) {
-      return
-    }
+    if (!captcha) return
 
     setState(State.PwdLogin_CheckingPwd)
     loginMutation({

--- a/www/src/components/users/MagicLogin.tsx
+++ b/www/src/components/users/MagicLogin.tsx
@@ -16,7 +16,7 @@ import {
   useGoogleReCaptcha,
 } from 'react-google-recaptcha-v3'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
-import styled, { useTheme } from 'styled-components'
+import styled from 'styled-components'
 
 import {
   AcceptLoginDocument,
@@ -216,7 +216,6 @@ type LoginState =
   | 'Initial'
   | 'CheckEmail'
   | 'CheckingEmail'
-  | 'PwdLogin_CheckPwd'
   | 'PwdLogin_CheckingPwd'
   | 'PwdLogin'
   | 'PasswordlessLogin'
@@ -227,7 +226,6 @@ const State = {
   CheckEmail: 'CheckEmail',
   CheckingEmail: 'CheckingEmail',
   PwdLogin: 'PwdLogin',
-  PwdLogin_CheckPwd: 'PwdLogin_CheckPwd',
   PwdLogin_CheckingPwd: 'PwdLogin_CheckingPwd',
   PasswordlessLogin: 'PasswordlessLogin',
   Signup: 'Signup',
@@ -251,7 +249,6 @@ export function Login() {
 }
 
 function LoginInternal() {
-  const theme = useTheme()
   const navigate = useNavigate()
   const [state, setState] = useState<LoginState>(State.Initial)
   const prevState = useRef<LoginState>(State.Initial)
@@ -268,16 +265,28 @@ function LoginInternal() {
   const emailRef = useRef<HTMLElement>()
 
   const { executeRecaptcha } = useGoogleReCaptcha()
-  const [captcha, setCaptcha] = useState('')
+  const [isVerifyingCaptcha, setIsVerifyingCaptcha] = useState(false)
+  const [captchaError, setCaptchaError] = useState<string>()
   const handleReCaptchaVerify = useCallback(async () => {
-    if (!executeRecaptcha) return
+    if (!executeRecaptcha) {
+      setCaptchaError('reCAPTCHA is still loading. Please try again.')
 
-    setCaptcha(await executeRecaptcha('login'))
-  }, [executeRecaptcha, setCaptcha])
+      return undefined
+    }
 
-  useEffect(() => {
-    handleReCaptchaVerify()
-  }, [handleReCaptchaVerify])
+    setIsVerifyingCaptcha(true)
+    setCaptchaError(undefined)
+
+    try {
+      return await executeRecaptcha('login')
+    } catch (_) {
+      setCaptchaError('Unable to verify reCAPTCHA. Please try again.')
+
+      return undefined
+    } finally {
+      setIsVerifyingCaptcha(false)
+    }
+  }, [executeRecaptcha])
 
   useEffect(() => {
     setInputFocus(emailRef)
@@ -299,12 +308,6 @@ function LoginInternal() {
 
   const [loginMutation, { loading: loginMLoading, error: loginMError }] =
     useLoginMutation({
-      variables: {
-        email,
-        password,
-        deviceToken: typeof deviceToken === 'string' ? deviceToken : undefined,
-        captcha,
-      },
       onCompleted: ({ login }) => {
         setToken(login?.jwt)
         if (deviceToken) finishedDeviceLogin()
@@ -326,10 +329,6 @@ function LoginInternal() {
           getLoginMethod()
           setState(State.CheckingEmail)
           break
-        case State.PwdLogin_CheckPwd:
-          loginMutation()
-          setState(State.PwdLogin_CheckingPwd)
-          break
         case State.PwdLogin:
           setInputFocus(passwordRef)
           break
@@ -338,7 +337,7 @@ function LoginInternal() {
       }
     }
     prevState.current = state
-  }, [getLoginMethod, loginMutation, state])
+  }, [getLoginMethod, state])
 
   useEffect(() => {
     if (state === State.Signup) {
@@ -410,11 +409,41 @@ function LoginInternal() {
 
   const isPasswordLogin =
     state === State.PwdLogin ||
-    state === State.PwdLogin_CheckingPwd ||
-    state === State.PwdLogin_CheckPwd
+    state === State.PwdLogin_CheckingPwd
   const disableSubmit = isPasswordLogin
-    ? password.length === 0 || !captcha
+    ? password.length === 0 || isVerifyingCaptcha || !executeRecaptcha
     : !isValidEmail(email)
+  const recaptchaErrorMessage = captchaError
+  const recaptchaHintMessage =
+    recaptchaErrorMessage ||
+    ((isPasswordLogin && !executeRecaptcha) &&
+      'Loading reCAPTCHA...')
+  const passwordHint = passwordErrorMsg || recaptchaHintMessage
+  const passwordError = !!passwordErrorMsg || !!recaptchaErrorMessage
+  const submitPasswordLogin = useCallback(async () => {
+    const captcha = await handleReCaptchaVerify()
+
+    if (!captcha) {
+      return
+    }
+
+    setState(State.PwdLogin_CheckingPwd)
+    loginMutation({
+      variables: {
+        email,
+        password,
+        deviceToken: typeof deviceToken === 'string' ? deviceToken : undefined,
+        captcha,
+      },
+    }).catch(() => undefined)
+  }, [
+    deviceToken,
+    email,
+    handleReCaptchaVerify,
+    loginMutation,
+    password,
+    setState,
+  ])
 
   const onSubmit = useCallback(
     (e) => {
@@ -424,7 +453,7 @@ function LoginInternal() {
       }
       switch (state) {
         case State.PwdLogin:
-          setState(State.PwdLogin_CheckPwd)
+          submitPasswordLogin()
           break
         case State.Initial:
           setState(State.CheckEmail)
@@ -433,10 +462,10 @@ function LoginInternal() {
           break
       }
     },
-    [disableSubmit, state]
+    [disableSubmit, state, submitPasswordLogin]
   )
 
-  const loading = loginMethodLoading || loginMLoading
+  const loading = loginMethodLoading || loginMLoading || isVerifyingCaptcha
 
   // This is to ensure that if both login token and login challenge are
   // available, user will not see the login view while oauth challenge
@@ -519,26 +548,13 @@ function LoginInternal() {
                       forgot your password?
                     </A>
                   }
-                  hint={passwordErrorMsg}
-                  error={!!passwordErrorMsg}
+                  hint={passwordHint}
+                  error={passwordError}
                   value={password}
                   onChange={setPassword}
                   placeholder="Enter password"
                 />
               </Collapsible>
-              {!captcha && (
-                <div
-                  css={{
-                    ...theme.partials.text.inlineLink,
-                    textAlign: 'end',
-                    cursor: 'pointer',
-                    marginBottom: theme.spacing.xsmall,
-                  }}
-                  onClick={handleReCaptchaVerify}
-                >
-                  verify reCAPTCHA
-                </div>
-              )}
               <Button
                 type="submit"
                 width="100%"


### PR DESCRIPTION
Verify reCAPTCHA on submit instead of loading the token on page load and then using it in login mutation. Doing it in two phases could lead to validation failures as tokens are short-lived. It also removes token from the state and the manual verify reCAPTCHA link under the password field.

## Test Plan
Tested locally both success path and a path where token is invalid (modified in code to check if it will fail with correct error).

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.