### PR TITLE
fix: Dependabot fast-uri and shell-quote

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -152,7 +152,9 @@
     "lodash-es": "4.18.1",
     "postcss": "8.5.19",
     "qs": "6.15.3",
-    "tar": "7.5.20"
+    "tar": "7.5.20",
+    "fast-uri": "3.1.4",
+    "shell-quote": "1.10.0"
   },
   "lint-staged": {
     "./src/**/*.{js,jsx,ts,tsx,graphql,md}": "prettier --write"

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -10483,10 +10483,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.1.3
-  resolution: "fast-uri@npm:3.1.3"
-  checksum: 10/7969a50a327482035d5c8c93faf51b26d7a93ce62bc750c91b3df158550004b5fbb378c95c900fd71f4dded36b5a78d1c666fb8043bb1214efbaebd8518d873e
+"fast-uri@npm:3.1.4":
+  version: 3.1.4
+  resolution: "fast-uri@npm:3.1.4"
+  checksum: 10/1c1ff8e7b6f7b38e997b1528aa2c97e290e0173d51250bfe4e11a303e454fc297a287555b5cb2ded59dbfce7876855fb15994a1a6b439f2497a2b8926513e397
   languageName: node
   linkType: hard
 
@@ -16906,14 +16906,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.4":
-  version: 1.8.4
-  resolution: "shell-quote@npm:1.8.4"
-  checksum: 10/a3e3796385f2cd5cf0b78207a4439f0c7395c0833fc75b2473084b5d298c109c5c0fa687fcd1c04e4b4484866e5bb8eaae7efae443b80fff71ea7e29baf11f0c
-  languageName: node
-  linkType: hard
-
-"shell-quote@npm:^1.7.3":
+"shell-quote@npm:1.10.0":
   version: 1.10.0
   resolution: "shell-quote@npm:1.10.0"
   checksum: 10/d4a22aeefe64919290af753ac6098239d7ffee52a5db62c20edef69794bd10b5f86e298f68be26af9606ac435e890dd391994a5405a90bb8aebef1ff1dde839b


### PR DESCRIPTION
## Summary
- Resolve Dependabot [#491](https://github.com/pluralsh/plural/security/dependabot/491) (`fast-uri` → ≥3.1.4)
- Resolve Dependabot [#490](https://github.com/pluralsh/plural/security/dependabot/490) (`shell-quote` → ≥1.9.0)

Both are transitive npm **dev** deps in `www/yarn.lock`, pinned via Yarn resolutions (same approach as brace-expansion in #1497).

## Test plan
- [x] `yarn install` refreshes lockfile without vulnerable versions
- [ ] CI www lint/test
- [ ] Confirm Dependabot alerts close after merge


Made with [Cursor](https://cursor.com)